### PR TITLE
Operator may provision a a Jitsi instance programmatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules
+.terraform
+*.tfstate*
+*secrets.tfvars

--- a/clients/zinc.tfvars
+++ b/clients/zinc.tfvars
@@ -1,0 +1,3 @@
+cloudflare_email   = "zee@zincma.de"
+cloudflare_zone_id = "211e94f01d483d1555310b9a19cf98dd"
+jitsi_ami          = "ami-034f04ba6493f366d"

--- a/features/infrastructure/hosting-jitsi.feature
+++ b/features/infrastructure/hosting-jitsi.feature
@@ -4,17 +4,14 @@ Feature: Jitsi Hosting
   I want to host a JITSI Meet server
 
   Scenario: Operator Provisions a single-server JITSI instance on AWS
-    Given AWS Access Key and Secret with the rights to provision instances
+    Given an AWS Access Key and Secret with the rights to provision instances
     And an empty hosts inventory
     And a public domain with a wildcard SSL certificate
     When an Operator runs the `jitsi/provision` command with:
       | arguments                                    |
-      | --instance-size=t3.micro                     |
-      | --include-nginx                              |
-      | --ssl-certificate={{ path_to_wildcard_ssl }} |
+      | --instance-type=t3.micro                     |
       | --public-domain={{ subdomain }}.{{domain}}   |
     Then a JITSI meet instance is provisioned with the following attributes:
       | attribute      | value                            |
-      | instance-size  | t3.micro                         |
+      | instance-type  | t3.micro                         |
       | accessible-via | https://{{subdomain}}.{{domain}} |
-    And the IP address is added to the hosts' inventory definition within the "[jitsi_hosts]" group

--- a/features/infrastructure/hosting-jitsi.feature
+++ b/features/infrastructure/hosting-jitsi.feature
@@ -4,14 +4,15 @@ Feature: Jitsi Hosting
   I want to host a JITSI Meet server
 
   Scenario: Operator Provisions a single-server JITSI instance on AWS
-    Given an AWS Access Key and Secret with the rights to provision instances
-    And an empty hosts inventory
-    And a public domain with a wildcard SSL certificate
+    Given an existing convene-jitsi AMI for {{subdomain}}.{{domain}} within the us-west-1 region
     When an Operator runs the `jitsi/provision` command with:
-      | arguments                                    |
-      | --instance-type=t3.micro                     |
-      | --public-domain={{ subdomain }}.{{domain}}   |
-    Then a JITSI meet instance is provisioned with the following attributes:
+      | arguments          |
+      | --region=us-west-1 |
+      | --provider=aws     |
+      | --size=t3.micro    |
+      | --at-domain   https://{{subdomain}}.{{domain}} |
+    Then a JITSI meet instance is provisioned on AWS with the following attributes:
       | attribute      | value                            |
-      | instance-type  | t3.micro                         |
+      | size           | t3.micro                         |
+      | region         | us-west-1                        |
       | accessible-via | https://{{subdomain}}.{{domain}} |

--- a/jitsi/install-letsencrypt-cert.sh
+++ b/jitsi/install-letsencrypt-cert.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+set -e
+
+DEB_CONF_RESULT=`debconf-show jitsi-meet-web-config | grep jvb-hostname`
+DOMAIN="${DEB_CONF_RESULT##*:}"
+# remove whitespace
+DOMAIN="$(echo -e "${DOMAIN}" | tr -d '[:space:]')"
+
+echo "-------------------------------------------------------------------------"
+echo "This script will:"
+echo "- Need a working DNS record pointing to this machine(for domain ${DOMAIN})"
+echo "- Download certbot from https://dl.eff.org to /usr/local/sbin"
+echo "- Install additional dependencies in order to request Let’s Encrypt certificate"
+echo "- If running with jetty serving web content, will stop Jitsi Videobridge"
+echo "- Configure and reload nginx or apache2, whichever is used"
+echo "- Configure the coturn server to use Let's Encrypt certificate and add required deploy hooks"
+echo "- Add command in weekly cron job to renew certificates regularly"
+echo ""
+echo "You need to agree to the ACME server's Subscriber Agreement (https://letsencrypt.org/documents/LE-SA-v1.1.1-August-1-2016.pdf) "
+echo "by providing an email address for important account notifications"
+
+echo -n "Enter your email and press [ENTER]: "
+read EMAIL
+
+cd /usr/local/sbin
+
+if command -v certbot >/dev/null 2>&1; then
+    echo "we good"
+else
+    sudo apt-get update
+    sudo apt-get -y install software-properties-common certbot
+fi
+
+CRON_FILE="/etc/cron.weekly/letsencrypt-renew"
+if [ ! -d "/etc/cron.weekly" ] ; then
+    mkdir "/etc/cron.weekly"
+fi
+echo "#!/bin/bash" > $CRON_FILE
+echo "/usr/local/sbin/certbot renew >> /var/log/le-renew.log" >> $CRON_FILE
+
+CERT_KEY="/etc/letsencrypt/live/$DOMAIN/privkey.pem"
+CERT_CRT="/etc/letsencrypt/live/$DOMAIN/fullchain.pem"
+
+if [ -f /etc/nginx/sites-enabled/$DOMAIN.conf ] ; then
+
+    TURN_CONFIG="/etc/turnserver.conf"
+    TURN_HOOK=/etc/letsencrypt/renewal-hooks/deploy/0000-coturn-certbot-deploy.sh
+    if [ -f $TURN_CONFIG ] && grep -q "jitsi-meet coturn config" "$TURN_CONFIG" ; then
+        mkdir -p $(dirname $TURN_HOOK)
+
+        cp /usr/share/jitsi-meet-turnserver/coturn-certbot-deploy.sh $TURN_HOOK
+        chmod u+x $TURN_HOOK
+        sed -i "s/jitsi-meet.example.com/$DOMAIN/g" $TURN_HOOK
+
+        certbot certonly --noninteractive \
+        --webroot --webroot-path /usr/share/jitsi-meet \
+        -d $DOMAIN \
+        --agree-tos --email $EMAIL \
+        --deploy-hook $TURN_HOOK
+    else
+        certbot certonly --noninteractive \
+        --webroot --webroot-path /usr/share/jitsi-meet \
+        -d $DOMAIN \
+        --agree-tos --email $EMAIL
+    fi
+
+    echo "Configuring nginx"
+
+    CONF_FILE="/etc/nginx/sites-available/$DOMAIN.conf"
+    CERT_KEY_ESC=$(echo $CERT_KEY | sed 's/\./\\\./g')
+    CERT_KEY_ESC=$(echo $CERT_KEY_ESC | sed 's/\//\\\//g')
+    sed -i "s/ssl_certificate_key\ \/etc\/jitsi\/meet\/.*key/ssl_certificate_key\ $CERT_KEY_ESC/g" \
+        $CONF_FILE
+    CERT_CRT_ESC=$(echo $CERT_CRT | sed 's/\./\\\./g')
+    CERT_CRT_ESC=$(echo $CERT_CRT_ESC | sed 's/\//\\\//g')
+    sed -i "s/ssl_certificate\ \/etc\/jitsi\/meet\/.*crt/ssl_certificate\ $CERT_CRT_ESC/g" \
+        $CONF_FILE
+
+    echo "service nginx reload" >> $CRON_FILE
+    service nginx reload
+elif [ -f /etc/apache2/sites-enabled/$DOMAIN.conf ] ; then
+
+    certbot certonly --noninteractive \
+    --webroot --webroot-path /usr/share/jitsi-meet \
+    -d $DOMAIN \
+    --agree-tos --email $EMAIL
+
+    echo "Configuring apache2"
+
+    CONF_FILE="/etc/apache2/sites-available/$DOMAIN.conf"
+    CERT_KEY_ESC=$(echo $CERT_KEY | sed 's/\./\\\./g')
+    CERT_KEY_ESC=$(echo $CERT_KEY_ESC | sed 's/\//\\\//g')
+    sed -i "s/SSLCertificateKeyFile\ \/etc\/jitsi\/meet\/.*key/SSLCertificateKeyFile\ $CERT_KEY_ESC/g" \
+        $CONF_FILE
+    CERT_CRT_ESC=$(echo $CERT_CRT | sed 's/\./\\\./g')
+    CERT_CRT_ESC=$(echo $CERT_CRT_ESC | sed 's/\//\\\//g')
+    sed -i "s/SSLCertificateFile\ \/etc\/jitsi\/meet\/.*crt/SSLCertificateFile\ $CERT_CRT_ESC/g" \
+        $CONF_FILE
+
+    echo "service apache2 reload" >> $CRON_FILE
+    service apache2 reload
+fi
+
+# the cron file that will renew certificates
+chmod a+x $CRON_FILE

--- a/jitsi/provision
+++ b/jitsi/provision
@@ -35,9 +35,17 @@ packer build \
   -var "region=${REGION}"\
   jitsi/aws-ebs.json
 
+
+
+# Provision instance(s) for the zinc client
+# TODO: Figure out how to share the secrets safely
+# TODO: Figure out how to safely share the terraform.tstate (push to private bucket/pull from private bucket?)
+# TODO: Parameterize this?
+terraform apply -var-file clients/zinc.tfvars -var-file clients/zinc-secrets.tfvars
 # Manually: Deploy instance:
-#   * Launch an instance
 #   * Apply a ssl certificate
+scp jitsi/install-letsencrypt-cert.sh
+
 #   * Configure Network setting
 #     * Terraform tool could config it
 

--- a/jitsi/provision
+++ b/jitsi/provision
@@ -42,12 +42,12 @@ packer build \
 # TODO: Figure out how to safely share the terraform.tstate (push to private bucket/pull from private bucket?)
 # TODO: Parameterize this?
 terraform apply -var-file clients/zinc.tfvars -var-file clients/zinc-secrets.tfvars
-# Manually: Deploy instance:
+
+# Push the certbot install script that works for Ubuntu 20.04 to the server
+scp jitsi/install-letsencrypt-cert.sh ubuntu@meet.zinc.coop:
+
+# Manually:
 #   * Apply a ssl certificate
-scp jitsi/install-letsencrypt-cert.sh
-
-#   * Configure Network setting
-#     * Terraform tool could config it
-
-# Manually release instance
-#   * Point DNS record to the instance
+#     - ssh ubuntu@meet.zinc.coop
+#     - sudo ./install-letsencrypt-cert.sh
+#     - enter your email

--- a/zinc.tf
+++ b/zinc.tf
@@ -1,0 +1,160 @@
+variable "cloudflare_email" {
+  type = string
+}
+
+
+variable "cloudflare_api_key" {
+  type = string
+}
+
+variable "cloudflare_zone_id" {
+  type = string
+}
+
+provider "cloudflare" {
+  version = "~> 2.0"
+  email   = var.cloudflare_email
+  api_key = var.cloudflare_api_key
+}
+
+# Create a record
+resource "cloudflare_record" "meet" {
+  zone_id = var.cloudflare_zone_id
+  name    = "meet"
+  value   = aws_eip.convene_ip.public_ip
+  type    = "A"
+  ttl     = 1
+}
+
+provider "aws" {
+  region = "us-west-1"
+}
+
+variable "jitsi_ami" {
+  type = string
+}
+
+resource "aws_instance" "convene_video" {
+  ami           = var.jitsi_ami
+  instance_type = "t2.micro"
+  tags = {
+    Name = "meet.zinc.coop"
+  }
+  security_groups = [aws_security_group.allow_ssh.name,
+                     aws_security_group.allow_http.name,
+                     aws_security_group.allow_tls.name,
+                     aws_security_group.allow_jitsi_video.name]
+  key_name = "deployer-key"
+}
+
+resource "aws_eip" "convene_ip" {
+  instance = aws_instance.convene_video.id
+}
+
+
+resource "aws_security_group" "allow_tls" {
+  name        = "allow_tls"
+  description = "Allow TLS inbound traffic"
+
+  ingress {
+    description = "TLS from World"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "allow_tls"
+  }
+}
+
+
+resource "aws_security_group" "allow_ssh" {
+  name        = "allow_ssh"
+  description = "Allow ssh inbound traffic"
+
+  ingress {
+    description = "SSH from World"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "allow_ssh"
+  }
+}
+
+resource "aws_security_group" "allow_http" {
+  name        = "allow_http"
+  description = "Allow HTTP inbound traffic"
+
+  ingress {
+    description = "HTTP from World"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "allow_ssh"
+  }
+}
+
+
+resource "aws_security_group" "allow_jitsi_video" {
+  name        = "allow_jitsi_video"
+  description = "Allow jitsi video inbound traffic"
+
+  ingress {
+    description = "Jitsi Video from world"
+    from_port   = 10000
+    to_port     = 10000
+    protocol    = "udp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "allow_jitsi_video"
+  }
+}
+
+resource "aws_key_pair" "deployer" {
+  key_name = "deployer-key"
+  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDePOrtPv6qxawIMnsDi3mhND3uKKFZKxxq/HGAIU294u1jBEYCjQSHKD1ZuRMSTlXmg1NWPhFz4pAlIUT8t0zkOSz2NKSXlJ0Rl69AbE+6ye2CIL9nfqq9mgA2XHOKPnVIuXdpBuFMmOCavMe7oZKH+qJ7wVFZRKaoWdL1Sw+7wjfCAqMcjq3FW+PvNldFe3B1q9SowXQlXyJW7+wXUj6wBUj3D7kpKOBe7EiLCBytBaQ2ejCxtM8/pqttQqBwUnjF93Gazyw7Ax3JTy+PTIJmkziWKAssvNHsXtB3ijVZY/Do1wGI3MN2zEf3X2wn16Cm67sHQ8/3OR9V4cOQUlOMiEwaWNiHHC0wRi2aIkISVqyDSChu1PN0FgKWvA9MG8EHxSRbhsSHrZ9eVGVsUz92Ca/ZLn6BlhP7ZptgVi+TFmzutRlcwxPb04iO2tL9PA4HqxbjCll0oFCnHwZd7uBxCtQ60UYTH57HzKh0nxkKov0hTr+5bK39d7EEwIehbjIxgy5FCaVuO+HvllxEYtuPhjUHj7gQOOTP7B3SB4OHmGblqNJ+9+oU13DkbdL8Ln/OVf+SrZ462VX3FdqefWu639xFcHt/87K22c3Pd2VsPXSEVGMMyR5sfVPWdKTRlqe1E9sJo3vl70Vjjio/LvQXrwrmn2ozamLc82YuQyZoJw=="
+}
+
+
+
+


### PR DESCRIPTION
There's a bunch of rough edges here, and it _only_ works for
meet.zinc.coop atm; but it should be possible to start parameterizing
pieces and figuring out how to organize it to support multiple
instances.

See https://github.com/zinc-collective/convene/issues/2