### PR TITLE
Add a scenario for building a Jitsi AMI for a client

### DIFF
--- a/features/infrastructure/hosting-jitsi.feature
+++ b/features/infrastructure/hosting-jitsi.feature
@@ -16,3 +16,11 @@ Feature: Jitsi Hosting
       | size           | t3.micro                         |
       | region         | us-west-1                        |
       | accessible-via | https://{{subdomain}}.{{domain}} |
+
+  Scenario: Operator Builds a single-server JITSI AMI on AWS
+    When an Operator runs the `jitsi/build` command with:
+      | arguments          |
+      | --region=us-west-1 |
+      | --provider=aws     |
+      | --at-domain   | {{subdomain}}.{{domain}} |
+    Then a convene-jitsi-{{subdomain}}.{{domain}} is available within the us-west-1 region

--- a/jitsi/build
+++ b/jitsi/build
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+for i in "$@"
+do
+case $i in
+    --instance-type=*)
+    INSTANCE_TYPE="${i#*=}"
+    shift
+    ;;
+    --ssl-certificate=*)
+    SSL_CERTIFICATE="${i#*=}"
+    shift
+    ;;
+    --public-domain=*)
+    PUBLIC_DOMAIN="${i#*=}"
+    shift
+    ;;
+    --region=*)
+    REGION="${i#*=}"
+    shift
+    ;;
+    --include-nginx)
+    INCLUDE_NGINX=YES
+    shift
+    ;;
+esac
+done
+
+# Automated: Build AMI
+packer build \
+  -var "instance_type=${INSTANCE_TYPE}" \
+  -var "ssl_certificate=${SSL_CERTIFICATE}" \
+  -var "public_domain=${PUBLIC_DOMAIN}" \
+  -var "include_nginx=${INCLUDE_NGINX}"\
+  -var "region=${REGION}"\
+  jitsi/aws-ebs.json
+
+

--- a/jitsi/provision
+++ b/jitsi/provision
@@ -26,17 +26,6 @@ case $i in
 esac
 done
 
-# Automated: Build AMI
-packer build \
-  -var "instance_type=${INSTANCE_TYPE}" \
-  -var "ssl_certificate=${SSL_CERTIFICATE}" \
-  -var "public_domain=${PUBLIC_DOMAIN}" \
-  -var "include_nginx=${INCLUDE_NGINX}"\
-  -var "region=${REGION}"\
-  jitsi/aws-ebs.json
-
-
-
 # Provision instance(s) for the zinc client
 # TODO: Figure out how to share the secrets safely
 # TODO: Figure out how to safely share the terraform.tstate (push to private bucket/pull from private bucket?)


### PR DESCRIPTION
To keep deploy time down for on-demand JITSI hosting, we want per-region
pre-built virtual machine images on a per-client basis. This makes it so
we can start an instance super-quick-like without having to do the full
jitsi installation process.