### PR TITLE
Updated with link to Cust Dev G Docs Folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ At present, Convene is split into three modules:
 - `web` which provides the human interface for Convene.
 - `api` which stores data long-term and provides a programmatic interface.
 
+## Customer Development
+[Link to Folder on G Docs](https://drive.google.com/drive/u/2/folders/1gncYSkVIAj4CnlUZM9KPQlFdj_aqulDl)
+
 ## Footnotes
 
 ### Paid Support


### PR DESCRIPTION
Pursuant to https://github.com/zinc-collective/convene/issues/10#issue-614888597 the Readme has been updated with a link to the Customer Development Folder on G Drive.