### PR TITLE
Automate creation of the Convene pricing tier

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# For local development, get these from https://dashboard.stripe.com/test/apikeys
+# For production, get them from https://dashboard.stripe.com/apikeys
+STRIPE_API_KEY=PLACE_STRIPE_SECRET_KEY_HERE
+STRIPE_PUBLISHABLE_API_KEY=PLACE_STRIPE_PUBLISHABLE_KEY_HERE

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 .terraform
 *.tfstate*
 *secrets.tfvars
+.env
+.env.production

--- a/bin/configure-pricing
+++ b/bin/configure-pricing
@@ -1,0 +1,123 @@
+#!/usr/bin/env ruby
+
+require 'net/http'
+require 'json'
+
+API_URI = URI("https://api.stripe.com/v1/")
+API_URI.user = ENV['STRIPE_API_KEY']
+
+# This gets called on the final line of the script.
+def main
+  # https://stripe.com/docs/billing/prices-guide
+
+  Net::HTTP.start(API_URI.hostname, API_URI.port, use_ssl: true) do |http|
+    product = find_or_create_product(name: "Convene", http: http)
+    raise "Can't find/create product for Convene" unless product
+    price = find_or_create_price(product_id: product[:id],
+                                amount: 20_00,
+                                nickname: "Early Access Small Room",
+                                currency: :usd,
+                                interval: :month,
+                                http: http)
+
+    raise "Can't find/create price for Convene" unless price
+    # Assembled from
+    # https://stripe.com/docs/payments/checkout/client-subscription
+    # TODO: Move this to Compensated and/or Support
+    puts <<~DOCS
+    Congratulations! You're set up to sell Convene for $20.00/mo.
+    Embed the following HTML into your page!
+    ```
+    <script src="https://js.stripe.com/v3/"></script>
+    <script>
+      var stripe = Stripe('#{ENV.fetch('STRIPE_PUBLISHABLE_API_KEY', 'STRIPE_PUBLISHABLE_API_KEY')}');
+      function beginPurchaseFlow() {
+        stripe.redirectToCheckout({
+          lineItems: [{
+            // Replace with the ID of your price
+            price: '#{price[:id]}',
+            quantity: 1,
+          }],
+          mode: 'subscription',
+          successUrl: 'https://example.com/success',
+          cancelUrl: 'https://example.com/cancel',
+        }).then(function (result) {
+          // If `redirectToCheckout` fails due to a browser or network
+          // error, display the localized error message to your customer
+          // using `result.error.message`.
+        });
+      }
+
+      window.addEventListener('DOMContentLoaded', (event) => {
+        const beginPurchaseButtons = document.getElementsByClassName('begin-purchase-flow')
+        for(const beginPurchaseButton of beginPurchaseButtons) {
+          beginPurchaseButton.addEventListener('click', beginPurchaseFlow)
+        }
+      });
+
+    </script>
+    <button class="begin-purchase-flow">Buy Now</button>
+    ```
+    DOCS
+  end
+end
+
+def api_uri(path)
+  URI.join(API_URI, path)
+end
+
+def request(req, http:)
+  req.basic_auth ENV['STRIPE_API_KEY'],''
+  res = http.request(req)
+  JSON.parse(res.body, symbolize_names: true)
+end
+
+def get(path, http:)
+  request(Net::HTTP::Get.new(api_uri(path)), http: http)
+end
+
+def post(path, data, http:)
+  req = Net::HTTP::Post.new(api_uri(path))
+  req.form_data = data
+  request(req, http: http)
+end
+
+# TODO: Move this to Compensated
+def find_or_create_product(name:, http:)
+  response_body = get("products", http: http)
+  products = response_body[:data]
+
+  product = products.find { |product| product[:name] == name }
+  if(!product && response_body[:has_more])
+    raise "Couldn't find product in first page of products..."
+  end
+
+  product ||= post("products", { name: name } , http: http)
+end
+
+# TODO: Move this to Compensated
+def find_or_create_price(product_id:, amount:, nickname:, currency: , interval:, http:)
+  # https://stripe.com/docs/api/prices/list#list_prices
+  response_body = get("prices", http: http)
+  prices = response_body[:data]
+
+  price = prices.find do |potential_price|
+    potential_price[:product] == product_id &&
+      potential_price[:unit_amount] == amount &&
+      potential_price[:currency].to_sym == currency.to_sym
+      potential_price[:recurring][:interval].to_sym == interval.to_sym
+  end
+
+  if(!price && response_body[:has_more])
+    raise "Couldn't find price in first page of prices..."
+  end
+
+  price ||= post("prices", { product: product_id,
+                             unit_amount: amount,
+                             nickname: nickname,
+                             currency: currency,
+                             "recurring[interval]": interval },
+                  http: http)
+end
+
+main


### PR DESCRIPTION
See: https://github.com/zinc-collective/convene/issues/8

I was using this primarily to explore what it would look like to build
Product and Pricing setup into Compensated/Support, while also ensuring
we have a papertrail for setting up pricing for Convene.