### PR TITLE
Releasing meet.zinc.coop no longer requires code changes

### DIFF
--- a/infrastructure/clients/meet.zinc.coop/infrastructure.tf
+++ b/infrastructure/clients/meet.zinc.coop/infrastructure.tf
@@ -30,15 +30,8 @@ provider "aws" {
   region = "us-west-1"
 }
 
-variable "jitsi_ami" {
-  type = string
-}
-
 resource "aws_instance" "convene_video" {
-  # TODO: Can we _infer_ this value or somehow detect the AMI based upon it's name?
-  #       Because every time we run `jitsi/build` it creates a new AMI on a
-  #       per-client basis.
-  ami           = var.jitsi_ami
+  ami           = data.aws_ami.convene_ami.id
   instance_type = "t2.micro"
   tags = {
     Name = "meet.zinc.coop"
@@ -48,6 +41,17 @@ resource "aws_instance" "convene_video" {
                      aws_security_group.allow_tls.name,
                      aws_security_group.allow_jitsi_video.name]
   key_name = "deployer-key"
+}
+
+data "aws_ami" "convene_ami" {
+  most_recent      = true
+  # name_regex       = "^convene-jitsi-*"
+  owners           = ["self"]
+
+  filter {
+    name   = "name"
+    values = ["convene-jitsi-meet.zinc.coop*"]
+  }
 }
 
 resource "aws_eip" "convene_ip" {

--- a/infrastructure/clients/meet.zinc.coop/infrastructure.tf
+++ b/infrastructure/clients/meet.zinc.coop/infrastructure.tf
@@ -45,7 +45,6 @@ resource "aws_instance" "convene_video" {
 
 data "aws_ami" "convene_ami" {
   most_recent      = true
-  # name_regex       = "^convene-jitsi-*"
   owners           = ["self"]
 
   filter {

--- a/infrastructure/clients/meet.zinc.coop/public.tfvars
+++ b/infrastructure/clients/meet.zinc.coop/public.tfvars
@@ -1,2 +1,1 @@
 cloudflare_zone_id = "211e94f01d483d1555310b9a19cf98dd"
-jitsi_ami          = "ami-0e37346b0342fb352"


### PR DESCRIPTION
Now whenever we do a build for meet.zinc.coop, a provision will use the
updated AMI without requiring us to update the variables.