### PR TITLE
Migrate meet.zinc.coop to Vultr

### DIFF
--- a/infrastructure/clients/meet.zinc.coop/infrastructure.tf
+++ b/infrastructure/clients/meet.zinc.coop/infrastructure.tf
@@ -1,7 +1,10 @@
-variable "cloudflare_email" {
+variable "public_key" {
   type = string
 }
 
+variable "cloudflare_email" {
+  type = string
+}
 
 variable "cloudflare_api_key" {
   type = string
@@ -21,146 +24,66 @@ provider "cloudflare" {
 resource "cloudflare_record" "meet" {
   zone_id = var.cloudflare_zone_id
   name    = "meet"
-  value   = aws_eip.convene_ip.public_ip
+  value   = vultr_server.convene_vultr_video.main_ip
   type    = "A"
   ttl     = 1
 }
 
-provider "aws" {
-  region = "us-west-1"
+variable "vultr_api_key" {
+  type = string
 }
 
-resource "aws_instance" "convene_video" {
-  ami           = data.aws_ami.convene_ami.id
-  instance_type = "t2.micro"
-  tags = {
-    Name = "meet.zinc.coop"
-  }
-  security_groups = [aws_security_group.allow_ssh.name,
-                     aws_security_group.allow_http.name,
-                     aws_security_group.allow_tls.name,
-                     aws_security_group.allow_jitsi_video.name]
-  key_name = "deployer-key"
+provider "vultr" {
+  api_key = var.vultr_api_key
 }
 
-data "aws_ami" "convene_ami" {
-  most_recent      = true
-  owners           = ["self"]
-
-  filter {
-    name   = "name"
-    values = ["convene-jitsi-meet.zinc.coop*"]
-  }
+variable "vultr_snapshot_id" {
+  type = string
 }
 
-resource "aws_eip" "convene_ip" {
-  instance = aws_instance.convene_video.id
+resource "vultr_ssh_key" "my_ssh_key" {
+  name = "my-ssh-key"
+  ssh_key = var.public_key
 }
 
-
-resource "aws_security_group" "allow_tls" {
-  name        = "allow_tls"
-  description = "Allow TLS inbound traffic"
-
-  ingress {
-    description = "TLS from World"
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  tags = {
-    Name = "allow_tls"
-  }
+# Create a Vultr server
+resource "vultr_server" "convene_vultr_video" {
+  snapshot_id = var.vultr_snapshot_id
+  region_id = "12"
+  plan_id = "201"
+  firewall_group_id = vultr_firewall_group.convene_vultr_firewall_group.id
+  ssh_key_ids = [vultr_ssh_key.my_ssh_key.id]
 }
 
-
-resource "aws_security_group" "allow_ssh" {
-  name        = "allow_ssh"
-  description = "Allow ssh inbound traffic"
-
-  ingress {
-    description = "SSH from World"
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  tags = {
-    Name = "allow_ssh"
-  }
+# Create Vultr firewall group
+resource "vultr_firewall_group" "convene_vultr_firewall_group" {
+  description = "convene_vultr_firewall_group"
 }
 
-resource "aws_security_group" "allow_http" {
-  name        = "allow_http"
-  description = "Allow HTTP inbound traffic"
-
-  ingress {
-    description = "HTTP from World"
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  tags = {
-    Name = "allow_ssh"
-  }
+resource "vultr_firewall_rule" "allow_tls_convene_vultr_firewall_rule" {
+  firewall_group_id = vultr_firewall_group.convene_vultr_firewall_group.id
+  protocol = "tcp"
+  network = "0.0.0.0/0"
+  from_port = "443"
 }
 
-
-resource "aws_security_group" "allow_jitsi_video" {
-  name        = "allow_jitsi_video"
-  description = "Allow jitsi video inbound traffic"
-
-  ingress {
-    description = "Jitsi Video from world"
-    from_port   = 10000
-    to_port     = 10000
-    protocol    = "udp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  tags = {
-    Name = "allow_jitsi_video"
-  }
+resource "vultr_firewall_rule" "allow_ssh_convene_vultr_firewall_rule" {
+  firewall_group_id = vultr_firewall_group.convene_vultr_firewall_group.id
+  protocol = "tcp"
+  network = "0.0.0.0/0"
+  from_port = "22"
 }
 
-resource "aws_key_pair" "deployer" {
-  key_name = "deployer-key"
-  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDePOrtPv6qxawIMnsDi3mhND3uKKFZKxxq/HGAIU294u1jBEYCjQSHKD1ZuRMSTlXmg1NWPhFz4pAlIUT8t0zkOSz2NKSXlJ0Rl69AbE+6ye2CIL9nfqq9mgA2XHOKPnVIuXdpBuFMmOCavMe7oZKH+qJ7wVFZRKaoWdL1Sw+7wjfCAqMcjq3FW+PvNldFe3B1q9SowXQlXyJW7+wXUj6wBUj3D7kpKOBe7EiLCBytBaQ2ejCxtM8/pqttQqBwUnjF93Gazyw7Ax3JTy+PTIJmkziWKAssvNHsXtB3ijVZY/Do1wGI3MN2zEf3X2wn16Cm67sHQ8/3OR9V4cOQUlOMiEwaWNiHHC0wRi2aIkISVqyDSChu1PN0FgKWvA9MG8EHxSRbhsSHrZ9eVGVsUz92Ca/ZLn6BlhP7ZptgVi+TFmzutRlcwxPb04iO2tL9PA4HqxbjCll0oFCnHwZd7uBxCtQ60UYTH57HzKh0nxkKov0hTr+5bK39d7EEwIehbjIxgy5FCaVuO+HvllxEYtuPhjUHj7gQOOTP7B3SB4OHmGblqNJ+9+oU13DkbdL8Ln/OVf+SrZ462VX3FdqefWu639xFcHt/87K22c3Pd2VsPXSEVGMMyR5sfVPWdKTRlqe1E9sJo3vl70Vjjio/LvQXrwrmn2ozamLc82YuQyZoJw=="
+resource "vultr_firewall_rule" "allow_http_convene_vultr_firewall_rule" {
+  firewall_group_id = vultr_firewall_group.convene_vultr_firewall_group.id
+  protocol = "tcp"
+  network = "0.0.0.0/0"
+  from_port = "80"
 }
 
-
-
-
+resource "vultr_firewall_rule" "allow_jitsi_video_convene_vultr_firewall_rule" {
+  firewall_group_id = vultr_firewall_group.convene_vultr_firewall_group.id
+  protocol = "udp"
+  network = "0.0.0.0/0"
+  from_port = "10000"
+}

--- a/infrastructure/clients/meet.zinc.coop/infrastructure.tf
+++ b/infrastructure/clients/meet.zinc.coop/infrastructure.tf
@@ -51,6 +51,7 @@ resource "vultr_server" "convene_vultr_video" {
   snapshot_id = var.vultr_snapshot_id
   region_id = "12"
   plan_id = "201"
+  label = "meet.zinc.coop"
   firewall_group_id = vultr_firewall_group.convene_vultr_firewall_group.id
   ssh_key_ids = [vultr_ssh_key.my_ssh_key.id]
 }

--- a/infrastructure/clients/meet.zinc.coop/public.tfvars
+++ b/infrastructure/clients/meet.zinc.coop/public.tfvars
@@ -1,1 +1,2 @@
 cloudflare_zone_id = "211e94f01d483d1555310b9a19cf98dd"
+vultr_snapshot_id = "3d75f13901998"

--- a/infrastructure/clients/meet.zinc.coop/secrets-example.tfvars
+++ b/infrastructure/clients/meet.zinc.coop/secrets-example.tfvars
@@ -1,2 +1,4 @@
 cloudflare_email   = "example@example.com"
 cloudflare_api_key = "get-this-from-cloudflare"
+public_key         = "ssh public_key"
+vultr_api_key      = "get-this-from-vultr"

--- a/infrastructure/features/video-workspaces.feature
+++ b/infrastructure/features/video-workspaces.feature
@@ -31,5 +31,5 @@ Feature: Video Workspaces
     When an Operator runs the `jitsi/provision` command with:
       | arguments                        |
       | --client-domain={{clientDomain}} |
-      | --ssh-username={{ssh_username}}  |
+      | --ssh-username=root              |
     Then a JITSI meet instance is available at https://{{clientDomain}}


### PR DESCRIPTION
#29 
Already built a Vultr snapshot for meet.zinc.coop

I believe @zspencer can run the following to destroy the Zinc Coop Convene instance on AWS and provision a Vultr instance after setting the additional `public_key` & `vultr_api_key` and run
```bash
jitsi/provision --client-domain=meet.zinc.coop --flush-dns-cache --ssh-username=zee
```