### PR TITLE
Expand view height to entire screen and allow mobile Jitsi video

### DIFF
--- a/convene-web/app/javascript/controllers/room_picker_controller.js
+++ b/convene-web/app/javascript/controllers/room_picker_controller.js
@@ -20,6 +20,9 @@ export default class extends Controller {
         DISABLE_RINGING: true,
         SETTINGS_SECTIONS: [],
       },
+      configOverwrite: {
+        disableDeepLinking: true,
+      },
     };
 
     document.jitsiApi = new JitsiMeetExternalAPI(domain, options);

--- a/convene-web/app/views/lobbies/show.html.erb
+++ b/convene-web/app/views/lobbies/show.html.erb
@@ -7,4 +7,4 @@
   </ul>
 </div>
 
-<div id="meet"></div>
+<div id="meet" class="h-screen"></div>


### PR DESCRIPTION
Ref: https://github.com/jitsi/jitsi-meet/blob/7bfb2fc21907b2de499b3bed6fe5a4149fecad65/config.js#L489-L491
<img width="1361" alt="Screen Shot 2020-07-26 at 12 50 24 PM" src="https://user-images.githubusercontent.com/8117421/88487951-a9af9580-cf3e-11ea-9bf3-6dfedb68a7a4.png">
