### PR TITLE
Convene-web enforce ssl in production

### DIFF
--- a/convene-web/config/environments/production.rb
+++ b/convene-web/config/environments/production.rb
@@ -44,7 +44,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
Already setup `https://convene.zinc.coop/` but forgot to enforce ssl.