### PR TITLE
Tidy the DemoWorkspace class up a bit

### DIFF
--- a/convene-web/app/models/demo_workspace.rb
+++ b/convene-web/app/models/demo_workspace.rb
@@ -26,14 +26,13 @@ class DemoWorkspace
     # Creates the Convene Demo Workspace and Zinc Client if necessary
     def find_or_create_workspace!
       workspace = client.workspaces.find_or_create_by!(name: 'Convene Demo')
-      workspace.update!(jitsi_meet_domain: 'meet.zinc.coop', access_level: :unlocked)
-      add_demo_rooms
+      workspace.update!(jitsi_meet_domain: 'meet.zinc.coop',
+                        access_level: :unlocked)
+      add_demo_rooms(workspace)
       workspace
     end
 
-    private def add_demo_rooms
-      workspace = Workspace.find_by!(name: 'Convene Demo')
-
+    private def add_demo_rooms(workspace)
       DEMO_ROOMS.each do |name|
         workspace.rooms.find_or_create_by!(name: name)
       end
@@ -41,7 +40,7 @@ class DemoWorkspace
     end
 
     private def client
-      @_client ||= Client.find_or_create_by!(name: 'Zinc')
+      @_client ||= client_repository.find_or_create_by!(name: 'Zinc')
     end
   end
 end


### PR DESCRIPTION
I had went through the trouble of creating a `client_repository` and
then went ahead and referenced `Workspace` and `Client`. This makes the
`Factory` class work with any class that's shaped like an
ActiveRecord::Relation with a structure that mirrors our database
schema.