### PR TITLE
Seeds are idempotent and fail with an exception

### DIFF
--- a/convene-web/db/seeds.rb
+++ b/convene-web/db/seeds.rb
@@ -6,24 +6,25 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-zee = Person.create(email: 'zee@example.com', name: "Zee")
-tom = Person.create(email: 'tom@example.com', name: "Tom")
-bene = Person.create(email: 'bene@example.com', name: "Bene")
+zee = Person.find_or_create_by!(email: 'zee@example.com', name: 'Zee')
+tom = Person.find_or_create_by!(email: 'tom@example.com', name: 'Tom')
+bene = Person.find_or_create_by!(email: 'bene@example.com', name: 'Bene')
 
-zinc = Client.find_or_create_by(name: 'Zinc')
+zinc = Client.find_or_create_by!(name: 'Zinc')
 
 zincs_workspace = zinc.workspaces
-                      .find_or_create_by(name: 'Zinc',
-                                         access_level: :unlocked,
-                                         jitsi_meet_domain: 'meet.zinc.coop')
+                      .find_or_create_by!(name: 'Zinc')
+zincs_workspace.update!(access_level: :unlocked,
+                        jitsi_meet_domain: 'meet.zinc.coop')
 
 zincs_workspace.members << zee
 zincs_workspace.members << tom
 zincs_workspace.members << bene
 
-
-ada = zincs_workspace.rooms.create(name: 'Ada', access_level: :unlocked, publicity_level: :listed)
-ttz = zincs_workspace.rooms.create(name: 'Talk to Zee', access_level: :unlocked, publicity_level: :unlisted)
+ada = zincs_workspace.rooms.find_or_create_by!(name: 'Ada')
+ada.update!(access_level: :unlocked, publicity_level: :listed)
+ttz = zincs_workspace.rooms.find_or_create_by!(name: 'Talk to Zee')
+ttz.update!(access_level: :unlocked, publicity_level: :unlisted)
 ttz.owners << zee
 
 DemoWorkspace.prepare


### PR DESCRIPTION
I wound up having duplicated workspaces because the name and slug was
not unique after running the seeds multiple times.  Now running
`db:seed` should not create the same workspace or room on additional
runs, and it should also raise exceptions if it cannot perform an update
or create operation.