### PR TITLE
Automate creating DNS entries for Convene-Web on Heroku

### DIFF
--- a/infrastructure/clients/meet.zinc.coop/infrastructure.tf
+++ b/infrastructure/clients/meet.zinc.coop/infrastructure.tf
@@ -42,18 +42,18 @@ variable "vultr_snapshot_id" {
 }
 
 resource "vultr_ssh_key" "my_ssh_key" {
-  name = "my-ssh-key"
+  name    = "my-ssh-key"
   ssh_key = var.public_key
 }
 
 # Create a Vultr server
 resource "vultr_server" "convene_vultr_video" {
-  snapshot_id = var.vultr_snapshot_id
-  region_id = "12"
-  plan_id = "201"
-  label = "meet.zinc.coop"
+  snapshot_id       = var.vultr_snapshot_id
+  region_id         = "12"
+  plan_id           = "201"
+  label             = "meet.zinc.coop"
   firewall_group_id = vultr_firewall_group.convene_vultr_firewall_group.id
-  ssh_key_ids = [vultr_ssh_key.my_ssh_key.id]
+  ssh_key_ids       = [vultr_ssh_key.my_ssh_key.id]
 }
 
 # Create Vultr firewall group
@@ -63,28 +63,28 @@ resource "vultr_firewall_group" "convene_vultr_firewall_group" {
 
 resource "vultr_firewall_rule" "allow_tls_convene_vultr_firewall_rule" {
   firewall_group_id = vultr_firewall_group.convene_vultr_firewall_group.id
-  protocol = "tcp"
-  network = "0.0.0.0/0"
-  from_port = "443"
+  protocol          = "tcp"
+  network           = "0.0.0.0/0"
+  from_port         = "443"
 }
 
 resource "vultr_firewall_rule" "allow_ssh_convene_vultr_firewall_rule" {
   firewall_group_id = vultr_firewall_group.convene_vultr_firewall_group.id
-  protocol = "tcp"
-  network = "0.0.0.0/0"
-  from_port = "22"
+  protocol          = "tcp"
+  network           = "0.0.0.0/0"
+  from_port         = "22"
 }
 
 resource "vultr_firewall_rule" "allow_http_convene_vultr_firewall_rule" {
   firewall_group_id = vultr_firewall_group.convene_vultr_firewall_group.id
-  protocol = "tcp"
-  network = "0.0.0.0/0"
-  from_port = "80"
+  protocol          = "tcp"
+  network           = "0.0.0.0/0"
+  from_port         = "80"
 }
 
 resource "vultr_firewall_rule" "allow_jitsi_video_convene_vultr_firewall_rule" {
   firewall_group_id = vultr_firewall_group.convene_vultr_firewall_group.id
-  protocol = "udp"
-  network = "0.0.0.0/0"
-  from_port = "10000"
+  protocol          = "udp"
+  network           = "0.0.0.0/0"
+  from_port         = "10000"
 }

--- a/infrastructure/clients/meet.zinc.coop/infrastructure.tf
+++ b/infrastructure/clients/meet.zinc.coop/infrastructure.tf
@@ -20,13 +20,22 @@ provider "cloudflare" {
   api_key = var.cloudflare_api_key
 }
 
-# Create a record
+# Create a DNS record for the Jitsi Meet Host
 resource "cloudflare_record" "meet" {
   zone_id = var.cloudflare_zone_id
   name    = "meet"
   value   = vultr_server.convene_vultr_video.main_ip
   type    = "A"
   ttl     = 1
+}
+
+# Create a DNS Record for the convene-web instance deployed to Heroku
+resource "cloudflare_record" "convene" {
+  zone_id = var.cloudflare_zone_id
+  name    = "convene"
+  value   = "concave-cougar-3i77opu3gndyc7goxubexjnz.herokudns.com"
+  type    = "CNAME"
+  ttl    = 1
 }
 
 variable "vultr_api_key" {


### PR DESCRIPTION
I noticed that we had set some cloudflare records for convene that were not being managed.

I'm not 100% sure that this is _quite_ how I want to do this; for instance it's not a _client_ that we are setting the DNS for right now; but I'm not sure it's too important.