### PR TITLE
Fix bug where invalid room name in pass onto Jitsi

### DIFF
--- a/convene-web/app/views/rooms/show.html.erb
+++ b/convene-web/app/views/rooms/show.html.erb
@@ -3,7 +3,7 @@
   data-controller="video-room"
   data-target="video-room.wrapper"
   data-video-room-video-host="<%= current_workspace.jitsi_meet_domain %>"
-  data-video-room-name="<%= @current_room.name %>"
+  data-video-room-name="<%= @current_room.slug %>"
   class="bg-gray-800"
 >
 </div>


### PR DESCRIPTION
Fix this:
<img width="1323" alt="Screen Shot 2020-08-03 at 8 17 21 PM" src="https://user-images.githubusercontent.com/8117421/89249165-5be1ff80-d5c6-11ea-83a3-c9bc3b8c0fbe.png">
Because the JS was try to GET `https://meet.zinc.coop/Vivek's%20Desk` and it errors out.