### PR TITLE
Non room creator can enter unlisted room if they know the url

### DIFF
--- a/convene-web/app/controllers/rooms_controller.rb
+++ b/convene-web/app/controllers/rooms_controller.rb
@@ -1,5 +1,5 @@
 class RoomsController < ApplicationController
   def show
-    @current_room = current_workspace.rooms.friendly.accessable_by(current_person).find(params[:id])
+    @current_room = current_workspace.rooms.friendly.find(params[:id])
   end
 end

--- a/convene-web/app/models/room.rb
+++ b/convene-web/app/models/room.rb
@@ -48,9 +48,5 @@ class Room < ApplicationRecord
   scope :unlisted, -> { where(publicity_level: :unlisted) }
 
   scope :owned_by,      -> (person) { joins(:owners).where(room_ownerships: { owner: person }) }
-  scope :accessable_by, -> (person = nil) {
-    listed
-    # TODO: Uncomment below when we implement https://github.com/zinc-collective/convene/issues/39
-    # union(self.owned_by(person)).union(self.listed)
-  }
+  scope :accessable_by, -> (person = nil) { union(self.owned_by(person)).union(self.listed) }
 end


### PR DESCRIPTION
Part of https://github.com/zinc-collective/convene/issues/72
Member can enter unlisted room if they know the url.

@zspencer This should fulfill `Room Creators can discover their own unlisted rooms` if we assume room creator has ownership on the room, let me know what you think.

Thinking about implementation for `Room Previous Attendees can discover previously visited unlisted rooms`:
1. Introduce `AccessRecord` model (or some other better name), upon member visiting a room, create an `AccessRecord` linked to the room and member.
2. `accessable_by` will check on room ownership, listed and presence of `AccessRecord`.
With `AccessRecord`, we might be able to introduce a history of room access record in the future.