### PR TITLE
Replace Jitsi Meet branding to Convene

### DIFF
--- a/infrastructure/videobridge/install
+++ b/infrastructure/videobridge/install
@@ -24,6 +24,9 @@ echo jitsi-meet-web-config    jitsi-meet/cert-path-key    string    /etc/ssl/$VI
 
 sudo apt-get -y install jitsi-meet
 sudo rm /usr/share/jitsi-meet/images/watermark.png
+# Change Jitsi Meet branding to Convene
+# Ref: https://community.jitsi.org/t/app-name-doesnt-have-effect/71648/2
+sudo sed -i "s/Jitsi Meet/Convene/" /usr/share/jitsi-meet/interface_config.js
 
 # Restart instance every PST midnight
 sudo crontab -l > mycron


### PR DESCRIPTION
While Jisti iframe Api `interfaceConfigOverride` mentioned APP_NAME,
APP_NAME doesn't have effect.
Jitsi team disabled APP_NAME due to users not respecting fair use instructions.

Convene is deploying its own instance of Jitsi so it's fair for us to
replace with Convene branding.

Ref: https://community.jitsi.org/t/app-name-doesnt-have-effect/71648/2

We might be able to dig into jitsi-meet React codebase to re-enable APP_NAME
but that would require us to build jitsi-meet frontend code upon deploy instead of
getting packages via apt-get.
If we ever have feature request for dynamic branding of Convene/ Jitsi, we could look into
that in the future.
If we want to have dynamic branding, I think we just need to edit [this file](https://github.com/jitsi/jitsi-meet/pull/7025/files) and built our own jitsi-meet front end code, however I haven't test this approach.

Tested by ssh into convene-videobridge-zinc.zinc.coop
<img width="1434" alt="Screen Shot 2020-08-12 at 12 03 54 PM" src="https://user-images.githubusercontent.com/8117421/90056596-fa8bf180-dc93-11ea-8fdf-0a0521d54f9e.png">