### PR TITLE
Setup Heroku review app

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,28 @@
+{
+  "name": "Convene Web Heroku Review App Configuration",
+  "env": {
+    "APP_BASE": {
+      "description": "Relative path for Convene Web, consume by Heroku mono repo buildpack",
+      "value": "convene-web"
+    }
+  },
+  "buildpacks": [
+    {
+      "url": "https://github.com/lstoll/heroku-buildpack-monorepo"
+    },
+    {
+      "url": "https://github.com/heroku/heroku-buildpack-ruby"
+    }
+  ],
+  "addons": [
+    {
+      "plan": "heroku-postgresql:hobby-dev",
+      "options": {
+        "version": "12"
+      }
+    }
+  ],
+  "scripts": {
+    "postdeploy": "bundle exec rails db:seed"
+  }
+}


### PR DESCRIPTION
Setup review app for smoke test purposes.


Eventually we would want to setup review app for system test purposes but that would require us to automatically setup convene-pr-xxx.zinc.coop per review app.