### PR TITLE
Setup Heroku review app

### DIFF
--- a/app.json
+++ b/app.json
@@ -4,6 +4,10 @@
     "APP_BASE": {
       "description": "Relative path for Convene Web, consume by Heroku mono repo buildpack",
       "value": "convene-web"
+    },
+    "SYSTEM_TEST": {
+      "description": "Seed system test data",
+      "value": "true"
     }
   },
   "buildpacks": [

--- a/app.json
+++ b/app.json
@@ -1,0 +1,28 @@
+{
+  "name": "Convene Web Heroku Review App Configuration",
+  "env": {
+    "APP_BASE": {
+      "description": "Relative path for Convene Web, consume by Heroku mono repo buildpack",
+      "value": "convene-web"
+    }
+  },
+  "buildpacks": [
+    {
+      "url": "https://github.com/lstoll/heroku-buildpack-monorepo"
+    },
+    {
+      "url": "https://github.com/heroku/heroku-buildpack-ruby"
+    }
+  ],
+  "addons": [
+    {
+      "plan": "heroku-postgresql:hobby-dev",
+      "options": {
+        "version": "12"
+      }
+    }
+  ],
+  "scripts": {
+    "postdeploy": "bundle exec rails db:seed"
+  }
+}

--- a/convene-web/app/models/feature.rb
+++ b/convene-web/app/models/feature.rb
@@ -6,6 +6,7 @@ class Feature
   def self.enabled?(feature)
     feature = feature.to_sym if feature.respond_to?(:to_sym)
     return true if feature == :demo && ENV['DEMO_ENABLED']
+    return true if feature == :system_test && ENV['SYSTEM_TEST']
 
     false
   end

--- a/convene-web/app/models/system_test_workspace.rb
+++ b/convene-web/app/models/system_test_workspace.rb
@@ -1,0 +1,58 @@
+class SystemTestWorkspace
+  # Creates the system test workspace, but only on environments which are
+  # configured to include the system test workspace.
+  def self.prepare
+    return unless Feature.enabled?(:system_test)
+
+    Factory.new(Client).find_or_create_workspace!
+  end
+
+  class Factory
+    attr_accessor :client_repository
+    # Expand this to include more room types for different test cases
+    DEMO_ROOMS = [
+      {
+        name: "Listed Room 1",
+        publicity_level: :listed,
+      },
+      {
+        name: "Listed Room 2",
+        publicity_level: :listed,
+      },
+      {
+        name: "Unlisted Room 1",
+        publicity_level: :unlisted,
+      },
+      {
+        name: "Unlisted Room 2",
+        publicity_level: :unlisted,
+      },
+    ].freeze
+
+    # @param [ActiveRecord::Relation<Client>] client_repository Where to ensure there
+    #  is a Zinc Client with the Convene Demo workspace
+    def initialize(client_repository)
+      self.client_repository = client_repository
+    end
+
+    def find_or_create_workspace!
+      workspace = client.workspaces.find_or_create_by!(name: 'System Test')
+      workspace.update!(jitsi_meet_domain: 'convene-videobridge-zinc.zinc.coop',
+                        branded_domain: "#{ENV.fetch('HEROKU_APP_NAME')}.herokuapp.com",
+                        access_level: :unlocked)
+      add_demo_rooms(workspace)
+      workspace
+    end
+
+    private def add_demo_rooms(workspace)
+      DEMO_ROOMS.each do |room|
+        workspace.rooms.find_or_create_by!(name: room[:name], publicity_level: room[:publicity_level])
+      end
+      workspace
+    end
+
+    private def client
+      @_client ||= client_repository.find_or_create_by!(name: 'Zinc')
+    end
+  end
+end

--- a/convene-web/db/seeds.rb
+++ b/convene-web/db/seeds.rb
@@ -29,3 +29,4 @@ ttz.update!(access_level: :unlocked, publicity_level: :unlisted)
 ttz.owners << zee
 
 DemoWorkspace.prepare
+SystemTestWorkspace.prepare


### PR DESCRIPTION
Setup review app for smoke test purposes.


Eventually we would want to setup review app for system test purposes but that would require us to automatically setup convene-pr-xxx.zinc.coop per review app.