### PR TITLE
Documents Screen Sharing Release Notes

### DIFF
--- a/convene-web/CHANGELOG.md
+++ b/convene-web/CHANGELOG.md
@@ -3,6 +3,9 @@
 HEAD
 --------
 ### Added
+- [Screen Sharing] (https://github.com/zinc-collective/convene/issues/91)
+Video fills the screens View Height, making it easier to read text when screen sharing.
+
 - [Discovering Rooms](https://github.com/zinc-collective/convene/issues/39)
 Guests and Workspace Members can see all the Listed Rooms in the workspace.
 


### PR DESCRIPTION
See: https://github.com/zinc-collective/convene/issues/91

Thanks to @user512, video panels fill the entire view portal, which makes it easier to 
see what is going on when screen sharing.