### PR TITLE
Wire in scenarios for guests not discovering unlisted rooms

### DIFF
--- a/features/discovering-rooms.feature
+++ b/features/discovering-rooms.feature
@@ -9,33 +9,9 @@ Feature: Discovering Rooms
     Then they see the Room
 
   @built @unimplemented-steps
-  Scenario: Workspace Member may not discover Unlisted Room
-    Given a Workspace with an Unlisted Room
-    When a Workspace Member is on the Workspace Dashboard
-    Then they do not see the Room
-
-  @built @unimplemented-steps
   Scenario: Guest may discover Listed Room
     Given a Workspace with a Listed Room
     When a Guest is on the Workspace Dashboard
-    Then they see the Room
-
-  @built @unimplemented-steps
-  Scenario: Guest may not discover Unlisted Rooms
-    Given a Workspace with an Unlisted Room
-    When a Guest is on the Workspace Dashboard
-    Then they do not see the Room
-
-  @unstarted
-  Scenario: Room Creator may discover Unlisted Room
-    Given a Workspace with an Unlisted Room
-    When the Room Creator is on the Workspace Dashboard
-    Then they see the Room
-
-  @unstarted
-  Scenario: Previous Attendee may discover previously visited Unlisted Room
-    Given a Workspace with an Unlisted Room
-    When a Previous Attendee of that Room is on the Workspace Dashboard
     Then they see the Room
 
   @unstarted
@@ -43,3 +19,28 @@ Feature: Discovering Rooms
     Given a Workspace with an Listed Internal Room
     When a Guest is on the Workspace Dashboard
     Then they do not see the Room
+
+  # Unlisted Rooms
+
+  @built
+  Scenario: Guest may not discover Unlisted Rooms
+    Given the Guest is on the "System Test" Workspace Dashboard
+    Then the Guest does not see the "Unlisted Room 1" Room's Door
+
+  @built
+  Scenario: Workspace Member may not discover Unlisted Room
+    Given the Workspace Member is on the "System Test" Workspace Dashboard
+    Then the Workspace Member does not see the "Unlisted Room 1" Room's Door
+
+  @unstarted @unimplemented-steps
+  Scenario: Room Creator may discover Unlisted Room
+    Given a Workspace with an Unlisted Room
+    When the Room Creator is on the Workspace Dashboard
+    Then they see the Room
+
+
+  @unstarted
+  Scenario: Room Previous Attendee may discover previously visited Unlisted Room
+    Given a Workspace with an Unlisted Room
+    When a Previous Attendee of that Room is on the Workspace Dashboard
+    Then they see the Room

--- a/features/page-objects/WorkspacePage.js
+++ b/features/page-objects/WorkspacePage.js
@@ -21,8 +21,11 @@ class WorkspacePage extends Page {
     roomCard.findElement(By.linkText("Enter Room")).click();
   }
 
-  async findRoomCard(room) {
-    await this.driver.wait(until.elementLocated(By.id(room.name)));
+  async findRoomCard(room, wait = true) {
+    if(wait) {
+      await this.driver.wait(until.elementLocated(By.id(room.name)));
+    }
+
     return await this.driver.findElement(By.id(room.name));
   }
 

--- a/features/steps/room_steps.js
+++ b/features/steps/room_steps.js
@@ -6,6 +6,11 @@ Given("a Workspace with a {accessLevel} {room}", function (accessLevel, room) {
   return "pending";
 });
 
+Given('a Workspace with an {publicityLevel} Room', function (publicityLevel) {
+  // Write code here that turns the phrase above into concrete actions
+  return 'pending';
+});
+
 When("a {actor} provides the wrong {room} Key", function (actor, room) {
   // Write code here that turns the phrase above into concrete actions
   return "pending";
@@ -33,4 +38,22 @@ Then("the {actor} is not placed in the {room}", function (actor, room) {
 Then('the {workspace} has a {room}', function (workspace, room) {
   // Write code here that turns the phrase above into concrete actions
   return 'pending';
+});
+
+
+Then('the {actor} does not see the {room}\'s Door', function (actor, room) {
+  // We bypass the wait for the room door, and if we _do_ find it,
+  // something has gone horribly wrong, so we're going to raise an
+  // exception and fail the test.
+  // If it _does not_ find the roomCard, then everything is beautiful;
+  // all is right with the world; and we pass the assertion.
+  //
+  // TODO: Figure out a way to do this that doesn't require changing the
+  //       find methods on our page objects!
+  return this.workspace.findRoomCard(room, false).then((ok) => {
+    throw `We found a door for ${room.name} that we did not want to find`
+  }).catch((e) => {
+    if(e.name === 'NoSuchElementError') { return true }
+    throw e
+  });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -193,6 +193,17 @@
         "xregexp": "^4.2.4"
       }
     },
+    "cucumber-pretty": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cucumber-pretty/-/cucumber-pretty-6.0.0.tgz",
+      "integrity": "sha512-ddx/VInPVKFB7N86QujgLivihJhuzexKwExMuFaUjSlEs5zVVqBgaf55f88h97VafXTWX+ZAcxTUwMBS4mYj/g==",
+      "dev": true,
+      "requires": {
+        "cli-table3": "^0.5.1",
+        "colors": "^1.4.0",
+        "figures": "^3.0.0"
+      }
+    },
     "cucumber-tag-expressions": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/cucumber-tag-expressions/-/cucumber-tag-expressions-2.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Community owned tools that bring people together, both online and off",
   "main": "index.js",
   "scripts": {
-    "test": "cucumber-js --tags 'not @unscheduled and not @wip and not @unimplemented-steps and not @unstarted'"
+    "test": "cucumber-js --format node_modules/cucumber-pretty --tags 'not @unscheduled and not @wip and not @unimplemented-steps and not @unstarted'"
   },
   "repository": {
     "type": "git",
@@ -23,7 +23,9 @@
   "homepage": "https://github.com/zinc-collective/convene#readme",
   "devDependencies": {
     "cucumber": "^6.0.5",
+    "cucumber-pretty": "^6.0.0",
     "geckodriver": "^1.20.0",
     "selenium-webdriver": "^4.0.0-alpha.7"
-  }
+  },
+  "dependencies": {}
 }


### PR DESCRIPTION
See: https://github.com/zinc-collective/convene/issues/72
See: https://github.com/zinc-collective/convene/issues/39

- You can bypass waiting for a room card to exist by passing `false` to
  the findRoomCard method on workspace

We think that it would be nice to make the `findRoomCard` function to
return the roomCard itself, or return a false; and move the wait out of
it completely; which would push responsibility for knowing whether we
should "wait for it" to the step.

This would also allow us to "check" the value of the roomCard in steps.

- We use `cucumber-pretty` to format our output legibly

Co-authored-by: Tom Lee <user512@users.noreply.github.com>
Co-authored-by: CJ Joulain <joulain@gmail.com>
Co-authored-by: KellyAH <KellyAH@users.noreply.github.com>