### PR TITLE
Begin to wire in feature test for Locking Rooms

### DIFF
--- a/features/locking-rooms.feature
+++ b/features/locking-rooms.feature
@@ -22,14 +22,14 @@ Feature: Locking Rooms
   @wip
   Scenario: Entering a Locked Room
     Given a Workspace with a Locked Room
-    Then a Workspace Member may enter the room after providing the correct Room Key
-    And a Workspace Member may not enter the room after providing the wrong Room Key
-    And a Guest may enter the room after providing the correct Room Key
-    And a Guest may not enter the room after providing the wrong Room Key
+    Then a Workspace Member may enter the Room after providing the correct Room Key
+    And a Workspace Member may not enter the Room after providing the wrong Room Key
+    And a Guest may enter the Room after providing the correct Room Key
+    And a Guest may not enter the Room after providing the wrong Room Key
     # We're not sure if this is actually a good idea, we should check with
     # design / product to make sure that it makes sense for admins to be able
     # to barge in like a grumpy parent on prom night.
-    And a Workspace Admin may enter the room without providing a Room Key
+    And a Workspace Admin may enter the Room without providing a Room Key
 
   # TODO: We should check with Colombene and Vivek re: "Is there `Invitation` feature?"
   @unstarted
@@ -47,10 +47,22 @@ Feature: Locking Rooms
     When a Workspace Member locks the Room with a Room Key
     Then the Room is Locked
 
+  # This is a "sad path" scenario, that we expect to delete once we
+  # have proven it out; since it's unlikely to be necessary to continuously check
+  # at the user-level; when we can rely on ActiveRecord validations and consistent
+  # usage of form builders that expose error information.
+  @wip
+  Scenario: Locking an Unlocked Room without setting a Room Key
+    Given a Workspace with an Unlocked Room
+    When a Workspace Member locks the Room without a Room Key
+    Then the Workspace Member is informed they need to set a Room Key when they are locking a Room
+    And the Room is Unlocked
+
+
   # Wireframe:
   # https://xd.adobe.com/view/fd425dbe-5384-44c9-997a-eeee6e886a86-a811/screen/847810bf-5d62-4131-a70d-d9efdfadb334
   @wip
   Scenario: Unlocking a Locked Room
   Given a Workspace with a Locked Room
-  When a Workspace Member unlocks the Room with a Room Key
+  When a Workspace Member unlocks the Room with the correct Room Key
   Then the Room is Unlocked

--- a/features/locking-rooms.feature
+++ b/features/locking-rooms.feature
@@ -18,32 +18,13 @@ Feature: Locking Rooms
   The following scenarios illustrate how these permissions play out
   based upon who is accessing rooms with which access level.
 
-  Scenario: Workspace Admin who knows Room Key enters Locked Room
+  Scenario: Entering a Locked Room
     Given a Workspace with a Locked Room
-    When a Workspace Admin provides the correct Room Key
-    Then the Workspace Admin is placed in the Room
-
-  Scenario: Workspace Admin who does not know Room Key cannot enter Locked Room
-    Given a Workspace with a Locked Room
-    When a Workspace Admin provides the wrong Room Key
-    Then the Workspace Admin is not placed in the Room
-
-  Scenario: Workspace Member who knows the Room Key enters Locked Room
-    Given a Workspace with a Locked Room
-    When a Workspace Member provides the correct Room Key
-    Then the Workspace Member is placed in the Room
-
-  Scenario: Workspace Member who does not know the Room Key cannot enter Locked Room
-    Given a Workspace with a Locked Room
-    When a Workspace Member provides the wrong Room Key
-    Then the Workspace Member is not placed in the Room
-
-  Scenario: Guest who knows Room Key enters Locked Room
-    Given a Workspace with a Locked Room
-    When a Guest provides the correct Room Key
-    Then the Guest is placed in the Room
-
-  Scenario: Guest who does not know Room Key cannot enter Locked Room
-    Given a Workspace with a Locked Room
-    When a Guest provides the wrong Room Key
-    Then the Guest is not placed in the Room
+    Then a Workspace Member may enter the room after providing the correct Room Key
+    And a Workspace Member may not enter the room after providing the wrong Room Key
+    And a Guest may enter the room after providing the correct Room Key
+    And a Guest may not enter the room after providing the wrong Room Key
+    # We're not sure if this is actually a good idea, we should check with
+    # design / product to make sure that it makes sense for admins to be able
+    # to barge in like a grumpy parent on prom night.
+    And a Workspace Admin may enter the room without providing a Room Key

--- a/features/locking-rooms.feature
+++ b/features/locking-rooms.feature
@@ -1,4 +1,3 @@
-@wip
 Feature: Locking Rooms
   In order to maintain control over who may participate in a conversation
   As a Workspace Member
@@ -9,7 +8,7 @@ Feature: Locking Rooms
 
   1. Unlocked, which grants access to anyone.
   2. Internal, which grants access to any Workspace Member.
-  3. Locked, which grants access only to people who know the Room's Access Key.
+  3. Locked, which grants access only to people who know the Room's Key.
 
   Design and discussion of the room access model may be found on GitHub at
   https://github.com/zinc-collective/convene/issues/12
@@ -18,6 +17,9 @@ Feature: Locking Rooms
   The following scenarios illustrate how these permissions play out
   based upon who is accessing rooms with which access level.
 
+  # Wireframe:
+  # https://xd.adobe.com/view/fd425dbe-5384-44c9-997a-eeee6e886a86-a811/screen/04ee266e-931b-4bde-bcf9-af94c7ac444e
+  @wip
   Scenario: Entering a Locked Room
     Given a Workspace with a Locked Room
     Then a Workspace Member may enter the room after providing the correct Room Key
@@ -28,3 +30,27 @@ Feature: Locking Rooms
     # design / product to make sure that it makes sense for admins to be able
     # to barge in like a grumpy parent on prom night.
     And a Workspace Admin may enter the room without providing a Room Key
+
+  # TODO: We should check with Colombene and Vivek re: "Is there `Invitation` feature?"
+  @unstarted
+  Scenario: Locking an Unlocked Room when Inviting People
+    Given a Workspace with an Unlocked Room
+    When a Workspace Member locks the Room with a Room Key while Inviting People
+    Then the Room is Locked
+
+
+  # Wireframe:
+  # https://xd.adobe.com/view/fd425dbe-5384-44c9-997a-eeee6e886a86-a811/screen/847810bf-5d62-4131-a70d-d9efdfadb334
+  @wip
+  Scenario: Locking an Unlocked Room
+    Given a Workspace with an Unlocked Room
+    When a Workspace Member locks the Room with a Room Key
+    Then the Room is Locked
+
+  # Wireframe:
+  # https://xd.adobe.com/view/fd425dbe-5384-44c9-997a-eeee6e886a86-a811/screen/847810bf-5d62-4131-a70d-d9efdfadb334
+  @wip
+  Scenario: Unlocking a Locked Room
+  Given a Workspace with a Locked Room
+  When a Workspace Member unlocks the Room with a Room Key
+  Then the Room is Unlocked

--- a/features/parameter-types/rooms.js
+++ b/features/parameter-types/rooms.js
@@ -4,8 +4,20 @@ const { defineParameterType } = require("cucumber");
 // steps that mention `Room` in isolation.
 defineParameterType({
   name: "room",
-  regexp: /"([^"]*)" ?Room/,
-  transformer: (room) => new Room(room),
+  // To make the Room Name optional, we had to capture two things, otherwise
+  // Cucumber will discard the "room" value. This appears to be because the
+  // `Group` class assumes that if there are capture-groups in a parameterType,
+  // the rest of the match should be discarded.
+  // See: https://github.com/cucumber/cucumber/blob/5a3a3167958c45d708228d953a1d5b0f5625a633/cucumber-expressions/javascript/src/Group.ts#L11
+  //
+  // There are probably multiple ways to work around this. For example, instead of
+  // adding a capture group, we could check if roomName is undefined in the Room
+  // class, and default it to 'Room' or something.
+  //
+  // In the meantime, adding a capture-group around "Room" ensures that the Room
+  // class has a string provided to it.
+  regexp: /("[^"]*" )?(Room)/,
+  transformer: (roomName) => new Room(roomName),
 });
 
 class Room {

--- a/features/parameter-types/rooms.js
+++ b/features/parameter-types/rooms.js
@@ -17,13 +17,14 @@ defineParameterType({
   // In the meantime, adding a capture-group around "Room" ensures that the Room
   // class has a string provided to it.
   regexp: /("[^"]*" )?(Room)/,
-  transformer: (roomName) => new Room(roomName),
+  transformer: (roomName) => new Room(roomName.trim().replace(/"/g, "")),
 });
 
+const slugify = (str) => str.replace(/\s+/g, "-").toLowerCase();
 class Room {
   constructor(roomName) {
     this.name = roomName;
-    this.slug = roomName.replace(/\s+/g, '-').toLowerCase();
+    this.slug = slugify(roomName);
   }
 }
 
@@ -55,8 +56,7 @@ class PublicityLevel {
   }
 }
 
-
 defineParameterType({
   name: "roomKey",
-  regexp: /(a |the )?(correct |wrong )?Room Key/
+  regexp: /(a |the )?(correct |wrong )?Room Key/,
 });

--- a/features/parameter-types/rooms.js
+++ b/features/parameter-types/rooms.js
@@ -32,7 +32,7 @@ class Room {
 // See: https://github.com/zinc-collective/convene/issues/41
 defineParameterType({
   name: "accessLevel",
-  regexp: /(Unlocked|Internal|Locked)/,
+  regexp: /(an |a )?(Unlocked|Internal|Locked)/,
   transformer: (level) => new AccessLevel(level),
 });
 
@@ -54,3 +54,9 @@ class PublicityLevel {
     this.level = level;
   }
 }
+
+
+defineParameterType({
+  name: "roomKey",
+  regexp: /(a |the )?(correct |wrong )?Room Key/
+});

--- a/features/steps/room_steps.js
+++ b/features/steps/room_steps.js
@@ -1,7 +1,7 @@
 const { Given, When, Then } = require("cucumber");
 const assert = require('assert').strict;
 
-Given("a Workspace with a {accessLevel} {room}", function (accessLevel, room) {
+Given("a Workspace with {accessLevel} {room}", function (accessLevel, room) {
   // Write code here that turns the phrase above into concrete actions
   return "pending";
 });
@@ -11,14 +11,19 @@ Given('a Workspace with an {publicityLevel} Room', function (publicityLevel) {
   return 'pending';
 });
 
-When("a {actor} provides the wrong {room} Key", function (actor, room) {
+When("a {actor} unlocks the {room} with {roomKey}", function (actor, room) {
   // Write code here that turns the phrase above into concrete actions
   return "pending";
 });
 
-When("a {actor} provides the correct {room} Key", function (actor, room) {
+When("a {actor} locks the {room} with {roomKey}", function (actor, room) {
   // Write code here that turns the phrase above into concrete actions
   return "pending";
+});
+
+When('a {actor} locks the {room} without {roomKey}', function (actor, room, roomKey) {
+  // Write code here that turns the phrase above into concrete actions
+  return 'pending';
 });
 
 When('the {actor} taps the {room} in the Room Picker', async function (actor, room) {
@@ -33,6 +38,21 @@ Then("the {actor} is placed in the {room}", async function (actor, room) {
 Then("the {actor} is not placed in the {room}", function (actor, room) {
   // Write code here that turns the phrase above into concrete actions
   return "pending";
+});
+
+Then('a {actor} may enter the Room without providing {roomKey}', function (actor, roomKey) {
+  // Write code here that turns the phrase above into concrete actions
+  return 'pending';
+});
+
+Then('a {actor} may not enter the {room} after providing {roomKey}', function (actor, room, roomKey) {
+  // Write code here that turns the phrase above into concrete actions
+  return 'pending';
+});
+
+Then('a {actor} may enter the {room} after providing {roomKey}', function (actor, room, roomKey) {
+  // Write code here that turns the phrase above into concrete actions
+  return 'pending';
 });
 
 Then('the {workspace} has a {room}', function (workspace, room) {
@@ -56,4 +76,14 @@ Then('the {actor} does not see the {room}\'s Door', function (actor, room) {
     if(e.name === 'NoSuchElementError') { return true }
     throw e
   });
+});
+
+Then('the Room is {accessLevel}', function (accessLevel) {
+  // Write code here that turns the phrase above into concrete actions
+  return 'pending';
+});
+
+Then('the {actor} is informed they need to set {roomKey} when they are locking a {room}', function (actor, roomKey, room) {
+  // Write code here that turns the phrase above into concrete actions
+  return 'pending';
 });


### PR DESCRIPTION
Paired with @cjoulain to flesh out the Feature definitions for Locking Rooms.

First, we noticed that there were a lot of scenarios that maybe didn't need to exist; and we collapsed them into a single scenario that lays out which people have which access rights.

Then, we noticed that there were some missing scenarios, like locking and unlocking the room. So we put those in as well.

Finally, we began to wire those scenarios into parameterTypes and step definitions so we can write user-level integration tests.


(P.s, I'm going to let @cjoulain merge after approval, so they get the `Co-Authored By` credit)
