### PR TITLE
🛠 Add a docker-compose file to streamline dev setup

### DIFF
--- a/convene-web/.env.example
+++ b/convene-web/.env.example
@@ -1,4 +1,11 @@
 DEMO_ENABLED=false
 SYSTEM_TEST=true
+
 ADMIN_USERNAME=admin
 ADMIN_PASSWORD=admin
+
+# If you are using docker to manage your postgresql database,
+# you will want to uncomment these
+# PGHOST=localhost
+# PGUSER=postgres
+# PGPASSWORD=password

--- a/convene-web/README.md
+++ b/convene-web/README.md
@@ -16,7 +16,10 @@ First, ensure your development environment has:
 
 1. Ruby (See [.ruby-version](./.ruby-version) for version)
 1. Node (See [.nvmrc](./.nvmrc) for version)
-1. [PostgreSQL 12](https://www.postgresql.org/download/)
+1. [PostgreSQL 12]. (Note: For people using [Docker], a [docker-compose.yml]
+   file has been included for convenience.)
+1. Copy `[.env.example]` to `.env` and make any changes: `cp .env.example
+   .env`
 
 Then, run `bin/setup` to install Ruby and Node dependencies and set up the
 database.
@@ -26,6 +29,11 @@ http://localhost:3000/workspaces/system-test and see Convene.
 
 Finally, run `bin/test` to ensure that your development environment is
 configured correctly.
+
+[PostgreSQL 12]: https://www.postgresql.org/download/
+[Docker]: https://www.docker.com
+[docker-compose.yml]: ../docker-compose.yml
+[.env.example]: ./.env.example
 
 ### Testing Convene Web
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.1'
+
+services:
+  db:
+    image: postgres
+    restart: always
+    environment:
+      POSTGRES_PASSWORD: password
+    ports:
+      - 5432:5432


### PR DESCRIPTION
For folks that already have docker set up, it saves a bit of effort to
use docker-compose to manage a postgresql database just for Convene.