### PR TITLE
🛠 Developers may override the interface convene-web listens on

### DIFF
--- a/convene-web/bin/run
+++ b/convene-web/bin/run
@@ -4,5 +4,9 @@
 # Conditionally assign PORT so that it can be overridden
 # https://stackoverflow.com/questions/2440947/how-to-build-a-conditional-assignment-in-bash
 : ${PORT:=3000}
-echo $PORT
-bin/rails s -p $PORT
+
+# When developing on remote machines it's useful to bind to the 0.0.0.0
+# interface in development instead of localhost so that the application can be
+# visited in browser without doing port forwarding.
+: ${BINDING:=localhost}
+bin/rails s -p $PORT -b $BINDING


### PR DESCRIPTION
I sometimes do my development on a remote VM, so my browser's
`localhost` is not the same as the development machine's `localhost`

I probably should figure out a way to use nginx or haproxy or something
to sit in between the requests instead of making this change; but that
seems non-trivial and I was hoping to make some progress :(.