### PR TITLE
Stay in video room when user refresh

### DIFF
--- a/convene-web/app/javascript/src/video_room.js
+++ b/convene-web/app/javascript/src/video_room.js
@@ -32,7 +32,9 @@ export default class VideoRoom {
     if (!this.roomName) return;
     this.jitsi = new JitsiMeetExternalAPI(this.domain, this.jitsiApiOption());
 
-    this.jitsi.on('videoConferenceLeft', () => this.exitRoom(true) );
+    // Exit room without dispatching event when user refresh to prevent replacing to workspace url
+    this.parentNode.addEventListener('beforeunload', () => this.exitRoom(false));
+    this.jitsi.on('readyToClose', () => this.exitRoom(true));
   }
 
   jitsiApiOption() {


### PR DESCRIPTION
Connects #115 
* Previously the `videoConferenceLeft` event will get triggered when user reload.
Use `readyToClose` event instead because it only got triggered when user intended to hangup.