### PR TITLE
added table of contents and summary sentence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Convene
 
-Space to (play || work || grow || be).
+* [Developing Convene](#developing-convene)
+* [Architecture](#architecture)
+* [Design](#design)
+
+Convene is a video conferencing software that provides secure, affordable, and private digital meeting spaces. 
+Spaces where anyone can (play || work || grow || be).
 
 ## Purpose
 


### PR DESCRIPTION
# Problem
The readme doesn't clearly state that the convene app is a video conference app. The doc is getting rather long and you have to scroll through a lot of text to get to the info you want.

# Code Change
**Docs**

- Added Table of Contents (TOC) for easier navigation.
- Added summary sentence because it is currently not easily communicated what the Convene is.

# Other readme changes that are worth considering
- [ ] Reorganize text under clearer header structure
E.g. 
```
- About Convene
  - [add summary what the app is]
  - [insert Objectives and Purpose - all the pretty marketing text]
- Contributing
  - [insert info for any devs wanting to work on the app, link to Convene::Web/README.md]
  - [insert Help and Support section]
  - [insert "Convene is Community Owned...." sentence]
  - [insert The Circle of Stewards section]
- Architecture
  - [insert Budget section]
- Design
- Using Convene
- About the Zinc Collective
```

- [ ] Add nice zinc promo text like:
E.g. `"Convene is one of many exciting projects maintained by a community of volunteer Contributors and Maintainers. Together, we are the Zinc Collective!"`

