### PR TITLE
Wire in steps for entering a locked room

### DIFF
--- a/convene-web/app/models/room.rb
+++ b/convene-web/app/models/room.rb
@@ -19,6 +19,7 @@ class Room < ApplicationRecord
   # `locked` indicates that only participants who know the rrooms `access_code` may access the room.
   # `internal` indicates that only participants who are Workspace Members _or_ know the Workspaces `access_code` may
   # access the room.
+  # TODO Return :unlocked by default, add database non null
   attribute :access_level, :string
 
   # A room's Access Code is a "secret" that, when known, grants access to the room.

--- a/convene-web/app/views/workspaces/_room_card.html.erb
+++ b/convene-web/app/views/workspaces/_room_card.html.erb
@@ -1,4 +1,4 @@
-<li class="col-span-1 bg-white rounded-lg shadow mb-4" id="<%= room.name %>" >
+<li class="col-span-1 bg-white rounded-lg shadow mb-4 <%= "--#{room.access_level}" %>" id="<%= room.name %>">
   <div class="w-full flex items-center justify-between p-6 space-x-6">
     <div class="flex-1 truncate">
       <div class="flex items-center space-x-3">

--- a/features/locking-rooms.feature
+++ b/features/locking-rooms.feature
@@ -19,13 +19,13 @@ Feature: Locking Rooms
 
   # Wireframe:
   # https://xd.adobe.com/view/fd425dbe-5384-44c9-997a-eeee6e886a86-a811/screen/04ee266e-931b-4bde-bcf9-af94c7ac444e
-  @built @unimplemented-steps
+  @built
   Scenario: Entering a Locked Room
     Given a Workspace with a Locked Room
-    Then a Workspace Member may enter the Room after providing the correct Room Key
-    And a Workspace Member may not enter the Room after providing the wrong Room Key
-    And a Guest may enter the Room after providing the correct Room Key
-    And a Guest may not enter the Room after providing the wrong Room Key
+    Then a Workspace Member may enter the Locked Room after providing the correct Room Key
+    And a Workspace Member may not enter the Locked Room after providing the wrong Room Key
+    And a Guest may enter the Locked Room after providing the correct Room Key
+    And a Guest may not enter the Locked Room after providing the wrong Room Key
 
   # TODO: We should check with Colombene and Vivek re: "Is there `Invitation` feature?"
   @unstarted

--- a/features/locking-rooms.feature
+++ b/features/locking-rooms.feature
@@ -19,7 +19,7 @@ Feature: Locking Rooms
 
   # Wireframe:
   # https://xd.adobe.com/view/fd425dbe-5384-44c9-997a-eeee6e886a86-a811/screen/04ee266e-931b-4bde-bcf9-af94c7ac444e
-  @built
+  @wip
   Scenario: Entering a Locked Room
     Given a Workspace with a Locked Room
     Then a Workspace Member may enter the Locked Room after providing the correct Room Key
@@ -37,7 +37,7 @@ Feature: Locking Rooms
 
   # Wireframe:
   # https://xd.adobe.com/view/fd425dbe-5384-44c9-997a-eeee6e886a86-a811/screen/847810bf-5d62-4131-a70d-d9efdfadb334
-  @wip
+  @unstarted
   Scenario: Locking an Unlocked Room
     Given a Workspace with an Unlocked Room
     When a Workspace Member locks the Room with a Room Key
@@ -47,7 +47,7 @@ Feature: Locking Rooms
   # have proven it out; since it's unlikely to be necessary to continuously check
   # at the user-level; when we can rely on ActiveRecord validations and consistent
   # usage of form builders that expose error information.
-  @wip
+  @unstarted
   Scenario: Locking an Unlocked Room without setting a Room Key
     Given a Workspace with an Unlocked Room
     When a Workspace Member locks the Room without a Room Key
@@ -57,7 +57,7 @@ Feature: Locking Rooms
 
   # Wireframe:
   # https://xd.adobe.com/view/fd425dbe-5384-44c9-997a-eeee6e886a86-a811/screen/847810bf-5d62-4131-a70d-d9efdfadb334
-  @wip
+  @unstarted
   Scenario: Unlocking a Locked Room
   Given a Workspace with a Locked Room
   When a Workspace Member unlocks the Room with the correct Room Key

--- a/features/page-objects/WorkspacePage.js
+++ b/features/page-objects/WorkspacePage.js
@@ -48,6 +48,11 @@ class WorkspacePage extends Page {
     assert.equal(videoPanels.length, 1, `${videoPanels.length} was found.`)
     return await this.driver.findElement(jitsiConferenceFrame);
   }
+
+  roomCardsWhere({ accessLevel }) {
+    const selector = `.--${accessLevel.level.toLowerCase()}`
+    return this.driver.findElements(By.css(`.--${accessLevel.level.toLowerCase()}`));
+  }
 }
 
 module.exports = WorkspacePage;

--- a/features/page-objects/WorkspacePage.js
+++ b/features/page-objects/WorkspacePage.js
@@ -22,14 +22,16 @@ class WorkspacePage extends Page {
   }
 
   async enterRoomWithAccessCode(room, accessCode) {
+    this.driver.manage().deleteAllCookies();
+    this.enter();
     await this.enterRoom(room);
 
-    const placeholderSelector = By.css("[placeholder='Access Code']");
-    await this.driver.wait(until.elementLocated(placeholderSelector));
-    const accessCodeInput = await this.driver.findElement(placeholderSelector);
+    const inputSelector = By.css("[id='waiting_room_access_code']");
+    await this.driver.wait(until.elementLocated(inputSelector));
+    const accessCodeInput = await this.driver.findElement(inputSelector);
     accessCodeInput.sendKeys(accessCode);
 
-    const submitInput = await this.driver.findElement(By.css("[value='Submit']"));
+    const submitInput = await this.driver.findElement(By.css("[type='submit']"));
     submitInput.click();
   }
 

--- a/features/page-objects/WorkspacePage.js
+++ b/features/page-objects/WorkspacePage.js
@@ -52,7 +52,6 @@ class WorkspacePage extends Page {
   }
 
   roomCardsWhere({ accessLevel }) {
-    const selector = `.--${accessLevel.level.toLowerCase()}`
     return this.driver.findElements(By.css(`.--${accessLevel.level.toLowerCase()}`));
   }
 }

--- a/features/parameter-types/rooms.js
+++ b/features/parameter-types/rooms.js
@@ -33,8 +33,8 @@ class Room {
 // See: https://github.com/zinc-collective/convene/issues/41
 defineParameterType({
   name: "accessLevel",
-  regexp: /(an |a )?(Unlocked|Internal|Locked)/,
-  transformer: (level) => new AccessLevel(level),
+  regexp: /(an |a |the )?(Unlocked|Internal|Locked)/,
+  transformer: (_, level) => new AccessLevel(level),
 });
 
 class AccessLevel {
@@ -60,3 +60,5 @@ defineParameterType({
   name: "roomKey",
   regexp: /(a |the )?(correct |wrong )?Room Key/,
 });
+
+module.exports = Room;

--- a/features/parameter-types/workspaces.js
+++ b/features/parameter-types/workspaces.js
@@ -15,3 +15,5 @@ class Workspace {
     this.slug = workspaceName.replace(/\s+/g, '-').toLowerCase();
   }
 }
+
+module.exports = Workspace;

--- a/features/steps/room_steps.js
+++ b/features/steps/room_steps.js
@@ -1,9 +1,15 @@
 const { Given, When, Then } = require("cucumber");
+const WorkspacePage = require("../page-objects/WorkspacePage");
+const Workspace = require("../parameter-types/workspaces");
+const Room = require("../parameter-types/rooms");
 const assert = require('assert').strict;
 
-Given("a Workspace with {accessLevel} {room}", function (accessLevel, room) {
-  // Write code here that turns the phrase above into concrete actions
-  return "pending";
+Given("a Workspace with {accessLevel} {room}", async function (accessLevel, room) {
+  const workspace = new Workspace("System Test");
+  this.workspace = new WorkspacePage(this.driver, workspace);
+  await this.workspace.enter();
+  const lockedRooms = await this.workspace.roomCardsWhere({ accessLevel });
+  assert(lockedRooms.length > 0);
 });
 
 Given('a Workspace with an {publicityLevel} Room', function (publicityLevel) {
@@ -45,13 +51,17 @@ Then('a {actor} may enter the Room without providing {roomKey}', function (actor
   return 'pending';
 });
 
-Then('a {actor} may not enter the {room} after providing {roomKey}', async function (actor, room, roomKey) {
-  // Write code here that turns the phrase above into concrete actions
-  return 'pending';
+Then('a {actor} may not enter {accessLevel} {room} after providing {roomKey}', async function (actor, accessLevel, room, roomKey) {
+  const lockedRoom = new Room(`Listed ${accessLevel.level} Room 1`);
+  await this.workspace.enterRoomWithAccessCode(lockedRoom, 'wrong key');
+  // TODO: Assert error message, assert videoPanel don't exist without waiting for timeout
+  const videoPanel = await this.workspace.videoPanel();
+  assert.fail(await videoPanel.isDisplayed());
 });
 
-Then('a {actor} may enter the {room} after providing {roomKey}', async function (actor, room, roomKey) {
-  await this.workspace.enterRoomWithAccessCode(room, 'secret');
+Then('a {actor} may enter {accessLevel} {room} after providing {roomKey}', async function (actor, accessLevel, room, roomKey) {
+  const lockedRoom = new Room(`Listed ${accessLevel.level} Room 1`);
+  await this.workspace.enterRoomWithAccessCode(lockedRoom, 'secret');
   const videoPanel = await this.workspace.videoPanel();
   assert(await videoPanel.isDisplayed());
 });

--- a/features/steps/room_steps.js
+++ b/features/steps/room_steps.js
@@ -4,6 +4,8 @@ const Workspace = require("../parameter-types/workspaces");
 const Room = require("../parameter-types/rooms");
 const assert = require('assert').strict;
 
+const { By, until } = require('selenium-webdriver');
+
 Given("a Workspace with {accessLevel} {room}", async function (accessLevel, room) {
   const workspace = new Workspace("System Test");
   this.workspace = new WorkspacePage(this.driver, workspace);
@@ -54,9 +56,11 @@ Then('a {actor} may enter the Room without providing {roomKey}', function (actor
 Then('a {actor} may not enter {accessLevel} {room} after providing {roomKey}', async function (actor, accessLevel, room, roomKey) {
   const lockedRoom = new Room(`Listed ${accessLevel.level} Room 1`);
   await this.workspace.enterRoomWithAccessCode(lockedRoom, 'wrong key');
-  // TODO: Assert error message, assert videoPanel don't exist without waiting for timeout
-  const videoPanel = await this.workspace.videoPanel();
-  assert.fail(await videoPanel.isDisplayed());
+
+  // TODO: Encapsulate checking error messages
+  const error = By.css("[class='access-code-form__error-message']")
+  const errorMsg = await this.driver.wait(until.elementLocated(error));
+  assert.equal(await errorMsg.isDisplayed(), true)
 });
 
 Then('a {actor} may enter {accessLevel} {room} after providing {roomKey}', async function (actor, accessLevel, room, roomKey) {


### PR DESCRIPTION
* [x] Fix AccessLevels getting undefined values from the accessLevel parameterType
* [X] Implement step definition for entering a workspace with a Locked Room
* [X] Implement step definition for entering a Locked Room
* [X] Implement step definition for being prevented from entering a Locked Room
* [X] Expose the Room's Access Level in the the room card's DOM
* [X] Add helper method to Workspace PageObject for selecting RoomCards from the DOM
* [x] Verify that an error message is provided when entering the wrong room and that people don't enter the room
* [ ] (Maybe?) Clarify parameter type and regex in README (@KellyAH, @zspencer)
* [ ] (Maybe?) Align SystemTest Workspace locked room access code with Demo Workspace
