### PR TITLE
Add running db:seed to bin/setup, and clarify a couple of bits in the README that confused me

### DIFF
--- a/convene-web/README.md
+++ b/convene-web/README.md
@@ -18,8 +18,8 @@ First, ensure your development environment has:
 1. Node (See [.nvmrc](./.nvmrc) for version)
 1. [PostgreSQL 12]. (Note: For people using [Docker], a [docker-compose.yml]
    file has been included for convenience.)
-1. Copy `[.env.example]` to `.env` and make any changes: `cp .env.example
-   .env`
+1. Copy `convene-web/.env.example` to `convene-web/.env` and make any changes: `cp convene-web/.env.example
+   convene-web/.env`.
 
 Then, run `bin/setup` to install Ruby and Node dependencies and set up the
 database.
@@ -27,8 +27,8 @@ database.
 Once you have completed setup; run `bin/run`. You now should be able to open
 http://localhost:3000/workspaces/system-test and see Convene.
 
-Finally, run `bin/test` to ensure that your development environment is
-configured correctly.
+Finally, with the server still running (perhaps in a different terminal), run
+`bin/test` to ensure that your development environment is configured correctly.
 
 [PostgreSQL 12]: https://www.postgresql.org/download/
 [Docker]: https://www.docker.com

--- a/convene-web/bin/setup
+++ b/convene-web/bin/setup
@@ -28,6 +28,9 @@ FileUtils.chdir APP_ROOT do
   puts "\n== Preparing development database =="
   system! 'bin/rails db:prepare'
 
+  puts "\n== Seeding development database according to feature settings in .env =="
+  system! 'bin/rake db:seed'
+
   puts "\n== Preparing test database =="
   system! 'RAILS_ENV=test bin/rails db:test:prepare'
 


### PR DESCRIPTION
I propose adding `bin/rake db:seed` to the steps in `bin/setup`, because it seems needed for the System Test and other test/demo workspaces to be created.

I'm not sure if there is a downside to having this step always in `bin/setup`, but at first glance `seeds.rb` seems idempotent. An alternative would be to simply add a step in the README for the developer to separately run `bin/rake db:seed`.

I also attempted to clarify a couple of things in the README that I found unclear.