### PR TITLE
Live Reloading Frontend Asset in Development & Optimize Webpack Recompile

### DIFF
--- a/convene-web/app/javascript/packs/application.js
+++ b/convene-web/app/javascript/packs/application.js
@@ -18,5 +18,6 @@ require("channels")
 
 import "controllers"
 
+require('../src/tailwind.scss')
 require('../src/application.scss')
 require("@fortawesome/fontawesome-free/css/all.css")

--- a/convene-web/app/javascript/src/application.scss
+++ b/convene-web/app/javascript/src/application.scss
@@ -1,8 +1,2 @@
-@import "tailwindcss/base";
-@import "tailwindcss/components";
-
-// All extract components must be placed between tailwindcss/components & tailwindcss/utilities to avoid being overwriting utilites
 @import "./custom_components";
 @import "./page_bem_class";
-
-@import "tailwindcss/utilities";

--- a/convene-web/app/javascript/src/custom_components/button.scss
+++ b/convene-web/app/javascript/src/custom_components/button.scss
@@ -1,9 +1,11 @@
-.button {
-  @apply font-bold py-2 px-4 rounded;
-}
-.button-blue {
-  @apply bg-blue-500 text-white;
-}
-.button-blue:hover {
-  @apply bg-blue-700;
+@layer components {
+  .button {
+    @apply font-bold py-2 px-4 rounded;
+  }
+  .button-blue {
+    @apply bg-blue-500 text-white;
+  }
+  .button-blue:hover {
+    @apply bg-blue-700;
+  }
 }

--- a/convene-web/app/javascript/src/custom_components/form.scss
+++ b/convene-web/app/javascript/src/custom_components/form.scss
@@ -1,24 +1,26 @@
-input {
-  @apply bg-white border border-gray-300 rounded-lg py-2 px-4 block appearance-none leading-normal;
-}
-input:focus {
-  @apply outline-none shadow-outline;
-}
-.access-code-form {
-  @apply m-auto flex flex-col;
-}
-.access-code-form__input {
-  @apply mt-4;
-}
-.access-code-form__input--error {
-  @apply border border-red-500;
-}
-.access-code-form__message {
-  @apply hidden;
-}
-.access-code-form__error-message {
-  @apply text-xs italic font-hairline text-red-500;
-}
-.access-code-form__submit {
-  @apply mt-4;
+@layer components {
+  input {
+    @apply bg-white border border-gray-300 rounded-lg py-2 px-4 block appearance-none leading-normal;
+  }
+  input:focus {
+    @apply outline-none shadow-outline;
+  }
+  .access-code-form {
+    @apply m-auto flex flex-col;
+  }
+  .access-code-form__input {
+    @apply mt-4;
+  }
+  .access-code-form__input--error {
+    @apply border border-red-500;
+  }
+  .access-code-form__message {
+    @apply hidden;
+  }
+  .access-code-form__error-message {
+    @apply text-xs italic font-hairline text-red-500;
+  }
+  .access-code-form__submit {
+    @apply mt-4;
+  }
 }

--- a/convene-web/app/javascript/src/custom_components/header.scss
+++ b/convene-web/app/javascript/src/custom_components/header.scss
@@ -1,13 +1,15 @@
-.header {
-  .items-container {
-    @apply flex items-center justify-between px-4 py-3 bg-blue-500 text-white font-bold;
+@layer components {
+  .header {
+    .items-container {
+      @apply flex items-center justify-between px-4 py-3 bg-blue-500 text-white font-bold;
 
-    h1 {
-      @apply text-2xl;
-    }
+      h1 {
+        @apply text-2xl;
+      }
 
-    h3 {
-      @apply text-sm;
+      h3 {
+        @apply text-sm;
+      }
     }
   }
 }

--- a/convene-web/app/javascript/src/custom_components/icons.scss
+++ b/convene-web/app/javascript/src/custom_components/icons.scss
@@ -1,7 +1,9 @@
-.icon-solid::before {
-  font-family: "Font Awesome 5 Free"; font-weight: 900;
-  @apply mr-2;
-}
-.phone-alt-icon::before {
-  content: "\f879";
+@layer components {
+  .icon-solid::before {
+    font-family: "Font Awesome 5 Free"; font-weight: 900;
+    @apply mr-2;
+  }
+  .phone-alt-icon::before {
+    content: "\f879";
+  }
 }

--- a/convene-web/app/javascript/src/custom_components/room_card.scss
+++ b/convene-web/app/javascript/src/custom_components/room_card.scss
@@ -1,34 +1,36 @@
-.room-card {
-  @apply grid grid-cols-1 grid-rows-2 grid-flow-col shadow rounded-lg;
+@layer components {
+  .room-card {
+    @apply grid grid-cols-1 grid-rows-2 grid-flow-col shadow rounded-lg;
 
-  header {
-    @apply w-full flex items-center;
+    header {
+      @apply w-full flex items-center;
 
-    h3 {
-      @apply text-gray-900 text-sm leading-5 font-medium truncate pl-8 mr-4;
-    }
-  }
-
-
-  footer {
-    @apply w-full flex items-center justify-center border-t border-gray-200;
-
-    .room-door_enter {
-      @apply flex justify-center text-sm leading-5 text-gray-700 font-medium border border-transparent rounded-br-lg transition ease-in-out duration-150;
-      a {
-        @apply flex-1 inline-flex items-center justify-center py-4;
-      }
-      span {
-        @apply pl-4;
+      h3 {
+        @apply text-gray-900 text-sm leading-5 font-medium truncate pl-8 mr-4;
       }
     }
 
-    .room-door_enter:focus {
-      @apply outline-none shadow-outline-blue border-blue-300 z-10;
-    }
 
-    .room-door_enter:hover {
-      @apply text-gray-500;
+    footer {
+      @apply w-full flex items-center justify-center border-t border-gray-200;
+
+      .room-door_enter {
+        @apply flex justify-center text-sm leading-5 text-gray-700 font-medium border border-transparent rounded-br-lg transition ease-in-out duration-150;
+        a {
+          @apply flex-1 inline-flex items-center justify-center py-4;
+        }
+        span {
+          @apply pl-4;
+        }
+      }
+
+      .room-door_enter:focus {
+        @apply outline-none shadow-outline-blue border-blue-300 z-10;
+      }
+
+      .room-door_enter:hover {
+        @apply text-gray-500;
+      }
     }
   }
 }

--- a/convene-web/app/javascript/src/tailwind.scss
+++ b/convene-web/app/javascript/src/tailwind.scss
@@ -1,0 +1,3 @@
+@import "tailwindcss/base";
+@import "tailwindcss/components";
+@import "tailwindcss/utilities";

--- a/convene-web/bin/run
+++ b/convene-web/bin/run
@@ -9,4 +9,4 @@
 # interface in development instead of localhost so that the application can be
 # visited in browser without doing port forwarding.
 : ${BINDING:=localhost}
-bin/rails s -p $PORT -b $BINDING
+bin/webpack-dev-server & bin/rails s -p $PORT -b $BINDING


### PR DESCRIPTION
74f53ef  provide live reload and compile frontend asset on JS / SCSS file change instead of waiting for a new request in development mode.

fbb02df optimize webpack recompile so recompile time is down to around 1 second.
Before fbb02df, making changes in any scss file that uses `@apply`
```
ℹ ｢wdm｣: Compiling...
ℹ ｢wdm｣: Hash: afed0a07af075545d568
Version: webpack 4.44.1
Time: 9598ms
```
After fbb02df
```
ℹ ｢wdm｣: Compiling...
ℹ ｢wdm｣: Hash: ead83387e0a910303855
Version: webpack 4.44.1
Time: 751ms
```

Please note that initial compile will still be slow but it'll be fine because developer only run `bin/run` once.