### PR TITLE
Disable access code input when intended to unlock room

### DIFF
--- a/convene-web/app/javascript/controllers/room_edit_form_controller.js
+++ b/convene-web/app/javascript/controllers/room_edit_form_controller.js
@@ -1,0 +1,9 @@
+import { Controller } from "stimulus"
+
+export default class extends Controller {
+  static targets = [ "accessCode" ]
+
+  accessLevelToggle() {
+    this.accessCodeTarget.disabled = !this.accessCodeTarget.disabled
+  }
+}

--- a/convene-web/app/javascript/src/custom_components/form.scss
+++ b/convene-web/app/javascript/src/custom_components/form.scss
@@ -23,6 +23,9 @@
     input:focus {
       @apply outline-none shadow-outline;
     }
+    input:disabled {
+      @apply bg-gray-200;
+    }
     .error-message {
       @apply mt-1 px-4 italic text-red-500;
     }

--- a/convene-web/app/views/rooms/edit.html.erb
+++ b/convene-web/app/views/rooms/edit.html.erb
@@ -1,4 +1,4 @@
-<div class="room-edit">
+<div class="room-edit" data-controller="room-edit-form">
   <h2>Configure <%= room.name %></h2>
 
   <%= form_with model: room, url: workspace_room_path(room.workspace, room), local: true do |room_form| %>
@@ -6,12 +6,12 @@
       <legend>Privacy and Security</legend>
       <div class="form-element">
         <%= room_form.label :access_level %>
-        <%= room_form.select :access_level, ['locked', 'unlocked'], { class: "form-select" } %>
+        <%= room_form.select :access_level, ['locked', 'unlocked'], { class: "form-select" }, "data-action": "room-edit-form#accessLevelToggle" %>
       </div>
 
       <div class="form-element">
         <%= room_form.label :access_code %>
-        <%= room_form.text_field :access_code %>
+        <%= room_form.text_field :access_code, "data-target": "room-edit-form.accessCode", disabled: !room.locked? %>
         <%- if room.errors[:access_code].present? %>
           <p class="error-message"><%= room.errors[:access_code].join(', ') %></p>
         <%- end %>


### PR DESCRIPTION
Disabled access code input when actor intended to unlock the room.

<img width="1432" alt="Screen Shot 2020-10-29 at 2 53 13 PM" src="https://user-images.githubusercontent.com/8117421/97636580-8f320000-19f6-11eb-892b-666029c7e578.png">
<img width="1429" alt="Screen Shot 2020-10-29 at 2 53 06 PM" src="https://user-images.githubusercontent.com/8117421/97636585-90fbc380-19f6-11eb-8185-efcdcf10a6a3.png">
