### PR TITLE
Use ruby/setup-ruby Github actions

### DIFF
--- a/.github/workflows/test-convene-web.yml
+++ b/.github/workflows/test-convene-web.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7.1 # If we can move .ruby-version to root, then we don't need to specifiy here.
+        ruby-version: 2.7.1 # If we can move .ruby-version to root, then we don't need to specify here.
         bundler-cache: true
 
     - name: Increase the amount of inotify watchers

--- a/.github/workflows/test-convene-web.yml
+++ b/.github/workflows/test-convene-web.yml
@@ -31,10 +31,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Ruby 2.7
-      uses: actions/setup-ruby@v1
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7
+        ruby-version: 2.7.1 # If we can move .ruby-version to root, then we don't need to specifiy here.
+        bundler-cache: true
 
     - name: Increase the amount of inotify watchers
       run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p


### PR DESCRIPTION
* This GH actions allow us to automatically respect .ruby-version
* The GH actions community favor ruby/setup-ruby (Ref: https://github.com/actions/setup-ruby/issues/80)
* I can't set specific minor version in actions/setup-ruby and this new action allow me to do so