### PR TITLE
Setup Passwordless Login

### DIFF
--- a/convene-web/Gemfile
+++ b/convene-web/Gemfile
@@ -62,3 +62,4 @@ end
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'active_record_extended'
+gem 'passwordless'

--- a/convene-web/Gemfile.lock
+++ b/convene-web/Gemfile.lock
@@ -139,6 +139,9 @@ GEM
     nio4r (2.5.3)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
+    passwordless (0.10.0)
+      bcrypt (~> 3.1.11)
+      rails (>= 5.1.4)
     pg (1.2.3)
     pry (0.13.1)
       coderay (~> 1.1)
@@ -260,6 +263,7 @@ DEPENDENCIES
   friendly_id (~> 5.2.4)
   jbuilder (~> 2.7)
   listen (~> 3.2)
+  passwordless
   pg (>= 0.18, < 2.0)
   pry-byebug
   puma (~> 4.1)

--- a/convene-web/app/controllers/application_controller.rb
+++ b/convene-web/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
     "ConveneWeb"
   end
 
-  include Passwordless::ControllerHelpers # <-- This!
+  include Passwordless::ControllerHelpers
 
   helper_method :current_person
 
@@ -18,7 +18,8 @@ class ApplicationController < ActionController::Base
 
   def require_person!
     return if current_person
-    redirect_to sign_in_path, flash: { error: 'Login required' }
+    save_passwordless_redirect_location!(Person)
+    redirect_to people.sign_in_path, flash: { error: 'Login required' }
   end
 
   # Retrieves the workspace based upon the requests domain or params

--- a/convene-web/app/controllers/application_controller.rb
+++ b/convene-web/app/controllers/application_controller.rb
@@ -6,10 +6,19 @@ class ApplicationController < ActionController::Base
     "ConveneWeb"
   end
 
-  # TODO: When we begin to implement authentication, we'll want this to return an actual Person
-  # @returns [nil, Person] The Person for whom we are building a response
-  helper_method def current_person
-    nil
+  include Passwordless::ControllerHelpers # <-- This!
+
+  helper_method :current_person
+
+  private
+
+  def current_person
+    @current_person ||= authenticate_by_session(Person)
+  end
+
+  def require_person!
+    return if current_person
+    redirect_to sign_in_path, flash: { error: 'Login required' }
   end
 
   # Retrieves the workspace based upon the requests domain or params

--- a/convene-web/app/controllers/workspaces_controller.rb
+++ b/convene-web/app/controllers/workspaces_controller.rb
@@ -1,5 +1,4 @@
 class WorkspacesController < ApplicationController
-  before_action :require_person!
   def show
     @workspace = current_workspace
   end

--- a/convene-web/app/controllers/workspaces_controller.rb
+++ b/convene-web/app/controllers/workspaces_controller.rb
@@ -1,4 +1,5 @@
 class WorkspacesController < ApplicationController
+  before_action :require_person!
   def show
     @workspace = current_workspace
   end

--- a/convene-web/app/models/person.rb
+++ b/convene-web/app/models/person.rb
@@ -8,4 +8,8 @@ class Person < ApplicationRecord
 
   # The Workspaces the Person is part of
   has_many :workspaces, through: :workspace_memberships
+
+  def self.fetch_resource_for_passwordless(email)
+    find_or_create_by(email: email)
+  end
 end

--- a/convene-web/app/models/person.rb
+++ b/convene-web/app/models/person.rb
@@ -1,5 +1,8 @@
 # A representation of a human
 class Person < ApplicationRecord
+  validates :email, presence: true, uniqueness: { case_sensitive: false }
+  passwordless_with :email
+
   # Joins the person to the workspaces they are part of
   has_many :workspace_memberships, inverse_of: :member, foreign_key: :member_id
 

--- a/convene-web/app/views/layouts/_header.html.erb
+++ b/convene-web/app/views/layouts/_header.html.erb
@@ -1,6 +1,6 @@
 <header class="header">
   <div class="items-container">
-    <h1><%= current_workspace.name %></h1>
+    <h1><%= current_workspace&.name %></h1>
     <div>
       <h3>Convene</h3>
       <h3 class="font-hairline">video meeting spaces</h3>

--- a/convene-web/config/locales/en.yml
+++ b/convene-web/config/locales/en.yml
@@ -44,3 +44,14 @@ en:
           attributes:
             access_code:
               incorrect: "Incorrect access code"
+  passwordless:
+    sessions:
+      create:
+        session_expired: 'Your session has expired, please sign in again.'
+        email_sent_if_record_found: "We've sent you an email."
+        token_claimed: "This link has already been used, try requesting the link again"
+      new:
+        submit: 'Send magic link'
+    mailer:
+      subject: "Your magic link ✨"
+      magic_link: "Here's your link: %{link}"

--- a/convene-web/config/routes.rb
+++ b/convene-web/config/routes.rb
@@ -1,6 +1,8 @@
 
 
 Rails.application.routes.draw do
+  passwordless_for :people
+
   namespace :admin do
       resources :workspaces
       resources :clients

--- a/convene-web/db/migrate/20201112224155_create_passwordless_sessions.passwordless.rb
+++ b/convene-web/db/migrate/20201112224155_create_passwordless_sessions.passwordless.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+# This migration comes from passwordless (originally 20171104221735)
+
+class CreatePasswordlessSessions < ActiveRecord::Migration[5.1]
+  def change
+    create_table :passwordless_sessions do |t|
+      t.belongs_to(
+        :authenticatable,
+        polymorphic: true,
+        index: {name: "authenticatable"}
+      )
+      t.datetime :timeout_at, null: false
+      t.datetime :expires_at, null: false
+      t.datetime :claimed_at
+      t.text :user_agent, null: false
+      t.string :remote_addr, null: false
+      t.string :token, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/convene-web/db/migrate/20201112224355_add_uniq_idx_to_person_email.rb
+++ b/convene-web/db/migrate/20201112224355_add_uniq_idx_to_person_email.rb
@@ -1,0 +1,6 @@
+class AddUniqIdxToPersonEmail < ActiveRecord::Migration[6.0]
+  def change
+    change_column :people, :email, :string, null: false
+    add_index :people, :email, unique: true
+  end
+end

--- a/convene-web/db/migrate/20201112231331_support_uuid_in_passwordless_sessions.rb
+++ b/convene-web/db/migrate/20201112231331_support_uuid_in_passwordless_sessions.rb
@@ -1,0 +1,9 @@
+class SupportUuidInPasswordlessSessions < ActiveRecord::Migration[6.0]
+  def change
+    remove_index :passwordless_sessions, column: [:authenticatable_type, :authenticatable_id] if index_exists? :authenticatable_type, :authenticatable_id
+    remove_column :passwordless_sessions, :authenticatable_id
+    add_column :passwordless_sessions, :authenticatable_id, :uuid
+    add_index :passwordless_sessions, [:authenticatable_type, :authenticatable_id], name: 'authenticatable'
+    # change_column :passwordless_sessions, :authenticatable_id, :uuid
+  end
+end

--- a/convene-web/db/schema.rb
+++ b/convene-web/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_12_224355) do
+ActiveRecord::Schema.define(version: 2020_11_12_231331) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -36,7 +36,6 @@ ActiveRecord::Schema.define(version: 2020_11_12_224355) do
 
   create_table "passwordless_sessions", force: :cascade do |t|
     t.string "authenticatable_type"
-    t.bigint "authenticatable_id"
     t.datetime "timeout_at", null: false
     t.datetime "expires_at", null: false
     t.datetime "claimed_at"
@@ -45,6 +44,7 @@ ActiveRecord::Schema.define(version: 2020_11_12_224355) do
     t.string "token", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "authenticatable_id"
     t.index ["authenticatable_type", "authenticatable_id"], name: "authenticatable"
   end
 

--- a/convene-web/db/schema.rb
+++ b/convene-web/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_01_203403) do
+ActiveRecord::Schema.define(version: 2020_11_12_224355) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -34,11 +34,26 @@ ActiveRecord::Schema.define(version: 2020_10_01_203403) do
     t.index ["sluggable_type", "sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_type_and_sluggable_id"
   end
 
+  create_table "passwordless_sessions", force: :cascade do |t|
+    t.string "authenticatable_type"
+    t.bigint "authenticatable_id"
+    t.datetime "timeout_at", null: false
+    t.datetime "expires_at", null: false
+    t.datetime "claimed_at"
+    t.text "user_agent", null: false
+    t.string "remote_addr", null: false
+    t.string "token", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["authenticatable_type", "authenticatable_id"], name: "authenticatable"
+  end
+
   create_table "people", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name"
-    t.string "email"
+    t.string "email", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["email"], name: "index_people_on_email", unique: true
   end
 
   create_table "room_ownerships", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/features/identification.feature
+++ b/features/identification.feature
@@ -20,7 +20,7 @@ Feature: Identification
     Then the Identified User may Identify themselves using that Email Address
 
   Scenario: Email Identification Code Times Out
-    Given a Guest reuqests to Identify themselves via Email
+    Given a Guest requests to Identify themselves via Email
     When the Guest waits for an hour
     Then the Guest can not Identify themselves by entering the code sent to their Email
     And the Guest can not Identify themselves by following the link sent to their Email


### PR DESCRIPTION
Setup passwordless login but we are not using it for now.
People are created when identification happens if we don't already have a person matching the email.
* We allow people to be created when identification happens because we might allow guest to enter room and provide id information.
* Route for the signing form: `/people/sign_in`