### PR TITLE
Improve composability of story tests and step definitions

### DIFF
--- a/features/locked-rooms.feature
+++ b/features/locked-rooms.feature
@@ -32,7 +32,7 @@ Feature: Locked Rooms
   @built
   Scenario: Locking an Unlocked Room
     Given a Workspace with an Unlocked Room
-    When a Workspace Member locks the Room with a Room Key
+    When a Workspace Member locks the Unlocked Room with a valid Room Key
     Then the Room is Locked
 
   # This is a "sad path" scenario, that we expect to delete once we
@@ -42,7 +42,7 @@ Feature: Locked Rooms
   @built
   Scenario: Locking an Unlocked Room without setting a Room Key
     Given a Workspace with an Unlocked Room
-    When a Workspace Member locks the Room without a Room Key
+    When a Workspace Member locks the Unlocked Room with an empty Room Key
     Then the Workspace Member is informed they need to set a Room Key when they are locking a Room
     And the Room is Unlocked
 
@@ -52,5 +52,5 @@ Feature: Locked Rooms
   @built
   Scenario: Unlocking a Locked Room
   Given a Workspace with a Locked Room
-  When a Workspace Member unlocks the Room with the correct Room Key
+  When a Workspace Member unlocks the Locked Room with the correct Room Key
   Then the Room is Unlocked

--- a/features/locked-rooms.feature
+++ b/features/locked-rooms.feature
@@ -1,4 +1,4 @@
-Feature: Locking Rooms
+Feature: Locked Rooms
   In order to maintain control over who may participate in a conversation
   As a Workspace Member
   I would like to be able to lock Rooms
@@ -26,14 +26,6 @@ Feature: Locking Rooms
     And a Workspace Member may not enter the Locked Room after providing the wrong Room Key
     And a Guest may enter the Locked Room after providing the correct Room Key
     And a Guest may not enter the Locked Room after providing the wrong Room Key
-
-  # TODO: We should check with Colombene and Vivek re: "Is there `Invitation` feature?"
-  @unstarted
-  Scenario: Locking an Unlocked Room when Inviting People
-    Given a Workspace with an Unlocked Room
-    When a Workspace Member locks the Room with a Room Key while Inviting People
-    Then the Room is Locked
-
 
   # Wireframe:
   # https://xd.adobe.com/view/fd425dbe-5384-44c9-997a-eeee6e886a86-a811/screen/847810bf-5d62-4131-a70d-d9efdfadb334

--- a/features/locked-rooms.feature
+++ b/features/locked-rooms.feature
@@ -22,17 +22,17 @@ Feature: Locked Rooms
   @built
   Scenario: Entering a Locked Room
     Given a Workspace with a Locked Room
-    Then a Workspace Member may enter the Locked Room after providing the correct Room Key
-    And a Workspace Member may not enter the Locked Room after providing the wrong Room Key
-    And a Guest may enter the Locked Room after providing the correct Room Key
-    And a Guest may not enter the Locked Room after providing the wrong Room Key
+    Then a Workspace Member may enter the Locked Room after providing the correct Access Code
+    And a Workspace Member may not enter the Locked Room after providing the wrong Access Code
+    And a Guest may enter the Locked Room after providing the correct Access Code
+    And a Guest may not enter the Locked Room after providing the wrong Access Code
 
   # Wireframe:
   # https://xd.adobe.com/view/fd425dbe-5384-44c9-997a-eeee6e886a86-a811/screen/847810bf-5d62-4131-a70d-d9efdfadb334
   @built
   Scenario: Locking an Unlocked Room
     Given a Workspace with an Unlocked Room
-    When a Workspace Member locks the Unlocked Room with a valid Room Key
+    When a Workspace Member locks the Unlocked Room with a valid Access Code
     Then the Room is Locked
 
   # This is a "sad path" scenario, that we expect to delete once we
@@ -40,10 +40,10 @@ Feature: Locked Rooms
   # at the user-level; when we can rely on ActiveRecord validations and consistent
   # usage of form builders that expose error information.
   @built
-  Scenario: Locking an Unlocked Room without setting a Room Key
+  Scenario: Locking an Unlocked Room without setting a Access Code
     Given a Workspace with an Unlocked Room
-    When a Workspace Member locks the Unlocked Room with an empty Room Key
-    Then the Workspace Member is informed they need to set a Room Key when they are locking a Room
+    When a Workspace Member locks the Unlocked Room with an empty Access Code
+    Then the Workspace Member is informed they need to set a Access Code when they are locking a Room
     And the Room is Unlocked
 
 
@@ -52,5 +52,5 @@ Feature: Locked Rooms
   @built
   Scenario: Unlocking a Locked Room
   Given a Workspace with a Locked Room
-  When a Workspace Member unlocks the Locked Room with the correct Room Key
+  When a Workspace Member unlocks the Locked Room with the correct Access Code
   Then the Room is Unlocked

--- a/features/page-objects/RoomSettingPage.js
+++ b/features/page-objects/RoomSettingPage.js
@@ -1,10 +1,9 @@
 const Page = require("./Page");
 
 class RoomSettingPage extends Page {
-  constructor(driver, room, accessCode) {
+  constructor(driver, room) {
     super(driver);
     this.room = room;
-    this.accessCode = accessCode;
   }
 
   async lock(accessCode) {
@@ -13,17 +12,19 @@ class RoomSettingPage extends Page {
     await this.clickUpdateRoom();
   }
 
-  async unlock() {
-    await this.enterAccessCode()
+  async unlock(accessCode) {
+    await this.enterAccessCode(accessCode)
+
     await this.setAccessLevel('unlocked');
     await this.clickUpdateRoom();
   }
 
-  async enterAccessCode() {
+  async enterAccessCode(accessCode) {
     const accessCodeInput = await this.findByCss("[id='waiting_room_access_code']");
-    accessCodeInput.sendKeys(this.accessCode);
+    accessCodeInput.sendKeys(accessCode.value);
+
     const submitInput = await this.findByCss("[type='submit']");
-    submitInput.click();
+    return submitInput.click();
   }
 
   async setAccessLevel(accessLevel) {
@@ -36,12 +37,12 @@ class RoomSettingPage extends Page {
 
   async setAccessCode(accessCode) {
     const accessCodeInput = await this.findByCss("[id='room_access_code']");
-    accessCodeInput.sendKeys(accessCode);
+    accessCodeInput.sendKeys(accessCode.value);
   }
 
   async clickUpdateRoom() {
     const submitInput = await this.findByCss("[type='submit']");
-    submitInput.click();
+    return submitInput.click();
   }
 
   async accessCodeError() {

--- a/features/page-objects/WorkspacePage.js
+++ b/features/page-objects/WorkspacePage.js
@@ -38,10 +38,10 @@ class WorkspacePage extends Page {
 
   async findRoomCard(room, wait = true) {
     if(wait) {
-      await this.driver.wait(until.elementLocated(By.id(room.name)));
+      await this.driver.wait(until.elementLocated(room.cardLocator));
     }
 
-    return await this.driver.findElement(By.id(room.name));
+    return await this.driver.findElement(room.cardLocator);
   }
 
   async videoPanel() {
@@ -53,15 +53,15 @@ class WorkspacePage extends Page {
   }
 
   roomCardsWhere({ accessLevel }) {
-    return this.driver.findElements(By.css(`.--${accessLevel.level.toLowerCase()}`));
+    return this.driver.findElements(accessLevel.locator);
   }
 
-  async enterConfigureRoom(room, roomKey) {
+  async enterConfigureRoom(room) {
     const roomCard = await this.findRoomCard(room);
     const linkText = await roomCard.findElement(By.linkText("Configure Room"));
     await linkText.click();
 
-    return new RoomSettingPage(this.driver, room, roomKey);
+    return new RoomSettingPage(this.driver, room);
   }
 }
 

--- a/features/page-objects/WorkspacePage.js
+++ b/features/page-objects/WorkspacePage.js
@@ -30,7 +30,7 @@ class WorkspacePage extends Page {
     const inputSelector = By.css("[id='waiting_room_access_code']");
     await this.driver.wait(until.elementLocated(inputSelector));
     const accessCodeInput = await this.driver.findElement(inputSelector);
-    accessCodeInput.sendKeys(accessCode);
+    accessCodeInput.sendKeys(accessCode.value);
 
     const submitInput = await this.driver.findElement(By.css("[type='submit']"));
     submitInput.click();

--- a/features/page-objects/WorkspacePage.js
+++ b/features/page-objects/WorkspacePage.js
@@ -1,6 +1,7 @@
 const Page = require("./Page");
 const RoomSettingPage = require("./RoomSettingPage")
 const { By, until } = require('selenium-webdriver');
+const RoomCard = require("./page-elements/RoomCard");
 const assert = require('assert').strict;
 
 class WorkspacePage extends Page {
@@ -37,11 +38,8 @@ class WorkspacePage extends Page {
   }
 
   async findRoomCard(room, wait = true) {
-    if(wait) {
-      await this.driver.wait(until.elementLocated(room.cardLocator));
-    }
-
-    return await this.driver.findElement(room.cardLocator);
+    const roomCard = new RoomCard(this.driver, room)
+    return roomCard.element(wait)
   }
 
   async videoPanel() {

--- a/features/page-objects/page-elements/RoomCard.js
+++ b/features/page-objects/page-elements/RoomCard.js
@@ -1,21 +1,28 @@
-const { By } = require('selenium-webdriver');
+const { By, until } = require('selenium-webdriver');
 
 const Page = require("../Page");
 const RoomPage = require("../RoomPage");
 
 class RoomCard extends Page {
-  constructor(driver, webElement) {
+  constructor(driver, room) {
     super(driver);
-    this.webElement = webElement;
+    this.room = room
+  }
+
+  async element(wait=true) {
+    if(wait) {
+      await this.driver.wait(until.elementLocated(this.room.cardLocator));
+    }
+    return this.driver.findElement(this.room.cardLocator);
   }
 
   async isLocked() {
-    const lockLogo = await this.webElement.findElement(By.className('fa-lock'));
-    lockLogo.isDisplayed();
+    const lockLogo = (await this.element()).findElement(By.className('fa-lock'));
+    return lockLogo.isDisplayed();
   }
 
   async enterRoom() {
-    await this.webElement.findElement(By.linkText("Enter Room")).click();
+    (await this.element()).findElement(By.linkText("Enter Room")).click();
     return new RoomPage(this.driver);
   }
 }

--- a/features/parameter-types/rooms.js
+++ b/features/parameter-types/rooms.js
@@ -75,12 +75,12 @@ class PublicityLevel {
 }
 
 defineParameterType({
-  name: "roomKey",
-  regexp: concatRegExp(FLEXIBLE_ARTICLE_ADJECTIVES, /(correct |valid |wrong |empty )?Room Key/),
-  transformer: (_, validity="") => new RoomKey(validity.trim())
+  name: "accessCode",
+  regexp: concatRegExp(FLEXIBLE_ARTICLE_ADJECTIVES, /(correct |valid |wrong |empty )?Access Code/),
+  transformer: (_, validity="") => new AccessCode(validity.trim())
 });
 
-class RoomKey {
+class AccessCode {
   constructor(validity) {
     this.validity = validity
   }

--- a/features/steps/room_steps.js
+++ b/features/steps/room_steps.js
@@ -34,16 +34,16 @@ Given('a Workspace with an {publicityLevel} Room', function (publicityLevel) {
   return 'pending';
 });
 
-When("a {actor} unlocks {accessLevel} {room} with {roomKey}", async function (actor, accessLevel, room, roomKey) {
+When("a {actor} unlocks {accessLevel} {room} with {accessCode}", async function (actor, accessLevel, room, accessCode) {
   linkParameters({ room, accessLevel })
   const roomConfigurationPage = await this.workspace.enterConfigureRoom(room);
-  await roomConfigurationPage.unlock(roomKey);
+  await roomConfigurationPage.unlock(accessCode);
 });
 
-When("a {actor} locks {accessLevel} {room} with {roomKey}", async function (actor, accessLevel, room, roomKey) {
+When("a {actor} locks {accessLevel} {room} with {accessCode}", async function (actor, accessLevel, room, accessCode) {
   linkParameters({ room, accessLevel })
   const roomSettingPage = await this.workspace.enterConfigureRoom(room);
-  await roomSettingPage.lock(roomKey);
+  await roomSettingPage.lock(accessCode);
 });
 
 When('the {actor} taps the {room} in the Room Picker', async function (actor, room) {
@@ -60,14 +60,14 @@ Then("the {actor} is not placed in the {room}", function (actor, room) {
   return "pending";
 });
 
-Then('a {actor} may enter the Room without providing {roomKey}', function (actor, roomKey) {
+Then('a {actor} may enter the Room without providing {accessCode}', function (actor, accessCode) {
   // Write code here that turns the phrase above into concrete actions
   return 'pending';
 });
 
-Then('a {actor} may not enter {accessLevel} {room} after providing {roomKey}', async function (actor, accessLevel, room, roomKey) {
+Then('a {actor} may not enter {accessLevel} {room} after providing {accessCode}', async function (actor, accessLevel, room, accessCode) {
   linkParameters({ room, accessLevel })
-  await this.workspace.enterRoomWithAccessCode(room, roomKey);
+  await this.workspace.enterRoomWithAccessCode(room, accessCode);
 
   // TODO: Encapsulate checking error messages
   const error = By.css("[class='access-code-form__error-message']")
@@ -75,9 +75,10 @@ Then('a {actor} may not enter {accessLevel} {room} after providing {roomKey}', a
   assert.equal(await errorMsg.isDisplayed(), true)
 });
 
-Then('a {actor} may enter {accessLevel} {room} after providing {roomKey}', async function (actor, accessLevel, room, roomKey) {
-  linkParameters({ room, accessLevel })
-  await this.workspace.enterRoomWithAccessCode(room, roomKey);
+Then('a {actor} may enter {accessLevel} {room} after providing {accessCode}', async function (actor, accessLevel, room, accessCode) {
+  console.log({ accessLevel, room })
+  linkParameters({ room, accessLevel, accessCode })
+  await this.workspace.enterRoomWithAccessCode(room, accessCode);
 
   const videoPanel = await this.workspace.videoPanel();
   assert(await videoPanel.isDisplayed());
@@ -117,7 +118,7 @@ Then('the Room {accessLevel}', async function (accessLevel) {
   }
 });
 
-Then('the {actor} is informed they need to set {roomKey} when they are locking a {room}', async function (actor, roomKey, room) {
+Then('the {actor} is informed they need to set {accessCode} when they are locking a {room}', async function (actor, accessCode, room) {
   const roomSettingPage = new RoomSettingPage(this.driver);
   assert(await roomSettingPage.accessCodeError());
 });

--- a/features/steps/room_steps.js
+++ b/features/steps/room_steps.js
@@ -76,7 +76,6 @@ Then('a {actor} may not enter {accessLevel} {room} after providing {accessCode}'
 });
 
 Then('a {actor} may enter {accessLevel} {room} after providing {accessCode}', async function (actor, accessLevel, room, accessCode) {
-  console.log({ accessLevel, room })
   linkParameters({ room, accessLevel, accessCode })
   await this.workspace.enterRoomWithAccessCode(room, accessCode);
 
@@ -108,10 +107,11 @@ Then('the {actor} does not see the {room}\'s Door', function (actor, room) {
 });
 
 Then('the Room {accessLevel}', async function (accessLevel) {
+  const room = new Room("")
+  linkParameters({ room, accessLevel })
   if (accessLevel.level === 'Locked') {
-    const room = new Room('Listed Room 1')
-    const roomCard = new RoomCard(this.driver, await this.workspace.findRoomCard(room))
-    assert(roomCard.isLocked());
+    const roomCard = new RoomCard(this.driver, room)
+    assert(await roomCard.isLocked());
 
     const page = await roomCard.enterRoom();
     assert(await page.isWaitingRoom());


### PR DESCRIPTION
See: https://github.com/zinc-collective/convene/issues/40

The changes here are intended to make it so our feature files and step definitions don't have to care as much about hardcoded values; thus making them easier to:
- Recompose into new story tests and...
- Parallelize the feature tests 

There's likely some more work to be done here; but this feels like a decent, safe step?