### PR TITLE
Add link to updated personas document to convene-web README.

### DIFF
--- a/convene-web/README.md
+++ b/convene-web/README.md
@@ -21,6 +21,11 @@ The central piece to Convene is `convene-web`, a Ruby on Rails server that is re
 * serving the Convene UI
 * managing users, workspaces, rooms, permissions, etc
 
+This [living excel sheet](https://docs.google.com/spreadsheets/d/1BOBCT0yrgrbCuQFTx_hIQak0FSQjnjjFZVA3YksEv8s/edit#gid=622652343)
+gives a high level view of the personas and segments we are focusing on initially in our design of
+Convene. It also includes our current vision of the types of workspaces, rooms and participants it
+serves and clarifies the design in privacy permissions.
+
 The Convene UI is based on Rails standard templating system, with heavy use of:
 * [Stimulus JS](https://stimulusjs.org/)
    * the entry point for our JavaScript is in `app/javascript/controllers/index.js`,


### PR DESCRIPTION
Looking for comments on language and placement. 
Currently I only added it to the convene-web README as it seems to be contributor facing more than explicitly for the public. 
I can easily add to the overall Convene README if desired or change the language as well.

I have also just sent the legal statement to operations so there shouldn't be any blockers on merging on that front.