### PR TITLE
Signpost the current page as a Convene Space more clearly

### DIFF
--- a/convene-web/app/controllers/application_controller.rb
+++ b/convene-web/app/controllers/application_controller.rb
@@ -3,7 +3,11 @@ class ApplicationController < ActionController::Base
   # Override on a per-controller basis to display different title
   # @returns [String]
   helper_method def page_title
-    "ConveneWeb"
+    if current_workspace.present?
+      "Convene - #{current_workspace.name}"
+    else
+      'Convene - Video Meeting Spaces'
+    end
   end
 
   include Passwordless::ControllerHelpers
@@ -19,6 +23,7 @@ class ApplicationController < ActionController::Base
 
   def require_person!
     return if current_person
+
     save_passwordless_redirect_location!(Person)
     redirect_to people.sign_in_path, flash: { error: 'Login required' }
   end

--- a/convene-web/app/controllers/rooms_controller.rb
+++ b/convene-web/app/controllers/rooms_controller.rb
@@ -20,7 +20,7 @@ class RoomsController < ApplicationController
   end
 
   helper_method def page_title
-    "#{current_workspace.name} - #{current_room.name}"
+    "[Convene] - #{current_room.name} - #{current_workspace.name}"
   end
 
   helper_method def room

--- a/features/navigate-between-convene-and-other-systems.feature
+++ b/features/navigate-between-convene-and-other-systems.feature
@@ -1,0 +1,9 @@
+Feature: Navigate Between Convene and other Systems
+  In order to build confidence that Convene plays well with others
+  We want to hold the affordances people use to switch between Convene and other systems with a degree of care and intentionality.
+
+  @built @unimplemented-steps
+  Scenario: Navigate Between Other Tabs in the Browser and Convene
+    Given an Attendee is in a Room
+    When the Attendee switches to a different tab
+    Then the Attendee can tell which of the other Browser tabs is the Convene Room


### PR DESCRIPTION
See: https://github.com/zinc-collective/convene/issues/160

This builds on @hangtwenty's initial shift; while putting the responsibility into the existing helpers for page-titles; which should allow us to more clearly sign-post which Space & Room a particular Tab is. 

It also drops the Feature into the code-base; so that it's more clear that navigation between external-systems and Convene is something we care about; and may want to more refine with additional intentions.