### PR TITLE
Clean-up from previous README update for adding Persona's link

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ See [Convene::Web/README.md "Configuring your Development Machine"] for more inf
 
 ## Design
 
-We have a set of [Personas](https://drive.google.com/open?id=1JwTh2uFTc6pxsXu3njEVKQrv-J5HWExhd1rgT-ravt4) that we use to guide our design and development. 
+We have a set of [Personas](https://docs.google.com/spreadsheets/d/1BOBCT0yrgrbCuQFTx_hIQak0FSQjnjjFZVA3YksEv8s/edit#gid=622652343) that we use to guide our design and development.
 Designers who have agreed to protect the privacy of our clients may access our [Customer Research Interviews](https://drive.google.com/drive/u/2/folders/1gncYSkVIAj4CnlUZM9KPQlFdj_aqulDl)
 
 ## About The Zinc Collective

--- a/convene-web/README.md
+++ b/convene-web/README.md
@@ -21,10 +21,10 @@ The central piece to Convene is `convene-web`, a Ruby on Rails server that is re
 * serving the Convene UI
 * managing users, workspaces, rooms, permissions, etc
 
-This [living excel sheet](https://docs.google.com/spreadsheets/d/1BOBCT0yrgrbCuQFTx_hIQak0FSQjnjjFZVA3YksEv8s/edit#gid=622652343)
-gives a high level view of the personas and segments we are focusing on initially in our design of
+This [high level view of our design](https://docs.google.com/spreadsheets/d/1BOBCT0yrgrbCuQFTx_hIQak0FSQjnjjFZVA3YksEv8s/edit#gid=622652343)
+shows the personas and segments we are focusing on initially with
 Convene. It also includes our current vision of the types of workspaces, rooms and participants it
-serves and clarifies the design in privacy permissions.
+serves and clarifies the design of privacy permissions.
 
 The Convene UI is based on Rails standard templating system, with heavy use of:
 * [Stimulus JS](https://stimulusjs.org/)


### PR DESCRIPTION
Replace personas link to main README and tighten language in convene-web README around persona link.

Addresses feedback from #166 