### PR TITLE
Refactor navbar to semantic html

### DIFF
--- a/convene-web/app/javascript/controllers/menu_controller.js
+++ b/convene-web/app/javascript/controllers/menu_controller.js
@@ -4,7 +4,7 @@ export default class extends Controller {
   static targets = [ "button", "items" ]
 
   toggle() {
-    this.itemsTarget.classList.toggle("hidden")
+    this.itemsTarget.classList.toggle("--hidden")
   }
 
   hide(e) {
@@ -12,6 +12,6 @@ export default class extends Controller {
       e.preventDefault()
       return false
     }
-    this.itemsTarget.classList.add("hidden")
+    this.itemsTarget.classList.add("--hidden")
   }
 }

--- a/convene-web/app/javascript/src/custom_components/header.scss
+++ b/convene-web/app/javascript/src/custom_components/header.scss
@@ -1,19 +1,19 @@
 @layer components {
   .header {
-    .items-container {
+    .space-menu {
       @apply flex items-center justify-between px-4 py-3 bg-blue-500 text-white;
 
       h1 {
-        @apply text-2xl font-bold;
+        @apply text-2xl font-bold flex-grow;
       }
 
-      .profile-menu-group {
+      .profile-menu {
         @apply flex flex-row items-center relative;
         figcaption {
           @apply font-hairline text-center text-xs;
         }
-        .profile-menu-dropdown-item {
-          @apply absolute bg-blue-600 px-4 py-1;
+        nav {
+          @apply absolute bg-blue-600 px-4 py-1 shadow;
         }
       }
 

--- a/convene-web/app/javascript/src/custom_components/icons.scss
+++ b/convene-web/app/javascript/src/custom_components/icons.scss
@@ -1,17 +1,19 @@
 @layer components {
-  .icon-solid::before {
-    font-family: "Font Awesome 5 Free"; font-weight: 900;
-    @apply mr-2;
-  }
   .phone-alt-icon::before {
+    @apply mr-2;
+    font-family: "Font Awesome 5 Free"; font-weight: 900;
     content: "\f879";
   }
 
   .configure-icon::before {
+    @apply mr-2;
+    font-family: "Font Awesome 5 Free"; font-weight: 900;
     content: "\f7d9";
   }
 
-  .chevron-icon::before {
+  .navigation-toggle::before {
+    @apply mr-2;
+    font-family: "Font Awesome 5 Free"; font-weight: 900;
     content: "\f078"
   }
 }

--- a/convene-web/app/javascript/src/page_bem_class.scss
+++ b/convene-web/app/javascript/src/page_bem_class.scss
@@ -5,3 +5,7 @@
     }
   }
 }
+
+.--hidden {
+  @apply hidden;
+}

--- a/convene-web/app/models/guest.rb
+++ b/convene-web/app/models/guest.rb
@@ -4,6 +4,6 @@ class Guest
   end
 
   def avatar_url
-    "/avatar.png"
+    "/avatar.svg"
   end
 end

--- a/convene-web/app/models/person.rb
+++ b/convene-web/app/models/person.rb
@@ -15,6 +15,6 @@ class Person < ApplicationRecord
 
   def avatar_url
     # TODO: Allow person to upload their image
-    "/avatar.png"
+    "/avatar.svg"
   end
 end

--- a/convene-web/app/views/layouts/_header.html.erb
+++ b/convene-web/app/views/layouts/_header.html.erb
@@ -1,38 +1,31 @@
 <header class="header">
-  <div class="items-container">
+  <div class="space-menu">
     <h1><%= current_workspace&.name %></h1>
-    <div class="profile-menu-group" data-controller="menu">
 
-      <%- if Feature.enabled?(:identification) %>
-        <div class="profile-menu">
+    <%- if Feature.enabled?(:identification) %>
+      <div class="profile-menu" data-controller="menu">
+        <div>
           <figure class="avatar">
             <%= image_tag current_person.avatar_url, size: 30 %>
             <figcaption><%= current_person.name %></figcaption>
           </figure>
 
-          <%- if current_person.is_a? Person %>
-            <ul class="profile-menu-dropdown hidden" data-target="menu.items">
-              <li>
-                <%= link_to "Logout", people.sign_out_path, class: "profile-menu-dropdown-item" %>
-              </li>
-            </ul>
-          <%- elsif %>
-            <ul class="profile-menu-dropdown hidden" data-target="menu.items">
-              <li>
-                <%= link_to "Login", people.sign_in_path, class: "profile-menu-dropdown-item" %>
-              </li>
-            </ul>
-          <%- end %>
-
+          <nav class="--hidden" data-target="menu.items">
+            <%- if current_person.is_a? Person %>
+              <%= link_to "Logout", people.sign_out_path, class: "profile-menu-dropdown-item" %>
+            <%- else %>
+              <%= link_to "Login",  people.sign_in_path,  class: "profile-menu-dropdown-item" %>
+            <%- end %>
+          </nav>
         </div>
 
-        <%= button_tag "", type: "button", class: "icon-solid chevron-icon", "data-action": "click->menu#toggle click@window->menu#hide",  "data-target": "menu.button" %>
-      <%- end %>
-
-      <div>
-        <h3>Convene</h3>
-        <h3 class="font-hairline">video meeting spaces</h3>
+        <%= button_tag "", type: "button", class: "navigation-toggle", "data-action": "click->menu#toggle click@window->menu#hide",  "data-target": "menu.button", "aria-labelledby": "profile-menu-dropdown-button" %>
       </div>
+    <%- end %>
+
+    <div>
+      <h3>Convene</h3>
+      <h3 class="font-hairline">video meeting spaces</h3>
     </div>
   </div>
 </header>

--- a/convene-web/app/views/workspaces/_room_card.html.erb
+++ b/convene-web/app/views/workspaces/_room_card.html.erb
@@ -11,14 +11,14 @@
   <footer>
     <div class="room-door_enter">
       <%= link_to workspace_room_path(room.workspace, room) do %>
-        <span class="icon-solid phone-alt-icon">Enter Room</span>
+        <span class="phone-alt-icon">Enter Room</span>
       <% end %>
     </div>
 
     <%- if Feature.enabled?(:configure_room) %>
       <div class="room-door_configure">
         <%= link_to edit_workspace_room_path(room.workspace, room) do %>
-          <span class="icon-solid configure-icon">Configure Room</span>
+          <span class="configure-icon">Configure Room</span>
         <% end %>
       </div>
     <% end %>

--- a/convene-web/public/avatar.svg
+++ b/convene-web/public/avatar.svg
@@ -1,0 +1,3 @@
+<svg id="Profile" xmlns="http://www.w3.org/2000/svg" width="33" height="33" viewBox="0 0 33 33">
+  <path id="Union_1" data-name="Union 1" d="M0,33V28.876c0-4.538,7.425-8.251,16.5-8.251S33,24.337,33,28.876V33ZM8.249,8.251A8.25,8.25,0,1,1,16.5,16.5,8.251,8.251,0,0,1,8.249,8.251Z" transform="translate(0 0)" fill="#fff"/>
+</svg>


### PR DESCRIPTION
Connects: https://github.com/zinc-collective/convene/issues/118
Follow up on https://github.com/zinc-collective/convene/pull/163

Refactor navbar to semantic html and replace screenshot avatar image to svg provided by @colombene.

<img width="615" alt="Screen Shot 2020-12-19 at 4 53 00 PM" src="https://user-images.githubusercontent.com/8117421/102702726-b056e600-421a-11eb-8af3-d9b752dded90.png">
