### PR TITLE
Styled login form and modified login new & create template wording

### DIFF
--- a/convene-web/app/javascript/src/application.scss
+++ b/convene-web/app/javascript/src/application.scss
@@ -1,5 +1,9 @@
 h2 {
   @apply text-xl font-medium text-gray-900;
 }
+.center-container {
+  @apply flex flex-col items-center justify-center px-4 pt-28;
+}
+
 @import "./custom_components";
 @import "./page_bem_class";

--- a/convene-web/app/javascript/src/custom_components/button.scss
+++ b/convene-web/app/javascript/src/custom_components/button.scss
@@ -8,4 +8,10 @@
   .button-blue:hover {
     @apply bg-blue-700;
   }
+  .button-gray {
+    @apply bg-gray-500 text-white;
+  }
+  .button-gray:hover {
+    @apply bg-gray-700;
+  }
 }

--- a/convene-web/app/javascript/src/custom_components/form.scss
+++ b/convene-web/app/javascript/src/custom_components/form.scss
@@ -76,3 +76,16 @@
 .access-code-form__submit {
   @apply mt-4;
 }
+
+.identification-form {
+  @apply w-full;
+  @screen sm {
+    @apply w-1/2;
+  }
+}
+.identification-form__submit {
+  @apply mt-6;
+  @screen sm {
+    @apply w-2/5 mx-auto
+  }
+}

--- a/convene-web/app/views/passwordless/sessions/create.html.erb
+++ b/convene-web/app/views/passwordless/sessions/create.html.erb
@@ -1,0 +1,3 @@
+<div class="center-container text-center">
+  <h1><%= I18n.t('passwordless.sessions.create.email_sent_if_record_found') %></h1>
+</div>

--- a/convene-web/app/views/passwordless/sessions/new.html.erb
+++ b/convene-web/app/views/passwordless/sessions/new.html.erb
@@ -1,9 +1,9 @@
 <div class="center-container">
   <%# This form is different from Rails form builder because it's from Passwordless %>
-  <%= form_for @session, url: send(Passwordless.mounted_as).sign_in_path do |f| %>
+  <%= form_for @session, url: send(Passwordless.mounted_as).sign_in_path, html: { class: "identification-form" } do |f| %>
     <% email_field_name = :"passwordless[#{@email_field}]" %>
     <%= label_tag I18n.t('passwordless.sessions.new.email_label') %>
     <%= text_field_tag email_field_name, params.fetch(email_field_name, nil) %>
-    <%= f.submit I18n.t('passwordless.sessions.new.submit'), class: "button-gray" %>
+    <%= f.submit I18n.t('passwordless.sessions.new.submit'), class: "identification-form__submit button-gray" %>
   <% end %>
-</div>>
+</div>

--- a/convene-web/app/views/passwordless/sessions/new.html.erb
+++ b/convene-web/app/views/passwordless/sessions/new.html.erb
@@ -1,0 +1,9 @@
+<div class="center-container">
+  <%# This form is different from Rails form builder because it's from Passwordless %>
+  <%= form_for @session, url: send(Passwordless.mounted_as).sign_in_path do |f| %>
+    <% email_field_name = :"passwordless[#{@email_field}]" %>
+    <%= label_tag I18n.t('passwordless.sessions.new.email_label') %>
+    <%= text_field_tag email_field_name, params.fetch(email_field_name, nil) %>
+    <%= f.submit I18n.t('passwordless.sessions.new.submit'), class: "button-gray" %>
+  <% end %>
+</div>>

--- a/convene-web/config/locales/en.yml
+++ b/convene-web/config/locales/en.yml
@@ -48,10 +48,11 @@ en:
     sessions:
       create:
         session_expired: 'Your session has expired, please sign in again.'
-        email_sent_if_record_found: "We've sent you an email."
+        email_sent_if_record_found: "Check your email for a link to log in automatically."
         token_claimed: "This link has already been used, try requesting the link again"
       new:
-        submit: 'Send magic link'
+        email_label: 'Your Email'
+        submit: 'Submit'
     mailer:
       subject: "Your magic link ✨"
       magic_link: "Here's your link: %{link}"


### PR DESCRIPTION
* When implementing the ok button, we were wondering the intent of the button
because we can't redirect people to their own email client,
skipping ok button in the implementation for now.
* UI Mockup:
https://xd.adobe.com/view/fd425dbe-5384-44c9-997a-eeee6e886a86-a811/screen/b1223ba7-c6bf-4e8e-94ee-0ef583a178cb/
https://xd.adobe.com/view/fd425dbe-5384-44c9-997a-eeee6e886a86-a811/screen/456d873b-accd-4f06-89a0-a1dfeadee38c/

Co-authored-by: Ana Ulin <anaulin@users.noreply.github.com>
Co-authored-by: Whitney <roseaboveit@users.noreply.github.com>
Co-authored-by: Zee <zspencer@users.noreply.github.com>

<img width="951" alt="Screen Shot 2021-01-09 at 3 47 25 PM" src="https://user-images.githubusercontent.com/8117421/104111172-e58faa80-5293-11eb-8cba-692fbcf053b9.png">
<img width="217" alt="Screen Shot 2021-01-09 at 3 56 56 PM" src="https://user-images.githubusercontent.com/8117421/104111174-e6c0d780-5293-11eb-9b54-e58e007226b0.png">
