### PR TITLE
Avoid eager loading in test

### DIFF
--- a/convene-web/app/controllers/admin/base_controller.rb
+++ b/convene-web/app/controllers/admin/base_controller.rb
@@ -5,7 +5,7 @@
 # If you want to add pagination or other controller-level concerns,
 # you're free to overwrite the RESTful controller actions.
 module Admin
-  class ApplicationController < Administrate::ApplicationController
+  class BaseController < Administrate::ApplicationController
     include Configuration::Configurable
 
     http_basic_authenticate_with configuration.basic_auth

--- a/convene-web/app/controllers/admin/clients_controller.rb
+++ b/convene-web/app/controllers/admin/clients_controller.rb
@@ -1,5 +1,5 @@
 module Admin
-  class ClientsController < Admin::ApplicationController
+  class ClientsController < Admin::BaseController
     # Overwrite any of the RESTful controller actions to implement custom behavior
     # For example, you may want to send an email after a foo is updated.
     #

--- a/convene-web/app/controllers/admin/people_controller.rb
+++ b/convene-web/app/controllers/admin/people_controller.rb
@@ -1,5 +1,5 @@
 module Admin
-  class PeopleController < Admin::ApplicationController
+  class PeopleController < Admin::BaseController
     # Overwrite any of the RESTful controller actions to implement custom behavior
     # For example, you may want to send an email after a foo is updated.
     #

--- a/convene-web/app/controllers/admin/room_ownerships_controller.rb
+++ b/convene-web/app/controllers/admin/room_ownerships_controller.rb
@@ -1,5 +1,5 @@
 module Admin
-  class RoomOwnershipsController < Admin::ApplicationController
+  class RoomOwnershipsController < Admin::BaseController
     # Overwrite any of the RESTful controller actions to implement custom behavior
     # For example, you may want to send an email after a foo is updated.
     #

--- a/convene-web/app/controllers/admin/rooms_controller.rb
+++ b/convene-web/app/controllers/admin/rooms_controller.rb
@@ -1,5 +1,5 @@
 module Admin
-  class RoomsController < Admin::ApplicationController
+  class RoomsController < Admin::BaseController
     # Overwrite any of the RESTful controller actions to implement custom behavior
     # For example, you may want to send an email after a foo is updated.
     #

--- a/convene-web/app/controllers/admin/workspace_memberships_controller.rb
+++ b/convene-web/app/controllers/admin/workspace_memberships_controller.rb
@@ -1,5 +1,5 @@
 module Admin
-  class WorkspaceMembershipsController < Admin::ApplicationController
+  class WorkspaceMembershipsController < Admin::BaseController
     # Overwrite any of the RESTful controller actions to implement custom behavior
     # For example, you may want to send an email after a foo is updated.
     #

--- a/convene-web/app/controllers/admin/workspaces_controller.rb
+++ b/convene-web/app/controllers/admin/workspaces_controller.rb
@@ -1,5 +1,5 @@
 module Admin
-  class WorkspacesController < Admin::ApplicationController
+  class WorkspacesController < Admin::BaseController
     # Overwrite any of the RESTful controller actions to implement custom behavior
     # For example, you may want to send an email after a foo is updated.
     #

--- a/convene-web/config/environments/test.rb
+++ b/convene-web/config/environments/test.rb
@@ -12,7 +12,7 @@ Rails.application.configure do
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that
   # preloads Rails for running tests, you may have to set it to true.
-  config.eager_load = true
+  config.eager_load = false
 
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true


### PR DESCRIPTION
I tried a few things to avoid eager loading:
1. Switch to classic loader instead of the default Rails 6 [Zeitwerk](https://github.com/fxn/zeitwerk#file-structure)
  * It works but classic loader will be deprecated eventually, not recommended.
2. Rename `Admin::ApplicationController` to `Admin::BaseController`
  * I wasn't 100% why it works but my guess is [Zeitwerk only made one autoload look up](https://guides.rubyonrails.org/autoloading_and_reloading_constants.html#less-file-lookups) and
    the first one it found was `Admin::ApplicationController`, and raise the superclass mismatch error.
  * There might be a way to config Zeitwerk to do a smarter look up but I think renaming
    `Admin::ApplicationController` to `Admin::BaseController` makes sense, and we can treat
    `ApplicationController` as a Rails keyword instead.