### PR TITLE
Avoid puma 4.3.5 that avoids bundle install

### DIFF
--- a/convene-web/Gemfile
+++ b/convene-web/Gemfile
@@ -15,7 +15,7 @@ gem 'rails', '~> 6'
 # Data Transport
 #
 # Use Puma as the app server
-gem 'puma', '~> 4.1'
+gem 'puma', '~> 4'
 
 
 # Browser Layer

--- a/convene-web/Gemfile
+++ b/convene-web/Gemfile
@@ -15,7 +15,7 @@ gem 'rails', '~> 6'
 # Data Transport
 #
 # Use Puma as the app server
-gem 'puma', '~> 4'
+gem 'puma'
 
 
 # Browser Layer

--- a/convene-web/Gemfile.lock
+++ b/convene-web/Gemfile.lock
@@ -155,7 +155,7 @@ GEM
     pry-byebug (3.9.0)
       byebug (~> 11.0)
       pry (~> 0.13.0)
-    puma (4.3.7)
+    puma (5.1.1)
       nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)
@@ -277,7 +277,7 @@ DEPENDENCIES
   passwordless
   pg (>= 0.18, < 2.0)
   pry-byebug
-  puma (~> 4)
+  puma
   rails (~> 6)
   rspec-rails
   sass-rails (>= 6)

--- a/convene-web/Gemfile.lock
+++ b/convene-web/Gemfile.lock
@@ -155,7 +155,7 @@ GEM
     pry-byebug (3.9.0)
       byebug (~> 11.0)
       pry (~> 0.13.0)
-    puma (4.3.5)
+    puma (4.3.7)
       nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)
@@ -277,7 +277,7 @@ DEPENDENCIES
   passwordless
   pg (>= 0.18, < 2.0)
   pry-byebug
-  puma (~> 4.1)
+  puma (~> 4)
   rails (~> 6)
   rspec-rails
   sass-rails (>= 6)


### PR DESCRIPTION
Closes: https://github.com/zinc-collective/convene/issues/182
Ref: https://github.com/puma/puma/issues/2342