### PR TITLE
Refactor Jitsi videobridge as Furniture

### DIFF
--- a/convene-web/app/lib/furniture.rb
+++ b/convene-web/app/lib/furniture.rb
@@ -1,6 +1,5 @@
 module Furniture
   REGISTRY = {
-    tables: Furniture::BreakoutTables,
     breakout_tables: Furniture::BreakoutTables,
     videobridge_jitsi: Furniture::VideobridgeJitsi,
   }

--- a/convene-web/app/lib/furniture.rb
+++ b/convene-web/app/lib/furniture.rb
@@ -1,0 +1,11 @@
+module Furniture
+  REGISTRY = {
+    tables: Furniture::BreakoutTables,
+    breakout_tables: Furniture::BreakoutTables,
+    videobridge_jitsi: Furniture::VideobridgeJitsi,
+  }
+
+  def self.from_placement(placement)
+    REGISTRY[placement.name.to_sym].new(placement)
+  end
+end

--- a/convene-web/app/lib/furniture/base_controller.rb
+++ b/convene-web/app/lib/furniture/base_controller.rb
@@ -1,0 +1,4 @@
+module Furniture
+  class BaseController < ::ApplicationController
+  end
+end

--- a/convene-web/app/lib/furniture/breakout_tables.rb
+++ b/convene-web/app/lib/furniture/breakout_tables.rb
@@ -31,7 +31,7 @@ module Furniture
       end
 
       helper_method def table
-        @table ||= room.furniture_placements.find_by!(name: :tables)
+        @table ||= room.furniture_placements.find_by!(name: :breakout_tables)
           &.furniture&.find_table(params[:id])
       end
 

--- a/convene-web/app/lib/furniture/videobridge_jitsi.rb
+++ b/convene-web/app/lib/furniture/videobridge_jitsi.rb
@@ -2,7 +2,7 @@ module Furniture
   class VideobridgeJitsi
     def initialize(placement)
       def in_room_template
-        "furniture/noop"
+        "furniture/videobridge_jitsi/in_room"
       end
     end
   end

--- a/convene-web/app/lib/furniture/videobridge_jitsi.rb
+++ b/convene-web/app/lib/furniture/videobridge_jitsi.rb
@@ -1,0 +1,9 @@
+module Furniture
+  class VideobridgeJitsi
+    def initialize(placement)
+      def in_room_template
+        "furniture/noop"
+      end
+    end
+  end
+end

--- a/convene-web/app/models/blueprint.rb
+++ b/convene-web/app/models/blueprint.rb
@@ -1,0 +1,42 @@
+# Used to assemble Spaces
+class Blueprint
+  attr_accessor :attributes
+
+  def initialize(attributes)
+    @attributes = attributes
+  end
+
+  def find_or_create!
+    space = client.spaces.find_or_create_by!(space_attrs[:name])
+    space.update!(space_attrs.except(:name))
+
+    room_attrs.each do |room_attrs|
+      room = space.rooms.find_or_initialize_by(name: room_attrs[:name])
+      room.update!(room_attrs.except(:name))
+      furniture_placements = room_attrs.fetch(:furniture_placements, {})
+      furniture_placements.each.with_index do |(furniture, settings), slot|
+        furniture_placement = room.furniture_placements
+                                  .find_or_initialize_by(name: furniture)
+        furniture_placement.update!(settings: settings, slot: slot)
+      end
+    end
+
+    space
+  end
+
+  private def space
+    @_space ||= client.spaces.find_or_create_by!(space_attrs[:name])
+  end
+
+  private def client
+      @_client ||= Client.find_or_create_by!(name: client_attrs[:name])
+  end
+
+  private def client_attrs
+    attributes[:client]
+  end
+
+  private def space_attrs
+    client_attrs[:space]
+  end
+end

--- a/convene-web/app/models/blueprint.rb
+++ b/convene-web/app/models/blueprint.rb
@@ -21,6 +21,10 @@ class Blueprint
       end
     end
 
+    space_attributes.fetch(:members, []).each do |person|
+      space.members << person
+    end
+
     space
   end
 

--- a/convene-web/app/models/demo_space.rb
+++ b/convene-web/app/models/demo_space.rb
@@ -4,28 +4,28 @@ class DemoSpace
       name: "Zee's Desk",
       publicity_level: :listed,
       furniture_placements: {
-        comlink: {}
+        videobridge_jitsi: {}
       }
     },
     {
       name: "Vivek's Desk",
       publicity_level: :listed,
       furniture_placements: {
-        comlink: {}
+        videobridge_jitsi: {}
       }
     },
     {
       name: "Water Cooler",
       publicity_level: :listed,
       furniture_placements: {
-        comlink: {}
+        videobridge_jitsi: {}
       }
     },
     {
       name: "The Ada Lovelace Room",
       publicity_level: :listed,
       furniture_placements: {
-        comlink: {}
+        videobridge_jitsi: {}
       }
     },
     {
@@ -34,7 +34,7 @@ class DemoSpace
       access_level: :locked,
       access_code: :friends,
       furniture_placements: {
-        comlink: {}
+        videobridge_jitsi: {}
       }
     },
   ].freeze

--- a/convene-web/app/models/demo_space.rb
+++ b/convene-web/app/models/demo_space.rb
@@ -1,71 +1,55 @@
 class DemoSpace
-  # Creates the demo space, but only on environments which are
-  # configured to include the demo space.
+  DEMO_ROOMS = [
+    {
+      name: "Zee's Desk",
+      publicity_level: :listed,
+      furniture_placements: {
+        comlink: {}
+      }
+    },
+    {
+      name: "Vivek's Desk",
+      publicity_level: :listed,
+      furniture_placements: {
+        comlink: {}
+      }
+    },
+    {
+      name: "Water Cooler",
+      publicity_level: :listed,
+      furniture_placements: {
+        comlink: {}
+      }
+    },
+    {
+      name: "The Ada Lovelace Room",
+      publicity_level: :listed,
+      furniture_placements: {
+        comlink: {}
+      }
+    },
+    {
+      name: "Locked Room",
+      publicity_level: :listed,
+      access_level: :locked,
+      access_code: :friends,
+      furniture_placements: {
+        comlink: {}
+      }
+    },
+  ].freeze
   def self.prepare
     return unless Feature.enabled?(:demo)
 
-    Factory.new(Client).find_or_create_space!
-  end
-
-  # Assembles the DemoSpace using the provided Client and Space
-  # classes.
-  class Factory
-    attr_accessor :client_repository
-
-    # These are the Rooms we expect the DemoSpace to have by default.
-    # Our customer team leverages them for their demonstrations of Convene's
-    # feature set.
-    DEMO_ROOMS = [
-      {
-        name: "Zee's Desk",
-        publicity_level: :listed,
+    Blueprint.new(client: {
+      name: 'Zinc',
+      space: {
+        name: 'Convene Demo',
+        jitsi_meet_domain: 'convene-videobridge-zinc.zinc.coop',
+        branded_domain: 'convene-demo.zinc.coop',
+        access_level: :unlocked,
+        rooms: DEMO_ROOMS
       },
-      {
-        name: "Vivek's Desk",
-        publicity_level: :listed,
-      },
-      {
-        name: "Water Cooler",
-        publicity_level: :listed,
-      },
-      {
-        name: "The Ada Lovelace Room",
-        publicity_level: :listed,
-      },
-      {
-        name: "Locked Room",
-        publicity_level: :listed,
-        access_level: :locked,
-        access_code: :friends,
-      },
-    ].freeze
-
-    # @param [ActiveRecord::Relation<Client>] client_repository Where to ensure there
-    #  is a Zinc Client with the Convene Demo space
-    def initialize(client_repository)
-      self.client_repository = client_repository
-    end
-
-    # Creates the Convene Demo Space and Zinc Client if necessary
-    def find_or_create_space!
-      space = client.spaces.find_or_create_by!(name: 'Convene Demo')
-      space.update!(jitsi_meet_domain: 'convene-videobridge-zinc.zinc.coop',
-                        branded_domain: 'convene-demo.zinc.coop',
-                        access_level: :unlocked)
-      add_demo_rooms(space)
-      space
-    end
-
-    private def add_demo_rooms(space)
-      DEMO_ROOMS.each do |room_properties|
-        room = space.rooms.find_or_initialize_by(name: room_properties[:name])
-        room.update!(room_properties.except(:name))
-      end
-      space
-    end
-
-    private def client
-      @_client ||= client_repository.find_or_create_by!(name: 'Zinc')
-    end
+    }).find_or_create!
   end
 end

--- a/convene-web/app/models/furniture_placement.rb
+++ b/convene-web/app/models/furniture_placement.rb
@@ -16,6 +16,6 @@ class FurniturePlacement < ApplicationRecord
   # TODO: Furniture probably wants to have a Registry that finds and
   # instantiates the appropriate furniture class for the placement.
   def furniture
-    @furniture ||= Furniture::BreakoutTables.new(self)
+    @furniture ||= Furniture.from_placement(self)
   end
 end

--- a/convene-web/app/models/furniture_placement.rb
+++ b/convene-web/app/models/furniture_placement.rb
@@ -13,8 +13,6 @@ class FurniturePlacement < ApplicationRecord
   attribute :slot, :integer
   validates :slot, presence: true, uniqueness: { scope: :room_id }
 
-  # TODO: Furniture probably wants to have a Registry that finds and
-  # instantiates the appropriate furniture class for the placement.
   def furniture
     @furniture ||= Furniture.from_placement(self)
   end

--- a/convene-web/app/models/system_test_space.rb
+++ b/convene-web/app/models/system_test_space.rb
@@ -4,20 +4,26 @@ class SystemTestSpace
   def self.prepare
     return unless Feature.enabled?(:system_test)
 
-    Factory.new(Client).find_or_create_space!
+    Blueprint.new(space: DEFAULT_SPACE_CONFIG.merge(
+      name: "System Test Branded Domain",
+      branded_domain: 'system-test.zinc.local'
+    )).find_or_create!
+
+    Blueprint.new(space: DEFAULT_SPACE_CONFIG.merge(name: "System Test"))
+      .find_or_create!
   end
 
-  class Factory
-    attr_accessor :client_repository
-
-    # Expand this to include more room types for different test cases
-    DEMO_ROOMS = [
+  DEFAULT_SPACE_CONFIG = {
+    jitsi_meet_domain: 'convene-videobridge-zinc.zinc.coop',
+    access_level: :unlocked,
+    rooms: [
       {
         name: 'Listed Room 1',
         publicity_level: :listed,
         access_level: :unlocked,
         access_code: nil,
         furniture_placements: {
+          comlink: {},
           tables: { names: %w[engineering design ops] }
         }
       },
@@ -25,65 +31,38 @@ class SystemTestSpace
         name: 'Listed Room 2',
         publicity_level: :listed,
         access_level: :unlocked,
-        access_code: nil
+        access_code: nil,
+        furniture_placements: {
+          comlink: {}
+        }
       },
       {
         name: 'Listed Locked Room 1',
         publicity_level: :listed,
         access_level: :locked,
-        access_code: :secret
+        access_code: :secret,
+        furniture_placements: {
+          comlink: {}
+        }
       },
       {
         name: 'Unlisted Room 1',
         publicity_level: :unlisted,
         access_level: :unlocked,
-        access_code: nil
+        access_code: nil,
+        furniture_placements: {
+          comlink: {}
+        }
       },
       {
         name: 'Unlisted Room 2',
         publicity_level: :unlisted,
         access_level: :unlocked,
-        access_code: nil
+        access_code: nil,
+        furniture_placements: {
+          comlink: {}
+        }
       }
-    ].freeze
-
-    # @param [ActiveRecord::Relation<Client>] client_repository Where to ensure there
-    #  is a Zinc Client with the Convene Demo space
-    def initialize(client_repository)
-      self.client_repository = client_repository
-    end
-
-    def find_or_create_space!
-      space = client.spaces.find_or_create_by!(name: 'System Test Branded Domain')
-      space.update!(jitsi_meet_domain: 'convene-videobridge-zinc.zinc.coop',
-                        branded_domain: 'system-test.zinc.local',
-                        access_level: :unlocked)
-      add_demo_rooms(space)
-
-      space = client.spaces.find_or_create_by!(name: 'System Test')
-      space.update!(jitsi_meet_domain: 'convene-videobridge-zinc.zinc.coop',
-                        branded_domain: nil,
-                        access_level: :unlocked)
-      add_demo_rooms(space)
-    end
-
-    private def add_demo_rooms(space)
-      DEMO_ROOMS.each do |room_properties|
-        room = space.rooms.find_or_initialize_by(name: room_properties[:name])
-        room.update!(room_properties.except(:name, :furniture_placements))
-
-        furniture_placements = room_properties.fetch(:furniture_placements, {})
-        furniture_placements.each.with_index do |(furniture, settings), slot|
-          furniture_placement = room.furniture_placements
-                                    .find_or_initialize_by(name: furniture)
-          furniture_placement.update!(settings: settings, slot: slot)
-        end
-      end
-      space
-    end
-
-    private def client
-      @_client ||= client_repository.find_or_create_by!(name: 'Zinc')
-    end
-  end
+    ]
+  }.freeze
 end

--- a/convene-web/app/models/system_test_space.rb
+++ b/convene-web/app/models/system_test_space.rb
@@ -4,14 +4,16 @@ class SystemTestSpace
   def self.prepare
     return unless Feature.enabled?(:system_test)
 
-    Blueprint.new(space: DEFAULT_SPACE_CONFIG.merge(
-      name: "System Test Branded Domain",
-      branded_domain: 'system-test.zinc.local'
-    )).find_or_create!
+    Blueprint.new(client: { name: 'System Test',
+                            space: DEFAULT_SPACE_CONFIG.merge(
+                              name: 'System Test Branded Domain',
+                              branded_domain: 'system-test.zinc.local'
+                            ) }).find_or_create!
 
-    Blueprint.new(client: "System Test",
-                  space: DEFAULT_SPACE_CONFIG.merge(name: "System Test"))
-      .find_or_create!
+    Blueprint.new(client: { name: 'System Test',
+                            space: DEFAULT_SPACE_CONFIG
+                              .merge(name: 'System Test') })
+             .find_or_create!
   end
 
   DEFAULT_SPACE_CONFIG = {
@@ -24,8 +26,8 @@ class SystemTestSpace
         access_level: :unlocked,
         access_code: nil,
         furniture_placements: {
-          comlink: {},
-          tables: { names: %w[engineering design ops] }
+          videobridge_jitsi: {},
+          breakout_tables: { names: %w[engineering design ops] }
         }
       },
       {
@@ -34,7 +36,7 @@ class SystemTestSpace
         access_level: :unlocked,
         access_code: nil,
         furniture_placements: {
-          comlink: {}
+          videobridge_jitsi: {}
         }
       },
       {
@@ -43,7 +45,7 @@ class SystemTestSpace
         access_level: :locked,
         access_code: :secret,
         furniture_placements: {
-          comlink: {}
+          videobridge_jitsi: {}
         }
       },
       {
@@ -52,7 +54,7 @@ class SystemTestSpace
         access_level: :unlocked,
         access_code: nil,
         furniture_placements: {
-          comlink: {}
+          videobridge_jitsi: {}
         }
       },
       {
@@ -61,7 +63,7 @@ class SystemTestSpace
         access_level: :unlocked,
         access_code: nil,
         furniture_placements: {
-          comlink: {}
+          videobridge_jitsi: {}
         }
       }
     ]

--- a/convene-web/app/models/system_test_space.rb
+++ b/convene-web/app/models/system_test_space.rb
@@ -9,7 +9,8 @@ class SystemTestSpace
       branded_domain: 'system-test.zinc.local'
     )).find_or_create!
 
-    Blueprint.new(space: DEFAULT_SPACE_CONFIG.merge(name: "System Test"))
+    Blueprint.new(client: "System Test",
+                  space: DEFAULT_SPACE_CONFIG.merge(name: "System Test"))
       .find_or_create!
   end
 

--- a/convene-web/app/views/furniture/breakout_tables/_in_room.html.erb
+++ b/convene-web/app/views/furniture/breakout_tables/_in_room.html.erb
@@ -1,5 +1,5 @@
 <h3>Tables</h3>
 <%- furniture.tables.each do |table| %>
   <%= link_to table.name,
-              space_room_furniture_table_path(room.space, room, table) %>
+              space_room_furniture_breakout_table_path(room.space, room, table) %>
 <%- end %>

--- a/convene-web/app/views/furniture/videobridge_jitsi/_in_room.html.erb
+++ b/convene-web/app/views/furniture/videobridge_jitsi/_in_room.html.erb
@@ -1,0 +1,8 @@
+<div
+  id="meet"
+  data-controller="video-room"
+  data-target="video-room.wrapper"
+  data-video-room-video-host="<%= room.video_host %>"
+  data-video-room-name="<%= room.full_slug %>"
+  data-video-room-space-path="<%= space_path(room.space) %>">
+</div>

--- a/convene-web/app/views/rooms/show.html.erb
+++ b/convene-web/app/views/rooms/show.html.erb
@@ -2,17 +2,6 @@
   app--no-header
 <% end %>
 
-<div
-  id="meet"
-  data-controller="video-room"
-  data-target="video-room.wrapper"
-  data-video-room-video-host="<%= room.video_host %>"
-  data-video-room-name="<%= room.full_slug %>"
-  data-video-room-space-path="<%= space_path(room.space) %>"
-  class="bg-neutral-800"
->
-</div>
-
 <%- room.furniture_placements.each do |furniture_placement| %>
   <%= render partial: furniture_placement.furniture.in_room_template,
              locals: { furniture: furniture_placement.furniture, room: room,

--- a/convene-web/config/routes.rb
+++ b/convene-web/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
     resources :rooms, only: %i[show edit update] do
       resource :waiting_room, only: %i[show update]
       namespace :furniture do
-        resources :tables, only: [:show], controller: 'breakout_tables/'
+        resources :breakout_tables, only: [:show], controller: 'breakout_tables/'
       end
     end
   end

--- a/convene-web/db/seeds.rb
+++ b/convene-web/db/seeds.rb
@@ -10,23 +10,31 @@ zee = Person.find_or_create_by!(email: 'zee@example.com', name: 'Zee')
 tom = Person.find_or_create_by!(email: 'tom@example.com', name: 'Tom')
 bene = Person.find_or_create_by!(email: 'bene@example.com', name: 'Bene')
 
-zinc = Client.find_or_create_by!(name: 'Zinc')
-
-zincs_space = zinc.spaces
-                      .find_or_create_by!(name: 'Zinc')
-zincs_space.update!(access_level: :unlocked,
-                        branded_domain: 'meet.zinc.local',
-                        jitsi_meet_domain: 'convene-videobridge-zinc.zinc.coop')
-
-zincs_space.members << zee
-zincs_space.members << tom
-zincs_space.members << bene
-
-ada = zincs_space.rooms.find_or_initialize_by(name: 'Ada')
-ada.update!(access_level: :unlocked, publicity_level: :listed)
-ttz = zincs_space.rooms.find_or_initialize_by(name: 'Talk to Zee')
-ttz.update!(access_level: :unlocked, publicity_level: :unlisted)
-ttz.owners << zee
+Blueprint.new(client: {
+  name: "Zinc",
+  space: {
+    members: [zee, tom, bene],
+    name: "Zinc", branded_domain: 'meet.zinc.local',
+    access_level: :unlocked,
+    jitsi_meet_domain: 'convene-videobridge-zinc.zinc.coop',
+    rooms: [{
+      name: "Ada",
+      access_level: :unlocked,
+      publicity_level: :listed,
+      furniture_placements: {
+        comlink: {}
+      }
+    },
+    {
+      name: "Talk to Zee",
+      access_level: :unlocked,
+      publicity_level: :unlisted,
+      furniture_placements: {
+        comlink: {}
+      }
+    }]
+  }
+}).find_or_create!
 
 DemoSpace.prepare
 SystemTestSpace.prepare

--- a/convene-web/db/seeds.rb
+++ b/convene-web/db/seeds.rb
@@ -22,7 +22,7 @@ Blueprint.new(client: {
       access_level: :unlocked,
       publicity_level: :listed,
       furniture_placements: {
-        comlink: {}
+        videobridge_jitsi: {}
       }
     },
     {
@@ -30,7 +30,7 @@ Blueprint.new(client: {
       access_level: :unlocked,
       publicity_level: :unlisted,
       furniture_placements: {
-        comlink: {}
+        videobridge_jitsi: {}
       }
     }]
   }

--- a/convene-web/lib/tasks/release.rake
+++ b/convene-web/lib/tasks/release.rake
@@ -3,5 +3,13 @@ namespace :release do
   task after_build: [:environment, "db:prepare"] do
     DemoSpace.prepare
     SystemTestSpace.prepare
+
+    # Create a FurniturePlacement in Slot 1 for the Jitsi Videobridge!
+    Room.all.each do |room|
+      room.furniture_placements.find_or_create_by!(name: 'videobridge_jitsi', slot: 0)
+    end
+
+    # Renames our furniture placements from tables to breakout_tables
+    FurniturePlacement.all.where(name: 'tables').update_all(name: 'breakout_tables')
   end
 end

--- a/convene-web/spec/models/furniture_placement_spec.rb
+++ b/convene-web/spec/models/furniture_placement_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe FurniturePlacement do
   describe '#furniture' do
     it 'returns the configured piece of furniture' do
       furniture_placement = FurniturePlacement
-                            .new(name: :tables, settings: { names: %w[a b] })
+                            .new(name: :breakout_tables, settings: { names: %w[a b] })
 
       expect(furniture_placement.furniture).to be_a(Furniture::BreakoutTables)
       expect(furniture_placement.furniture.placement).to eql(furniture_placement)


### PR DESCRIPTION
See https://github.com/zinc-collective/convene/issues/186

In order to support more diverse use cases, I'm trying to move the Videobridge into a piece of Furniture that can be placed in a Room. The intent here is to allow us to have Rooms that _don't_ use a VideoBridge, such as for the Fundraising ACH Tool

Can Haz Review on:

1. [x] Running `bin/setup` completes successfully?
2. [x] Running `convene-web/bin rake release:after_build` makes sure all the rooms on your machine have a videobridge?
3. [x] Sanity check?
