### PR TITLE
Fix review apps

### DIFF
--- a/convene-web/Procfile
+++ b/convene-web/Procfile
@@ -1,2 +1,2 @@
-release:  bin/rake release:after_build
+release:  bin/rake db:prepare && bin/rake release:after_build
 web:      bundle exec puma -C config/puma.rb


### PR DESCRIPTION
There is probably a smarter way to do this, but what I think is
happening is because `db:prepare` is being called in the same process
that is doing the loading of the data, the models haven't had their
underlying mapping to the database tables "refreshed" which is causing
the builds to fail.