### PR TITLE
Expire sessions after seven days

### DIFF
--- a/convene-web/config/application.rb
+++ b/convene-web/config/application.rb
@@ -31,5 +31,7 @@ module ConveneWeb
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    config.session_store :cookie_store, expire_after: 7.days
   end
 end

--- a/features/identification.feature
+++ b/features/identification.feature
@@ -64,6 +64,12 @@ Feature: Identification
   # @unstarted
   # And the Guest can not Identify themselves by entering the code sent to their Email
 
+  @built @unimplemented-steps
+  Scenario: Authentication times out
+    Given an Authenticated Person who has not signed in for 7 days
+    When the Authenticated Person visits Convene
+    Then the Authenticated Person is treated as a Guest
+
   @unimplemented-steps
   Scenario: Authentication times out due to inactivity
     Given an Authenticated Person who has been Inactive for 7 days


### PR DESCRIPTION
Connects: https://github.com/zinc-collective/convene/issues/118

We haven't figured out how to expire a session due to inactivity,
so we just expire the session after seven days regardless.