### PR TITLE
Fix initializer logic for setting the ActionMailer port

### DIFF
--- a/convene-web/config/initializers/action_mailer.rb
+++ b/convene-web/config/initializers/action_mailer.rb
@@ -15,6 +15,6 @@ end
 if ENV["APP_ROOT_URL"]
   root_uri = URI.parse(ENV["APP_ROOT_URL"])
   ActionMailer::Base.default_url_options[:host] = root_uri.host
-  ActionMailer::Base.default_url_options[:port] = root_uri.port if root_uri.port == root_uri.default_port
+  ActionMailer::Base.default_url_options[:port] = root_uri.port if root_uri.port != root_uri.default_port
   ActionMailer::Base.default_url_options[:scheme] = root_uri.scheme
 end


### PR DESCRIPTION
This logic was accidentally inverted: we want to set the port explicitly when we are _not_ running on the default port.

(Extracting this fix from https://github.com/zinc-collective/convene/pull/199, so that we can have it merged in sooner.)