### PR TITLE
Cache setup / installation steps when running in the CI environment

### DIFF
--- a/.github/workflows/test-convene-web.yml
+++ b/.github/workflows/test-convene-web.yml
@@ -19,6 +19,7 @@ jobs:
       SMTP_PORT: 1025
       SMTP_DOMAIN: localhost
       SMTP_ENABLE_TLS: false
+      # Tell ruby/setup-ruby which Gemfile to use for caching.
       BUNDLE_GEMFILE: convene-web/Gemfile
 
     services:
@@ -58,6 +59,19 @@ jobs:
 
     - name: Use Development mode env
       run: cd convene-web && cp .env.example .env
+
+    # Yarn caching steps borroed from https://github.com/actions/cache/blob/main/examples.md#node---yarn
+    - name: Get yarn cache directory path
+      id: yarn-cache-dir-path
+      run: echo "::set-output name=dir::$(yarn cache dir)"
+
+    - uses: actions/cache@v2
+      id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
 
     - name: Setup environment
       run: |

--- a/.github/workflows/test-convene-web.yml
+++ b/.github/workflows/test-convene-web.yml
@@ -19,8 +19,6 @@ jobs:
       SMTP_PORT: 1025
       SMTP_DOMAIN: localhost
       SMTP_ENABLE_TLS: false
-      # Tell ruby/setup-ruby which Gemfile to use for caching.
-      BUNDLE_GEMFILE: convene-web/Gemfile
 
     services:
       postgres:
@@ -47,6 +45,8 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true
+        # Use this directory for finding the Gemfile and other Ruby goodies.
+        working-directory: 'convene-web'
 
     - name: Increase the amount of inotify watchers
       run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p

--- a/.github/workflows/test-convene-web.yml
+++ b/.github/workflows/test-convene-web.yml
@@ -19,6 +19,7 @@ jobs:
       SMTP_PORT: 1025
       SMTP_DOMAIN: localhost
       SMTP_ENABLE_TLS: false
+      BUNDLE_GEMFILE: convene-web/Gemfile
 
     services:
       postgres:

--- a/convene-web/.ruby-version
+++ b/convene-web/.ruby-version
@@ -1,0 +1,1 @@
+.ruby-version

--- a/convene-web/.ruby-version
+++ b/convene-web/.ruby-version
@@ -1,1 +1,1 @@
-.ruby-version
+../.ruby-version


### PR DESCRIPTION
Address https://github.com/zinc-collective/convene/issues/209 by caching bundled gems and installed node_modules in the CI environment.

Zippy builds are here:

![image](https://user-images.githubusercontent.com/6729309/112739100-35425180-8f26-11eb-9415-2f9fd54bf631.png)
