### PR TITLE
Expose server logs in development

### DIFF
--- a/convene-web/config/environments/development.rb
+++ b/convene-web/config/environments/development.rb
@@ -62,4 +62,7 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # Expose server logs in development
+  config.logger       = ActiveSupport::Logger.new(STDOUT)
 end


### PR DESCRIPTION
For some reason, after switching to Hivemind, I no longer see the server logs.
This pull request fixes it.