### PR TITLE
Better configure Passwordless, add an initializer

### DIFF
--- a/convene-web/config/initializers/passwordless.rb
+++ b/convene-web/config/initializers/passwordless.rb
@@ -1,0 +1,8 @@
+# Configuration for the Passwordless gem: https://github.com/mikker
+
+Passwordless.default_from_address = "no-reply@convene.zinc.coop"
+Passwordless.redirect_back_after_sign_in = true
+Passwordless.success_redirect_path = ENV["APP_ROOT_URL"]
+Passwordless.sign_out_redirect_path = ENV["APP_ROOT_URL"]
+# Expiry time for magic link
+Passwordless.timeout_at = lambda { 1.hour.from_now }


### PR DESCRIPTION
This PR addresses some of the issues we uncovered when doing manual testing for https://github.com/zinc-collective/convene/issues/118:
* add a better "from" address for magic link emails
* set an explicit token timeout setting
* set explicit sign in, sign out, and failure redirect paths
* add an explicit setting for redirecting "back" after sign in (where possible)