### PR TITLE
Use tweaked custom mailer to email magic links that point the user to the domain they were using

### DIFF
--- a/convene-web/app/mailers/magic_link_mailer.rb
+++ b/convene-web/app/mailers/magic_link_mailer.rb
@@ -1,0 +1,13 @@
+class MagicLinkMailer < ApplicationMailer
+  default from: Passwordless.default_from_address
+
+  # Based on Passwordless' default Mailer implementation
+  def magic_link(session, request)
+    @magic_link = people.token_sign_in_url(session.token, host: request.host)
+    email = session.authenticatable.class.passwordless_email_field
+    mail(
+      to: session.authenticatable.send(email),
+      subject: I18n.t("passwordless.mailer.subject")
+    )
+  end
+end

--- a/convene-web/app/views/magic_link_mailer/magic_link.text.erb
+++ b/convene-web/app/views/magic_link_mailer/magic_link.text.erb
@@ -1,0 +1,1 @@
+<%= I18n.t('passwordless.mailer.magic_link', link: @magic_link) %>

--- a/convene-web/config/initializers/passwordless.rb
+++ b/convene-web/config/initializers/passwordless.rb
@@ -6,3 +6,9 @@ Passwordless.success_redirect_path = ENV["APP_ROOT_URL"]
 Passwordless.sign_out_redirect_path = ENV["APP_ROOT_URL"]
 # Expiry time for magic link
 Passwordless.timeout_at = lambda { 1.hour.from_now }
+
+Passwordless.after_session_save = lambda do |session, request|
+  # Replace default Passwordless Mailer with our own, where we make sure
+  # to direct the user to the correct (sub)domain.
+  MagicLinkMailer.magic_link(session, request).deliver_now
+end


### PR DESCRIPTION
This PR attempts to resolve an issue we found when testing https://github.com/zinc-collective/convene/issues/118, where a magic link URl was directing the user to the incorrect subdomain.

Another option might have been monkeypatching Passwordless, but to me this feels a little less brittle, more explicit, and hopefully easier to further extend in the future.