### PR TITLE
Wait for assets before running bin/run

### DIFF
--- a/.github/workflows/test-convene-web.yml
+++ b/.github/workflows/test-convene-web.yml
@@ -87,9 +87,9 @@ jobs:
     - name: Test convene-web
       run: |
           sudo sh -c "echo '127.0.0.1 system-test.zinc.local' >> /etc/hosts"
-          # To trigger asset compile in development mode
+          # To wait for asset built
           # TODO: Start server in production mode
-          curl system-test.zinc.local 1> /dev/null
+          curl system-test.zinc.local:3035/packs/manifest.json 1> /dev/null
           bin/test
 
     - uses: actions/upload-artifact@v2


### PR DESCRIPTION
Before Hivemind, we curl system-test.zinc.local to trigger asset built before running `bin/test`.
Now with Hivemind, we have dedicated asset process to run `webpack-dev-server` so we need to check if the `manifest.json` is ready.