### PR TITLE
Gracefully handle error when space has no entrance

### DIFF
--- a/convene-web/app/views/spaces/show.html.erb
+++ b/convene-web/app/views/spaces/show.html.erb
@@ -4,7 +4,7 @@
   <% end %>
 </div>
 
-<%- space.entrance.furniture_placements.each do |furniture_placement| %>
+<%- space.entrance&.furniture_placements&.each do |furniture_placement| %>
   <%= render partial: furniture_placement.furniture.in_room_template,
              locals: { furniture: furniture_placement.furniture, room: space.entrance,
                        person: current_person } %>

--- a/features/spaces.feature
+++ b/features/spaces.feature
@@ -13,3 +13,9 @@ Feature: Spaces
     Given a Space with a Room specified as its Entrance
     When Anyone visits the Space
     Then they see the Furniture in the Entrance Room
+
+  @built @unimplemented-steps
+  Scenario: Space without Entrances
+    Given a Space with no Entrance
+    When Anyone visits the Space
+    Then they only see the Rooms


### PR DESCRIPTION
Connects: https://github.com/zinc-collective/convene/issues/233

I didn't write test for this because:
1. This is breaking all `SpaceController#show` page so it's better to fix it sooner than later. I manually test it locally with a space with no entrance.
2. I want to get some advice/ directions on how to generate seed for different space configuration for feature test and implement in another pull request.