### PR TITLE
Eliminate error when running `bin/setup` on a Mac without shared-mime-info installed

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -22,9 +22,9 @@ function setup_package {
   fi
 }
 
-
 setup_package "overmind"
 setup_package "yarn"
+setup_package "shared-mime-info"
 
 if test -f ".env"; then
   echo "Found .env, leaving it in place!"


### PR DESCRIPTION
Turns out, some dev machines do not yet have the mime info installed; and it's a system-level dependency
So we added it in our `bin/setup` script.