### PR TITLE
Aggregate failures in rspec by default

### DIFF
--- a/convene-web/spec/spec_helper.rb
+++ b/convene-web/spec/spec_helper.rb
@@ -46,7 +46,9 @@ RSpec.configure do |config|
   # inherited by the metadata hash of host groups and examples, rather than
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
-
+  config.define_derived_metadata do |meta|
+    meta[:aggregate_failures] = true
+  end
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
 =begin


### PR DESCRIPTION
It's OK for a test to have multiple asserts; especially given how
expensive most of the test setup/teardown is in rails.