### PR TITLE
Authorize updates to Furniture Placements in controller

### DIFF
--- a/convene-web/app/controllers/furniture_placements_controller.rb
+++ b/convene-web/app/controllers/furniture_placements_controller.rb
@@ -1,5 +1,7 @@
 class FurniturePlacementsController < ApplicationController
   def update
+    authorize(furniture_placement)
+
     furniture_placement.update(furniture_placement_params)
     flash[:notice] = "Updated #{furniture_placement.furniture.model_name.human.titleize}"
 

--- a/convene-web/spec/factories/furniture_placement.rb
+++ b/convene-web/spec/factories/furniture_placement.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :furniture_placement do
     room
     furniture_kind { "markdown_text_block" }
+    settings { { content: "# Original Content"} }
     slot { 1 }
   end
 end

--- a/convene-web/spec/requests/spaces/room/furniture_placements_spec.rb
+++ b/convene-web/spec/requests/spaces/room/furniture_placements_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe '/spaces/:space_slug/room/:room_slug/furniture_placements', type: :request do
+  let(:placement) { create(:furniture_placement) }
+  let(:space) { placement.room.space}
+  let(:placement_path) { "/spaces/#{space.slug}/rooms/#{placement.room.slug}/furniture_placements/#{placement.id}" }
+
+  describe 'PATCH /spaces/:space_slug/room/:room_slug/furniture_placements/:id' do
+    context 'when the person is a guest' do
+      it 'does not allow updating placements' do
+
+        patch placement_path, params: { furniture_placement: { furniture_attributes: { content: 'updated content' }} }
+        expect(response).not_to have_http_status(:success)
+      end
+    end
+
+    context 'when the person is a space member' do
+      let(:space_membership) { create(:space_membership, space: space) }
+      let!(:person) { space_membership.member }
+
+      before do
+        sign_in(person)
+      end
+
+      it 'allows updating a placement' do
+        patch placement_path, params: { furniture_placement: { furniture_attributes: { content: 'updated content' }} }
+        expect(response).to have_http_status(302)
+        expect(placement.reload.settings['content']).to eq('updated content')
+      end
+    end
+  end
+end

--- a/convene-web/spec/requests/waiting_rooms_request_spec.rb
+++ b/convene-web/spec/requests/waiting_rooms_request_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe "WaitingRooms", type: :request do
-
-end


### PR DESCRIPTION
To prevent non-space-members from messing with a Space's furniture.