### PR TITLE
Restructure Header and Footer to prioritize the Space

### DIFF
--- a/convene-web/app/javascript/src/base/layout.scss
+++ b/convene-web/app/javascript/src/base/layout.scss
@@ -1,5 +1,5 @@
 @layer base {
-  html {
+  body {
     background: rgb(200, 200, 200);
     background: linear-gradient(
       0deg,
@@ -8,10 +8,13 @@
     );
     background-repeat: no-repeat;
     background-size: cover;
-    @apply min-h-screen;
+    @apply min-h-screen flex flex-col;
   }
 
   main {
-    @apply mx-2;
+    @apply mx-2 flex-1;
+    :last-child {
+      @apply mb-2;
+    }
   }
 }

--- a/convene-web/app/javascript/src/base/typography.scss
+++ b/convene-web/app/javascript/src/base/typography.scss
@@ -47,4 +47,9 @@
   ul {
     @apply list-disc;
   }
+
+
+  a {
+    @apply underline;
+  }
 }

--- a/convene-web/app/javascript/src/components.scss
+++ b/convene-web/app/javascript/src/components.scss
@@ -9,14 +9,14 @@
  */
 @import "./components/button";
 @import "./components/form";
-
 @import "./components/icons";
 
 /**
  * App Specific Components
  */
-@import "./components/meeting_room";
+@import "./components/branding";
 @import "./components/guide_summary";
-@import "./components/room_card";
 
+@import "./components/meeting_room";
+@import "./components/room_card";
 @import "./components/spaces";

--- a/convene-web/app/javascript/src/components.scss
+++ b/convene-web/app/javascript/src/components.scss
@@ -1,12 +1,22 @@
-@import "./components/breadcrumbs";
+/**
+ * Layout Components
+ */
+@import "./components/header";
+@import "./components/footer";
+
+/**
+ * Generic Components
+ */
 @import "./components/button";
 @import "./components/form";
-@import "./components/guide_summary";
-@import "./components/header";
+
 @import "./components/icons";
 
+/**
+ * App Specific Components
+ */
 @import "./components/meeting_room";
-
+@import "./components/guide_summary";
 @import "./components/room_card";
 
 @import "./components/spaces";

--- a/convene-web/app/javascript/src/components/branding.scss
+++ b/convene-web/app/javascript/src/components/branding.scss
@@ -1,0 +1,10 @@
+@layer components {
+  .branding {
+    .tagline {
+      @apply hidden;
+      @screen sm {
+        @apply inline;
+      }
+    }
+  }
+}

--- a/convene-web/app/javascript/src/components/footer.scss
+++ b/convene-web/app/javascript/src/components/footer.scss
@@ -1,0 +1,14 @@
+@layer components {
+  body > footer {
+    @apply flex items-center justify-between px-2 py-2 bg-primary-900 text-white;
+
+    .branding {
+      .tagline {
+        @apply hidden;
+        @screen sm {
+          @apply inline;
+        }
+      }
+    }
+  }
+}

--- a/convene-web/app/javascript/src/components/footer.scss
+++ b/convene-web/app/javascript/src/components/footer.scss
@@ -1,14 +1,5 @@
 @layer components {
   body > footer {
     @apply flex items-center justify-between px-2 py-2 bg-primary-900 text-white;
-
-    .branding {
-      .tagline {
-        @apply hidden;
-        @screen sm {
-          @apply inline;
-        }
-      }
-    }
   }
 }

--- a/convene-web/app/javascript/src/components/header.scss
+++ b/convene-web/app/javascript/src/components/header.scss
@@ -1,26 +1,12 @@
 @layer components {
-  .header {
-    @apply flex items-center justify-between px-2 py-2 bg-primary-900 text-white;
-    .branding {
-      .tagline {
-        @apply hidden;
-        @screen sm {
-          @apply inline;
-        }
-      }
-    }
-    .space-menu {
-      @apply flex-grow text-right px-4;
-    }
+  body > header {
+    @apply flex justify-between px-2 py-2 bg-primary-900 text-white place-items-end;
+
 
     .profile-menu {
-      @apply flex flex-row items-center relative;
-      figcaption {
-        @apply font-hairline text-center text-xs;
-      }
-      nav {
-        @apply absolute bg-primary-600 px-4 py-1 shadow;
-      }
+      @apply flex flex-row relative;
+      :first-child { @apply pr-0; }
+      > * { @apply px-2 }
     }
   }
 

--- a/convene-web/app/javascript/src/components/room_card.scss
+++ b/convene-web/app/javascript/src/components/room_card.scss
@@ -16,7 +16,7 @@
       .room-door_enter, .room-door_configure {
         @apply flex justify-center text-sm leading-5 text-neutral-700 font-medium transition ease-in-out duration-150;
         a {
-          @apply flex-1 inline-flex items-center justify-center py-4;
+          @apply flex-1 inline-flex items-center justify-center py-4 no-underline;
         }
         span {
           @apply pl-4;

--- a/convene-web/app/models/guest.rb
+++ b/convene-web/app/models/guest.rb
@@ -5,9 +5,12 @@ class Guest
   attribute :name, :string, default: "Guest"
   # TODO: Make feature test not dependent on email
   attribute :email, :string, default: "guest@example.com"
-  attribute :avatar_url, :string, default: '/avatar.svg'
 
   def member_of?(_space)
+    false
+  end
+
+  def authenticated?
     false
   end
 end

--- a/convene-web/app/models/person.rb
+++ b/convene-web/app/models/person.rb
@@ -13,12 +13,11 @@ class Person < ApplicationRecord
     find_or_create_by(email: email)
   end
 
-  def avatar_url
-    # TODO: Allow person to upload their image
-    "/avatar.svg"
-  end
-
   def member_of?(space)
     spaces.include?(space)
+  end
+
+  def authenticated?
+    true
   end
 end

--- a/convene-web/app/views/layouts/_header.html.erb
+++ b/convene-web/app/views/layouts/_header.html.erb
@@ -1,37 +1,27 @@
-<header class="header">
-  <div class="branding">
-    <h3>Convene<span class="tagline">: Space to Work, Play, or Simply Be</span></h3>
-  </div>
-
-  <div class="space-menu">
-    <h1><%= current_space&.name %></h1>
-  </div>
+<header>
+  <%- if current_space.present? %>
+    <div>
+      <%= breadcrumbs container_tag: 'nav' , fragment_class: 'crumb' , separator: " &rsaquo; " , semantic: true, display_single_fragment: true %>
+    </div>
+  <%- end %>
 
 
-    <%- if Feature.enabled?(:identification) %>
-      <div class="profile-menu" data-controller="menu">
-        <div>
-          <figure class="avatar">
-            <%= image_tag current_person.avatar_url, size: 30 %>
-            <figcaption><%= current_person.name %></figcaption>
-          </figure>
 
-          <nav class="--hidden" data-target="menu.items">
-            <%- if current_person.is_a? Person %>
-              <%= link_to "Sign out", people.sign_out_path, class: "profile-menu-dropdown-item sign-out"  %>
-            <%- else %>
-              <%= link_to "Sign in",  people.sign_in_path,  class: "profile-menu-dropdown-item" %>
-            <%- end %>
-          </nav>
-        </div>
-
-        <%= button_tag "", type: "button", class: "navigation-toggle", "data-action": "click->menu#toggle click@window->menu#hide",  "data-target": "menu.button", "aria-labelledby": "profile-menu-dropdown-button" %>
-      </div>
-    <%- end %>
+  <%- if Feature.enabled?(:identification) %>
+    <nav aria-label="Menu" class="profile-menu">
+      <%- if current_person.authenticated? %>
+        <%= link_to "Sign out" , people.sign_out_path %>
+      <%- else %>
+        <%= link_to "Sign in" , people.sign_in_path %>
+      <%- end %>
+    </nav>
+  <%- end %>
 </header>
 
 <%- flash.each do |kind, message| %>
   <div class="flash-message --<%= kind %>">
-    <p><%= message %></p>
+    <p>
+      <%= message %>
+    </p>
   </div>
 <%- end %>

--- a/convene-web/app/views/layouts/_header.html.erb
+++ b/convene-web/app/views/layouts/_header.html.erb
@@ -10,9 +10,9 @@
   <%- if Feature.enabled?(:identification) %>
     <nav aria-label="Menu" class="profile-menu">
       <%- if current_person.authenticated? %>
-        <%= link_to "Sign out" , people.sign_out_path %>
+        <%= link_to "Sign out", people.sign_out_path, class: 'sign-out' %>
       <%- else %>
-        <%= link_to "Sign in" , people.sign_in_path %>
+        <%= link_to "Sign in", people.sign_in_path, class: "sign-in" %>
       <%- end %>
     </nav>
   <%- end %>

--- a/convene-web/app/views/layouts/application.html.erb
+++ b/convene-web/app/views/layouts/application.html.erb
@@ -17,10 +17,15 @@
     <%= render 'layouts/header' %>
 
     <main>
-      <%= breadcrumbs container_tag: 'nav', fragment_class: 'crumb', separator: " &rsaquo; " %>
       <%= yield %>
-      <%= breadcrumbs container_tag: 'nav', fragment_class: 'crumb', separator: " &rsaquo; " %>
     </main>
 
+
+    <footer>
+      <%= breadcrumbs container_tag: 'nav', fragment_class: 'crumb', separator: " &rsaquo; ", semantic: true, display_single_fragment: true %>
+      <div class="branding">
+        <h3>Convene<span class="tagline">: Space to Work, Play, or Simply Be</span></h3>
+      </div>
+    </footer>
   </body>
 </html>

--- a/convene-web/app/views/waiting_rooms/show.html.erb
+++ b/convene-web/app/views/waiting_rooms/show.html.erb
@@ -1,3 +1,4 @@
+<% breadcrumb :waiting_room, waiting_room %>
 <div class="min-h-screen flex items-center justify-between">
   <div class="m-auto">
     <div class="bg-neutral-500 text-white font-extrabold px-8 py-4 rounded">

--- a/convene-web/config/breadcrumbs.rb
+++ b/convene-web/config/breadcrumbs.rb
@@ -26,3 +26,8 @@ crumb :edit_room do |room|
   link "Configure #{room.name}", edit_space_room_path(room.space, room)
   parent :room, room
 end
+
+crumb :waiting_room do |waiting_room|
+  link 'Waiting Room', space_room_waiting_room_path(waiting_room.room.space, waiting_room.room)
+  parent :room, waiting_room.room
+end

--- a/features/harness/PersonNavigationComponent.js
+++ b/features/harness/PersonNavigationComponent.js
@@ -4,33 +4,7 @@ class PersonNavigationComponent extends Component {
    * @returns {Promise<PersonNavigationComponent>}
    */
   signOut() {
-    return this.expand()
-      .then((c) => c.signOutLink().click())
-      .then(() => this);
-  }
-
-  /**
-   * @returns {Promise<PersonNavigationComponent>}
-   */
-  expand() {
-    return this.links()
-      .isDisplayed()
-      .then((visible) => !visible && this.navigationToggleButton().click())
-      .then(() => this);
-  }
-
-  /**
-   * @returns {Promise<Component>}
-   */
-  links() {
-    return this.component("nav");
-  }
-
-  /**
-   * @returns {Promise<Component>}
-   */
-  navigationToggleButton() {
-    return this.component(".navigation-toggle");
+    return this.signOutLink().click().then(() => this )
   }
 
   /**


### PR DESCRIPTION


- Moves Convene to a Footer
- Adds Breadcrumbs to the Header and Footer
- Gets rid of Avatars since we don't have it yet
- Gets rid of the tap to Sign out / Sign In

![Screen Shot 2021-05-01 at 7 06 36 PM](https://user-images.githubusercontent.com/50284/116799901-41837680-aab1-11eb-930a-e01901df1a37.png)
![Screen Shot 2021-05-01 at 7 06 48 PM](https://user-images.githubusercontent.com/50284/116799900-40eae000-aab1-11eb-93ca-99dce70b7e31.png)
![Screen Shot 2021-05-01 at 7 07 02 PM](https://user-images.githubusercontent.com/50284/116799898-3fb9b300-aab1-11eb-8ec2-eef35c489691.png)


