### PR TITLE
Docs/move root level instructions for development back readme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,16 +60,37 @@ Designers who have agreed to protect the privacy of our clients may access our
 
 ### 2.1. Developer Setup and Documentation.
 
-Much of Convene development happens in `convene-web`. The
-[`README`](./convene-web/README.md) in that directory contains more
-documentation on how to work on Convene.
+Much of Convene development happens in `convene-web`.
 
 To set up your development environment you'll need `ruby`, `node` and
-`postgresql`. See [Convene::Web/README.md "Configuring your Development
-Machine"] for more information.
+`postgresql`. 
 
-[convene::web/readme.md "configuring your development machine"]:
-  ./convene-web/README.md#configuring-your-development-machine
+First, ensure your development environment has:
+
+1. Ruby (See [.ruby-version](./.ruby-version) for version)
+1. Node (See [.nvmrc](./.nvmrc) for version)
+1. [Yarn]
+1. [PostgreSQL 12]. (Note: For people using [Docker], a [docker-compose.yml]
+   file has been included for convenience.)
+
+Then, run `bin/setup` to install Ruby and Node dependencies and set up the
+database.
+
+Once setup completes, configure your local development environment.
+1. Open `convene-web/.env` and make any changes.
+1. Open `.env` and make any changes.
+
+Once you have completed configuration; run `bin/run`. You now should be able to open
+http://localhost:3000/spaces/system-test and see Convene.
+
+Finally, with the server still running (perhaps in a different terminal), run
+`bin/test` to ensure that your development environment is configured correctly.
+
+[PostgreSQL 12]: https://www.postgresql.org/download/
+[Docker]: https://www.docker.com
+[docker-compose.yml]: ../docker-compose.yml
+[.env.example]: ./.env.example
+[Yarn]: https://yarnpkg.com/getting-started/install
 
 ### 2.2. Testing Setup and Documentation.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,7 @@ Finally, with the server still running (perhaps in a different terminal), run
 
 [PostgreSQL 12]: https://www.postgresql.org/download/
 [Docker]: https://www.docker.com
-[docker-compose.yml]: ../docker-compose.yml
+[docker-compose.yml]: ./docker-compose.yml
 [.env.example]: ./.env.example
 [Yarn]: https://yarnpkg.com/getting-started/install
 

--- a/convene-web/README.md
+++ b/convene-web/README.md
@@ -51,31 +51,7 @@ _Last updated: April 2021_
 Original on Miro:  https://miro.com/app/board/o9J_lLrbz1g=/
 
 ## Configuring Your Development Machine
-
-First, ensure your development environment has:
-
-1. Ruby (See [.ruby-version](./.ruby-version) for version)
-1. Node (See [.nvmrc](./.nvmrc) for version)
-1. [Yarn]
-1. [PostgreSQL 12]. (Note: For people using [Docker], a [docker-compose.yml]
-   file has been included for convenience.)
-1. Copy `convene-web/.env.example` to `convene-web/.env` and make any changes: `cp convene-web/.env.example
-   convene-web/.env`.
-
-Then, run `bin/setup` to install Ruby and Node dependencies and set up the
-database.
-
-Once you have completed setup; run `bin/run`. You now should be able to open
-http://localhost:3000/spaces/system-test and see Convene.
-
-Finally, with the server still running (perhaps in a different terminal), run
-`bin/test` to ensure that your development environment is configured correctly.
-
-[PostgreSQL 12]: https://www.postgresql.org/download/
-[Docker]: https://www.docker.com
-[docker-compose.yml]: ../docker-compose.yml
-[.env.example]: ./.env.example
-[Yarn]: https://yarnpkg.com/getting-started/install
+See [Developer setup and documentation](../CONTRIBUTING.md#2-machine-setup).
 
 ### Debugger
 


### PR DESCRIPTION
move development documentation to a doc that makes it easier to find and makes more sense.