### PR TITLE
Replace phone icon with "open door" icon for the "Enter Room" button.

### DIFF
--- a/convene-web/app/javascript/src/components/icons.scss
+++ b/convene-web/app/javascript/src/components/icons.scss
@@ -1,8 +1,8 @@
 @layer components {
-  .phone-alt-icon::before {
+  .enter-room-icon::before {
     @apply mr-2;
     font-family: "Font Awesome 5 Free"; font-weight: 900;
-    content: "\f879";
+    content: "\f52b";
   }
 
   .configure-icon::before {

--- a/convene-web/app/views/spaces/_room_card.html.erb
+++ b/convene-web/app/views/spaces/_room_card.html.erb
@@ -11,7 +11,7 @@
   <footer>
     <div class="room-door_enter">
       <%= link_to space_room_path(room.space, room) do %>
-        <span class="phone-alt-icon">Enter Room</span>
+        <span class="enter-room-icon">Enter Room</span>
       <% end %>
     </div>
 


### PR DESCRIPTION
Small visual tweak, so that we no longer have a phone icon for rooms, since rooms might or might not have "call" capabilities.

Looks like this:
![Screen Shot 2021-05-08 at 3 26 11 PM](https://user-images.githubusercontent.com/6729309/117555216-19949580-b012-11eb-8aae-b00b87f3cdf7.png)
