### PR TITLE
Fix broken symbolic link for nvmrc

### DIFF
--- a/convene-web/.nvmrc
+++ b/convene-web/.nvmrc
@@ -1,1 +1,1 @@
-.nvmrc
+../.nvmrc


### PR DESCRIPTION
When working with CJ, we noticed that their environment was haivng some
weird issues. Turns out, the .nvmrc file in the convene-web directory
was not a valid symbolic link; which may have been throwing their
node-version manager for a loop.

Symbolic Links: https://www.lifewire.com/create-symbolic-links-ln-command-4059723