### PR TITLE
Small improvements to bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -3,7 +3,7 @@
 function install_package {
   echo "Attempting to install $1"
   output=$(command -v brew)
-  if [ -n $output ]; then
+  if [ -n "$output" ]; then
     echo "Installing $1 via homebrew"
     brew install $1
     return
@@ -16,9 +16,9 @@ function install_package {
 function setup_package {
   command_output=$(command -v $1)
   brew_output=$(brew ls --versions $1)
-  if [ -z $command_output ]; then
+  if [ -z "$command_output" ]; then
     echo "$1 command not detected, checking brew"
-    if [ -n $brew_output ]; then
+    if [ -z "$brew_output" ]; then
       echo "$1 not found, installing through Homebrew"
       install_package $1
     else

--- a/convene-web/bin/setup
+++ b/convene-web/bin/setup
@@ -20,10 +20,10 @@ FileUtils.chdir APP_ROOT do
   puts '== Installing JavaScript dependencies =='
   system!('bin/yarn')
 
-  # puts "\n== Copying sample files =="
-  # unless File.exist?('config/database.yml')
-  #   FileUtils.cp 'config/database.yml.sample', 'config/database.yml'
-  # end
+  puts "\n== Copying sample files =="
+  unless File.exist?('.env.example')
+    FileUtils.cp '.env.example', '.env'
+  end
 
   puts "\n== Preparing development database =="
   system! 'bin/rails db:prepare'
@@ -39,6 +39,5 @@ FileUtils.chdir APP_ROOT do
   system! 'bin/rails log:clear tmp:clear'
 
   puts "\n== Restarting application server =="
-
   system! 'bin/rails restart'
 end


### PR DESCRIPTION
This PR tweaks a couple of things I noticed re-setting this repo from scratch:
* make our string handling in bash resilient to the cases where `$brew_output` or `$command_output` might contain spaces
* fix the check for existence of `$brew_output` to check for an empty string (I believe this check was previously logically inverted)
* make `convene-web/bin/setup` make a copy of `.env.example` if there isn't an existing `.env`