### PR TITLE
Streamline Space and Room configuration

### DIFF
--- a/convene-web/app/javascript/src/components.scss
+++ b/convene-web/app/javascript/src/components.scss
@@ -10,6 +10,7 @@
 @import "./components/button";
 @import "./components/form";
 @import "./components/icons";
+@import "./components/breadcrumbs";
 
 /**
  * App Specific Components

--- a/convene-web/app/javascript/src/components/breadcrumbs.scss
+++ b/convene-web/app/javascript/src/components/breadcrumbs.scss
@@ -1,7 +1,5 @@
 @layer components {
   .breadcrumbs {
-    a {
-      @apply underline;
-    }
+    display: inline-block;
   }
 }

--- a/convene-web/app/javascript/src/components/icons.scss
+++ b/convene-web/app/javascript/src/components/icons.scss
@@ -1,14 +1,18 @@
 @layer components {
   .icon {
-    @apply mr-2;
-    text-decoration: none;
-    font-family: "Font Awesome 5 Free"; font-weight: 900;
+    display: inline-block;
 
     &.--enter::before {
+      @apply mr-2;
+      font-family: "Font Awesome 5 Free"; font-weight: 900;
       content: "\f52b";
+      text-underline: none;
     }
     &.--configure::before {
-      content: "\f013";
+      @apply mr-2;
+      font-family: "Font Awesome 5 Free"; font-weight: 900;
+      content: "\f013 ";
+      text-underline: none;
     }
   }
 }

--- a/convene-web/app/javascript/src/components/icons.scss
+++ b/convene-web/app/javascript/src/components/icons.scss
@@ -1,18 +1,18 @@
 @layer components {
   .icon {
     display: inline-block;
+    text-decoration: none;
+
+    &::before {
+      font-family: "Font Awesome 5 Free"; font-weight: 900;
+    }
 
     &.--enter::before {
-      @apply mr-2;
-      font-family: "Font Awesome 5 Free"; font-weight: 900;
       content: "\f52b";
-      text-underline: none;
     }
+
     &.--configure::before {
-      @apply mr-2;
-      font-family: "Font Awesome 5 Free"; font-weight: 900;
       content: "\f013 ";
-      text-underline: none;
     }
   }
 }

--- a/convene-web/app/javascript/src/components/icons.scss
+++ b/convene-web/app/javascript/src/components/icons.scss
@@ -1,19 +1,14 @@
 @layer components {
-  .enter-room-icon::before {
+  .icon {
     @apply mr-2;
+    text-decoration: none;
     font-family: "Font Awesome 5 Free"; font-weight: 900;
-    content: "\f52b";
-  }
 
-  .configure-icon::before {
-    @apply mr-2;
-    font-family: "Font Awesome 5 Free"; font-weight: 900;
-    content: "\f013";
-  }
-
-  .navigation-toggle::before {
-    @apply mr-2;
-    font-family: "Font Awesome 5 Free"; font-weight: 900;
-    content: "\f078"
+    &.--enter::before {
+      content: "\f52b";
+    }
+    &.--configure::before {
+      content: "\f013";
+    }
   }
 }

--- a/convene-web/app/javascript/src/components/icons.scss
+++ b/convene-web/app/javascript/src/components/icons.scss
@@ -8,7 +8,7 @@
   .configure-icon::before {
     @apply mr-2;
     font-family: "Font Awesome 5 Free"; font-weight: 900;
-    content: "\f7d9";
+    content: "\f013";
   }
 
   .navigation-toggle::before {

--- a/convene-web/app/views/application/_breadcrumbs.html.erb
+++ b/convene-web/app/views/application/_breadcrumbs.html.erb
@@ -1,0 +1,6 @@
+<div>
+  <%- if policy(current_space).edit? %>
+    <%= link_to "", edit_space_path(current_space), class: "icon --configure", aria_label: "Configure Space", role: "img" %>
+  <% end %>
+  <%= breadcrumbs container_tag: 'nav', fragment_class: 'crumb', separator: " &rsaquo; ", semantic: true, display_single_fragment: true %>
+</div>

--- a/convene-web/app/views/layouts/_header.html.erb
+++ b/convene-web/app/views/layouts/_header.html.erb
@@ -1,10 +1,12 @@
 <header>
   <%- if current_space.present? %>
     <div>
+      <%- if policy(current_space).edit? %>
+        <%= link_to "", edit_space_path(current_space), class: "icon --configure", aria_label: "Configure Space", role: "img" %>
+      <% end %>
       <%= breadcrumbs container_tag: 'nav' , fragment_class: 'crumb' , separator: " &rsaquo; " , semantic: true, display_single_fragment: true %>
     </div>
   <%- end %>
-
 
 
   <%- if Feature.enabled?(:identification) %>

--- a/convene-web/app/views/layouts/_header.html.erb
+++ b/convene-web/app/views/layouts/_header.html.erb
@@ -1,13 +1,5 @@
 <header>
-  <%- if current_space.present? %>
-    <div>
-      <%- if policy(current_space).edit? %>
-        <%= link_to "", edit_space_path(current_space), class: "icon --configure", aria_label: "Configure Space", role: "img" %>
-      <% end %>
-      <%= breadcrumbs container_tag: 'nav' , fragment_class: 'crumb' , separator: " &rsaquo; " , semantic: true, display_single_fragment: true %>
-    </div>
-  <%- end %>
-
+  <%= render partial: "breadcrumbs" %>
 
   <%- if Feature.enabled?(:identification) %>
     <nav aria-label="Menu" class="profile-menu">

--- a/convene-web/app/views/layouts/application.html.erb
+++ b/convene-web/app/views/layouts/application.html.erb
@@ -22,12 +22,13 @@
 
 
     <footer>
-      <%= breadcrumbs container_tag: 'nav', fragment_class: 'crumb', separator: " &rsaquo; ", semantic: true, display_single_fragment: true %>
-      <%- if policy(current_space).edit? %>
-        <%= link_to edit_space_path(current_space) do %>
-        <span class="icon --configure" aria-role="img" aria-label="Configure"></span>
+      <div>
+        <%- if policy(current_space).edit? %>
+          <%= link_to "", edit_space_path(current_space), class: "icon --configure", aria_label: "Configure Space", role: "img" %>
         <% end %>
-      <% end %>
+        <%= breadcrumbs container_tag: 'nav', fragment_class: 'crumb', separator: " &rsaquo; ", semantic: true, display_single_fragment: true %>
+      </div>
+
       <div class="branding">
         <h3>Convene<span class="tagline">: Space to Work, Play, or Simply Be</span></h3>
       </div>

--- a/convene-web/app/views/layouts/application.html.erb
+++ b/convene-web/app/views/layouts/application.html.erb
@@ -22,12 +22,7 @@
 
 
     <footer>
-      <div>
-        <%- if policy(current_space).edit? %>
-          <%= link_to "", edit_space_path(current_space), class: "icon --configure", aria_label: "Configure Space", role: "img" %>
-        <% end %>
-        <%= breadcrumbs container_tag: 'nav', fragment_class: 'crumb', separator: " &rsaquo; ", semantic: true, display_single_fragment: true %>
-      </div>
+      <%= render partial: "breadcrumbs" %>
 
       <div class="branding">
         <h3>Convene<span class="tagline">: Space to Work, Play, or Simply Be</span></h3>

--- a/convene-web/app/views/layouts/application.html.erb
+++ b/convene-web/app/views/layouts/application.html.erb
@@ -25,7 +25,7 @@
       <%= breadcrumbs container_tag: 'nav', fragment_class: 'crumb', separator: " &rsaquo; ", semantic: true, display_single_fragment: true %>
       <%- if policy(current_space).edit? %>
         <%= link_to edit_space_path(current_space) do %>
-        <span class="configure-icon" aria-role="img" aria-label="Configure"></span>
+        <span class="icon --configure" aria-role="img" aria-label="Configure"></span>
         <% end %>
       <% end %>
       <div class="branding">

--- a/convene-web/app/views/spaces/_room_card.html.erb
+++ b/convene-web/app/views/spaces/_room_card.html.erb
@@ -11,7 +11,7 @@
   <footer>
     <div class="room-door_enter">
       <%= link_to space_room_path(room.space, room) do %>
-        <span class="enter-room-icon">Enter Room</span>
+        <span class=".icon --enter">Enter Room</span>
       <% end %>
     </div>
 

--- a/convene-web/app/views/spaces/_room_card.html.erb
+++ b/convene-web/app/views/spaces/_room_card.html.erb
@@ -11,16 +11,8 @@
   <footer>
     <div class="room-door_enter">
       <%= link_to space_room_path(room.space, room) do %>
-        <span class="icon --enter">Enter Room</span>
+        <span class="icon --enter" role="img" aria-label="Enter <%= room.name %>">Enter Room</span>
       <% end %>
     </div>
-
-    <%- if Feature.enabled?(:configure_room) && policy(room).edit? %>
-      <div class="room-door_configure">
-        <%= link_to edit_space_room_path(room.space, room) do %>
-          <span class="icon --configure">Configure Room</span>
-        <% end %>
-      </div>
-    <% end %>
   </footer>
 </div>

--- a/convene-web/app/views/spaces/_room_card.html.erb
+++ b/convene-web/app/views/spaces/_room_card.html.erb
@@ -1,4 +1,4 @@
-<div class="room-card <%= "--#{room.access_level} --#{room.slug}"%>">
+<div data-access-level="<%= room.access_level %>" data-slug="<%= room.slug %>" data-model="room" data-id="<%= room.id%>" class="room-card">
   <header>
     <h3><%= room.name %></h3>
     <%- if room.locked? %>

--- a/convene-web/app/views/spaces/_room_card.html.erb
+++ b/convene-web/app/views/spaces/_room_card.html.erb
@@ -11,14 +11,14 @@
   <footer>
     <div class="room-door_enter">
       <%= link_to space_room_path(room.space, room) do %>
-        <span class=".icon --enter">Enter Room</span>
+        <span class="icon --enter">Enter Room</span>
       <% end %>
     </div>
 
     <%- if Feature.enabled?(:configure_room) && policy(room).edit? %>
       <div class="room-door_configure">
         <%= link_to edit_space_room_path(room.space, room) do %>
-          <span class="configure-icon">Configure Room</span>
+          <span class="icon --configure">Configure Room</span>
         <% end %>
       </div>
     <% end %>

--- a/convene-web/app/views/spaces/edit.html.erb
+++ b/convene-web/app/views/spaces/edit.html.erb
@@ -7,3 +7,23 @@
     <%- end %>
   <%- end %>
 </fieldset>
+
+
+<fieldset>
+  <h3>Rooms</h3>
+  <ul>
+    <%- space.rooms.each do |room| %>
+      <li>
+        <%= room.name %>
+        <%- if policy(room).edit? %>
+          <%= link_to edit_space_room_path(room.space, room) do %>
+            <span class="icon --configure"></span>Configure
+          <% end %>
+        <%- end %>
+        <%= link_to space_room_path(room.space, room) do %>
+          <span class="icon --enter"></span>Enter
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
+</fieldset>

--- a/convene-web/app/views/spaces/edit.html.erb
+++ b/convene-web/app/views/spaces/edit.html.erb
@@ -1,4 +1,19 @@
 <% breadcrumb :edit_space, space %>
+
+<fieldset>
+  <h3>Rooms</h3>
+
+    <%- space.rooms.each do |room| %>
+      <%- if policy(room).edit? %>
+        <p>
+          <%= link_to edit_space_room_path(room.space, room) do %>
+            <span class="icon --configure" role="img" aria-label="Configure"></span><%= room.name %>
+          <% end %>
+        </p>
+      <%- end %>
+    <% end %>
+</fieldset>
+
 <fieldset>
   <h3>Utility Hookups</h3>
   <%- space.utility_hookups.each do |utility_hookup| %>
@@ -6,24 +21,4 @@
     <%= render partial: "utility_hookups/form", locals: { utility_hookup: utility_hookup } %>
     <%- end %>
   <%- end %>
-</fieldset>
-
-
-<fieldset>
-  <h3>Rooms</h3>
-  <ul>
-    <%- space.rooms.each do |room| %>
-      <li>
-        <%= room.name %>
-        <%- if policy(room).edit? %>
-          <%= link_to edit_space_room_path(room.space, room) do %>
-            <span class="icon --configure"></span>Configure
-          <% end %>
-        <%- end %>
-        <%= link_to space_room_path(room.space, room) do %>
-          <span class="icon --enter"></span>Enter
-        <% end %>
-      </li>
-    <% end %>
-  </ul>
 </fieldset>

--- a/convene-web/app/views/spaces/edit.html.erb
+++ b/convene-web/app/views/spaces/edit.html.erb
@@ -5,7 +5,7 @@
 
     <%- space.rooms.each do |room| %>
       <%- if policy(room).edit? %>
-        <p>
+        <p data-access-level="<%=room.access_level %>" data-slug="<%=room.slug%>" data-model="room" data-id="<%=room.id%>">
           <%= link_to edit_space_room_path(room.space, room) do %>
             <span class="icon --configure" role="img" aria-label="Configure"></span><%= room.name %>
           <% end %>

--- a/convene-web/config/breadcrumbs.rb
+++ b/convene-web/config/breadcrumbs.rb
@@ -10,7 +10,7 @@ crumb :root do
 end
 
 crumb :edit_space do |space|
-  link 'Configure', edit_space_path(space)
+  link 'Configure Space', edit_space_path(space)
 end
 
 crumb :utility_hookups do |space|
@@ -33,7 +33,7 @@ end
 
 crumb :edit_room do |room|
   link "Configure #{room.name}", edit_space_room_path(room.space, room)
-  parent :room, room
+  parent :edit_space, room.space
 end
 
 crumb :waiting_room do |waiting_room|

--- a/convene-web/config/routes.rb
+++ b/convene-web/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
   resources :spaces, only: %I[show edit update] do
     resource :authenticated_session, only: %i[new create destroy show]
 
-    resources :rooms, only: %i[show edit update] do
+    resources :rooms, only: %i[show edit update new create] do
       resource :waiting_room, only: %i[show update]
       resources :furniture_placements, only: [:update]
       namespace :furniture do

--- a/features/harness/Component.js
+++ b/features/harness/Component.js
@@ -18,7 +18,7 @@ class Component {
   }
 
   /**
-   * @returns {Promise<Component>}
+   * @returns {Promise<this>}
    */
   click() {
     return this.el()
@@ -28,7 +28,7 @@ class Component {
 
   /**
    * @param {string} value
-   * @returns {Promise<Component>}
+   * @returns {Promise<this>}
    */
   fillIn(value) {
     return this.el()
@@ -39,7 +39,7 @@ class Component {
   /**
    *
    * @param {string} value
-   * @returns {Promise<Component>}
+   * @returns {Promise<this>}
    */
   select(value) {
     return this.click()
@@ -55,7 +55,7 @@ class Component {
   }
 
   /**
-   * @returns {Promise<Component>}
+   * @returns {Promise<this>}
    */
   submit() {
     return this.el()

--- a/features/harness/Page.js
+++ b/features/harness/Page.js
@@ -31,7 +31,7 @@ class Page {
 
   /**
    * Goes directly to the page, as defined in the path method.
-   * @returns {Promise<Page>}
+   * @returns {Promise<this>}
    */
   visit() {
     return this.driver.get(`${this.baseUrl}${this.path()}`).then(() => this);

--- a/features/harness/RoomCardComponent.js
+++ b/features/harness/RoomCardComponent.js
@@ -24,13 +24,13 @@ class RoomCardComponent extends Component {
     if (this._selector && this._selector.value) {
       return this._selector;
     }
-    const selectorParts = [".room-card"];
+    const selectorParts = ["*[data-model='room']"];
     if (this.room.slug) {
-      selectorParts.push(`.--${this.room.slug}`);
+      selectorParts.push(`[data-slug="${this.room.slug}"]`);
     }
 
     if (this.room.accessLevel) {
-      selectorParts.push(this.room.accessLevel.locator.value);
+      selectorParts.push(this.room.accessLevel.attributeSelector);
     }
 
     return (this.selector = By.css(selectorParts.join("")));
@@ -100,7 +100,7 @@ class RoomCardComponent extends Component {
    * @returns {Component}
    */
   configureRoomButton() {
-    return this.component(".room-door_configure");
+    return this.component(".--configure");
   }
 }
 

--- a/features/harness/RoomEditPage.js
+++ b/features/harness/RoomEditPage.js
@@ -9,7 +9,7 @@ class RoomEditPage extends Page {
 
   /**
    * @param {AccessCode} accessCode
-   * @returns {Promise<RoomEditPage>}
+   * @returns {Promise<this>}
    */
   async lock(accessCode) {
     await this.accessLevel().select("locked");
@@ -19,6 +19,10 @@ class RoomEditPage extends Page {
     return this;
   }
 
+  /**
+   * @param {AccessCode} accessCode
+   * @returns {Promise<this>}
+   */
   async unlock(accessCode) {
     const waitingRoom = new WaitingRoomPage(this.driver);
     await waitingRoom.submitAccessCode(accessCode);

--- a/features/harness/SpaceEditPage.js
+++ b/features/harness/SpaceEditPage.js
@@ -1,6 +1,7 @@
 const { ThenableWebDriver } = require("selenium-webdriver");
 const Page = require('./Page');
-const Component = require("./Component");
+const Room = require('../lib/Room');
+const RoomCardComponent = require("./RoomCardComponent");
 
 class SpaceEditPage extends Page {
   /**
@@ -17,6 +18,14 @@ class SpaceEditPage extends Page {
    */
   path() {
     return `/spaces/${this.space.slug}/edit`;
+  }
+
+  /**
+   * @param {Room} room
+   * @returns {RoomCardComponent}
+   */
+  roomCard(room) {
+    return new RoomCardComponent(this.driver, room);
   }
 
   /**

--- a/features/lib/AccessLevel.js
+++ b/features/lib/AccessLevel.js
@@ -8,7 +8,11 @@ class AccessLevel {
    * @returns {By}
    */
   get locator() {
-    return By.css(`.--${this.level.toLowerCase()}`)
+    return By.css(`*${this.attributeSelector}`);
+  }
+
+  get attributeSelector() {
+    return `[data-access-level="${this.level.toLowerCase()}"]`
   }
 }
 

--- a/features/lib/AccessLevel.js
+++ b/features/lib/AccessLevel.js
@@ -11,6 +11,10 @@ class AccessLevel {
     return By.css(`*${this.attributeSelector}`);
   }
 
+  /**
+   *
+   * @returns {string}
+   */
   get attributeSelector() {
     return `[data-access-level="${this.level.toLowerCase()}"]`
   }

--- a/features/steps/room_steps.js
+++ b/features/steps/room_steps.js
@@ -1,6 +1,6 @@
 const { Given, When, Then } = require("cucumber");
 
-const { SpacePage, RoomEditPage, RoomPage } = require("../harness/Pages");
+const { SpacePage, SpaceEditPage, RoomEditPage, RoomPage } = require("../harness/Pages");
 const { RoomCardComponent } = require("../harness/Components");
 const { Space, Room, Actor } = require("../lib");
 
@@ -41,9 +41,9 @@ When(
     const { space } = linkParameters({ room, accessLevel });
     await actor.signIn(this.driver, space)
 
-    return new SpacePage(this.driver, space)
+    return new SpaceEditPage(this.driver, space)
       .visit()
-      .then((spacePage) => spacePage.roomCard(room).configure())
+      .then((page) => page.roomCard(room).configure())
       .then((roomSettingsPage) => roomSettingsPage.unlock(accessCode));
   }
 );
@@ -54,9 +54,9 @@ When(
     const { space } = linkParameters({ accessLevel, room })
     await actor.signIn(this.driver, space)
 
-    return this.space
+    return new SpaceEditPage(this.driver, space)
       .visit()
-      .then((space) => space.roomCard(room).configure())
+      .then((page) => page.roomCard(room).configure())
       .then((roomSettingsPage) => roomSettingsPage.lock(accessCode));
   }
 );

--- a/features/steps/room_steps.js
+++ b/features/steps/room_steps.js
@@ -44,7 +44,7 @@ When(
     return new SpaceEditPage(this.driver, space)
       .visit()
       .then((page) => page.roomCard(room).configure())
-      .then((roomSettingsPage) => roomSettingsPage.unlock(accessCode));
+      .then((page) => page.unlock(accessCode));
   }
 );
 


### PR DESCRIPTION
Coops not cages wanted to update their content, but because they have an Unlisted Room as their Entrance Hall, there isn't any way for them to find the configure button!

We:

- Switched to a "Gear" for configure, which seems more in line with visual conventions
- Got our ass kicked by the CSS trying to get rid of the icon underline (But we did it!)
- Added a list of Rooms with links to Configure them on the Space Configuration page.
