### PR TITLE
Cache brew caches between CI runs

### DIFF
--- a/.github/workflows/test-convene-web.yml
+++ b/.github/workflows/test-convene-web.yml
@@ -74,7 +74,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ steps.brew-cache-path.outputs.path }}
-        key: ${{ runner.os }}-brew-${{ github.sha }}
+        key: ${{ runner.os }}-brew-${{ hashFiles('bin/setup') }}
         restore-keys: ${{ runner.os }}-brew-
 
     - name: Setup environment

--- a/.github/workflows/test-convene-web.yml
+++ b/.github/workflows/test-convene-web.yml
@@ -73,7 +73,7 @@ jobs:
     - name: Configure Homebrew cache
       uses: actions/cache@v2
       with:
-        path: ${{ steps.brew-cache-path.outputs.path }}/overmind*
+        path: ${{ steps.brew-cache-path.outputs.path }}
         key: ${{ runner.os }}-brew-${{ github.sha }}
         restore-keys: ${{ runner.os }}-brew-
 

--- a/.github/workflows/test-convene-web.yml
+++ b/.github/workflows/test-convene-web.yml
@@ -66,6 +66,17 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-yarn-
 
+    - name: Get brew cache path
+      id: brew-cache-path
+      run: echo "::set-output name=path::$(brew --cache)"
+
+    - name: Configure Homebrew cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.brew-cache-path.outputs.path }}/overmind*
+        key: ${{ runner.os }}-brew-${{ github.sha }}
+        restore-keys: ${{ runner.os }}-brew-
+
     - name: Setup environment
       run: |
           sudo chown -R $USER /usr/local/lib/node_modules

--- a/bin/setup
+++ b/bin/setup
@@ -32,7 +32,6 @@ function setup_package {
 ## SYSTEM LEVEL DEPENDENCIES ##
 setup_package "overmind"
 setup_package "yarn"
-setup_package "shared-mime-info"
 # Firefox web browser is used for interface testing.
 brew install --cask firefox
 yarn global add maildev


### PR DESCRIPTION
To speed up each run:
* cache the Homebrew cache between CI runs
* stop installing `shared-mime-info`, since we  no longer need it