### PR TITLE
117/start space invitations logic

### DIFF
--- a/convene-web/spec/requests/spaces/invitations_request_spec.rb
+++ b/convene-web/spec/requests/spaces/invitations_request_spec.rb
@@ -1,12 +1,36 @@
 require 'rails_helper'
 
 RSpec.describe "/spaces/:space_id/invitations", type: :request do
-  it "doesn't expose" do
+  it "created and sends an invitation for a space" do
     client = Client.create!
     space = Space.create!(:client => client, :name => "bar")
+    mail = double(deliver_now: true)
+    allow(SpaceInvitationMailer).to receive(:space_invitation_email).and_return(mail)
 
     post "/spaces/#{space.slug}/invitations", :params => { :invitation => {:name => "foobar", :email => "foobar@example.com"} }
-    expect(response).to redirect_to([space, space.invitations.find_by(name: 'foobar', email: 'foobar@example.com')])
-    expect(space.invitations.find_by(name: 'foobar', email: 'foobar@example.com')).to be_present
+
+    invitation = space.invitations.find_by(name: 'foobar', email: 'foobar@example.com')
+
+    expect(response).to redirect_to([space, invitation])
+    expect(invitation).to be_present
+
+    # TODO finish building logic to get below assertions to pass
+    # generate mailer and views
+    expect(SpaceInvitationMailer).to have_received(:space_invitation_email).with(invitation)
+    expect(mail).to have_received(:deliver_now)
+    expect(invitation.status).to eq("sent")
   end
+
+
+  # We decided that possible invitation status:
+  # pending - email was not sent yet
+  # sent - email was sent but not accepted
+  # accepted - reciever accepted it
+  # rejected - reciever rejected the invitation
+  # FUTURE: expired -
+  #
+  # ALL CREATE INVITATION SCENARIOS  - POST CALL
+  # invitation email is sent
+  #
+  # send invitation to same email if old one expired
 end

--- a/convene-web/spec/requests/spaces/invitations_request_spec.rb
+++ b/convene-web/spec/requests/spaces/invitations_request_spec.rb
@@ -21,16 +21,15 @@ RSpec.describe "/spaces/:space_id/invitations", type: :request do
     expect(invitation.status).to eq("sent")
   end
 
-
-  # We decided that possible invitation status:
-  # pending - email was not sent yet
+  # ------ #
+  # NOTES
+  # ------ #
+  # Kelly H, Zee, Egbet decided these are the possible invitation statuses:
+  # pending - email was not sent yet due to mailer issues etc.
   # sent - email was sent but not accepted
-  # accepted - reciever accepted it
-  # rejected - reciever rejected the invitation
-  # FUTURE: expired -
-  #
-  # ALL CREATE INVITATION SCENARIOS  - POST CALL
-  # invitation email is sent
-  #
-  # send invitation to same email if old one expired
+  # accepted - receiver accepted the invitation
+  # rejected - receivers rejected the invitation
+
+  # FUTURE STATUS AND TEST:
+  # expired status and tests for testing the possible scenarios
 end


### PR DESCRIPTION
Continued fleshing out the test for creating a space invitation.

- added validation for the space invitation record status.
- added validation for the sending of the space invitation email.
- discussed and fleshed out status types.