### PR TITLE
Remove deprecation warnings related to autoloading

### DIFF
--- a/convene-web/config/initializers/action_mailer.rb
+++ b/convene-web/config/initializers/action_mailer.rb
@@ -1,21 +1,23 @@
-if ENV["SMTP_ADDRESS"]
-  ActionMailer::Base.smtp_settings = {
-    address: ENV["SMTP_ADDRESS"],
-    domain: ENV["SMTP_DOMAIN"],
-    port: ENV["SMTP_PORT"].to_i,
-    user_name: ENV["SMTP_USERNAME"],
-    password: ENV["SMTP_PASSWORD"],
-    authentication: ENV["SMTP_AUTHENTICATION"]&.to_sym,
-    tls: ENV.fetch("SMTP_ENABLE_TLS", true) != "false",
-    enable_starttls_auto: ENV.fetch("SMTP_ENABLE_TLS", true) != "false"
-  }.compact
+Rails.application.reloader.to_prepare do
+  if ENV["SMTP_ADDRESS"]
+    ActionMailer::Base.smtp_settings = {
+      address: ENV["SMTP_ADDRESS"],
+      domain: ENV["SMTP_DOMAIN"],
+      port: ENV["SMTP_PORT"].to_i,
+      user_name: ENV["SMTP_USERNAME"],
+      password: ENV["SMTP_PASSWORD"],
+      authentication: ENV["SMTP_AUTHENTICATION"]&.to_sym,
+      tls: ENV.fetch("SMTP_ENABLE_TLS", true) != "false",
+      enable_starttls_auto: ENV.fetch("SMTP_ENABLE_TLS", true) != "false"
+    }.compact
 
-  ActionMailer::Base.delivery_method = :smtp
-end
+    ActionMailer::Base.delivery_method = :smtp
+  end
 
-if ENV["APP_ROOT_URL"]
-  root_uri = URI.parse(ENV["APP_ROOT_URL"])
-  ActionMailer::Base.default_url_options[:host] = root_uri.host
-  ActionMailer::Base.default_url_options[:port] = root_uri.port if root_uri.port != root_uri.default_port
-  ActionMailer::Base.default_url_options[:protocol] = root_uri.scheme
+  if ENV["APP_ROOT_URL"]
+    root_uri = URI.parse(ENV["APP_ROOT_URL"])
+    ActionMailer::Base.default_url_options[:host] = root_uri.host
+    ActionMailer::Base.default_url_options[:port] = root_uri.port if root_uri.port != root_uri.default_port
+    ActionMailer::Base.default_url_options[:protocol] = root_uri.scheme
+  end
 end


### PR DESCRIPTION
This change adds a `Rails.application.reloader.to_prepare do` around an initializer call to `ActionMailer::Base`. This removes the deprecation warning:
```
DEPRECATION WARNING: Initialization autoloaded the constants ActionText::ContentHelper and ActionText::TagHelper.
```

`Rails.application.reloader.to_prepare` is meant explicitly for autoloading during application boot, with the caveat that the contents of the block must be idempotent (which this code is) since it might be called twice. Rails docs: https://guides.rubyonrails.org/autoloading_and_reloading_constants.html#autoloading-when-the-application-boots

We still have a handful of errors `warning: already initialized constant` on startup, but that seems more innocuous and also harder to fix.