### PR TITLE
Finish transformation to Space Owner from Space Admin

### DIFF
--- a/features/space-membership.feature
+++ b/features/space-membership.feature
@@ -6,7 +6,7 @@ Feature: Space membership
 
   @unstarted @andromeda
   Scenario: Inviting Guests
-    When a Space Admin invites a Guest to be a Space Member via Email
+    When a Space Owner invites a Guest to be a Space Member via Email
     Then the Guest receives a Space Invitation Email
 
   @unstarted @andromeda
@@ -19,7 +19,7 @@ Feature: Space membership
   @unstarted @andromeda
   Scenario: Removing Space Members
     Given a Space with multiple Space Members
-    When the Space Admin removes a Space Member
+    When the Space Owner removes a Space Member
     Then that Space Member receives a Space Membership Revoked Email
     And the Space Member can still sign in
     And the Space Member is not a member of that Space
@@ -29,7 +29,7 @@ Feature: Space membership
   Scenario: Inviting Space Members who already have a convene account
 
   @unstarted
-  Scenario: Space Admin Knows When A Space Invitation Email Bounces
+  Scenario: Space Owner Knows When A Space Invitation Email Bounces
 
   @unstarted
   Scenario: Guest Accepts The Same Space Invitation Email Multiple Times

--- a/features/support/parameter-types/actors.js
+++ b/features/support/parameter-types/actors.js
@@ -3,8 +3,13 @@ const Actor = require('../../lib/Actor.js')
 
 // Actors are the people or sytems our test suite emulates as it
 // interacts with Convene.
+// We have several Actor types:
+// - Guest (Someone who is not authenticated within Convene)
+// - Neighbor (Someone who is authenticated within Convene, but not a Member of the Space)
+// - Space Member (Someone who is authenticated and is a Member of the Space)
+// - Space Owner (Someone who is authenticated and has moderator rights within the Space)
 defineParameterType({
   name: "actor",
-  regexp: /(Guest|Space Member|Space Admin)/,
+  regexp: /(Guest|Space Member|Space Owner|Neighbor)/,
   transformer: (type) => new Actor(type)
 });


### PR DESCRIPTION
I thought I had gotten all the "Space Admin" references from our Feature/Docs but alas, I had not. THis Also elaborates on the "Neighbor" actor, providing an affordance for test definitions between Space Member and Guest for navigating scenarios where that is a significant difference.
