### PR TITLE
Link "Convene" name in footer to Convene's landing page

### DIFF
--- a/convene-web/app/views/layouts/application.html.erb
+++ b/convene-web/app/views/layouts/application.html.erb
@@ -25,7 +25,9 @@
       <%= render partial: "breadcrumbs" %>
 
       <div class="branding">
-        <h3>Convene<span class="tagline">: Space to Work, Play, or Simply Be</span></h3>
+        <h3>
+          <%= link_to "Convene", "https://convene.zinc.coop/" %><span class="tagline">: Space to Work, Play, or Simply Be</span>
+        </h3>
       </div>
     </footer>
   </body>


### PR DESCRIPTION
Just a minimal change to make it possible for folks stumbling across a Convene space to know who is running this and maybe how to reach us.