### PR TITLE
Add Rails support to Solargraph

### DIFF
--- a/.solargraph.yml
+++ b/.solargraph.yml
@@ -1,0 +1,23 @@
+---
+include:
+- "**/*.rb"
+exclude:
+- spec/**/*
+- test/**/*
+- vendor/**/*
+- ".bundle/**/*"
+require: []
+domains: []
+reporters:
+- rubocop
+- require_not_found
+formatter:
+  rubocop:
+    cops: safe
+    except: []
+    only: []
+    extra_args: []
+require_paths: []
+plugins:
+  - solargraph-rails
+max_files: 5000


### PR DESCRIPTION
For those of us who use Solargraph for type-hinting, method definition / documentation previews and similar delightful features; you'll notice that Rails classes are often ... missing.

This should make that a little more consistent!

See:
- https://solargraph.org/guides/rails
- https://github.com/castwide/solargraph/issues/87
- https://github.com/iftheshoefritz/solargraph-rails