### PR TITLE
Make Blueprint more Idempotent

### DIFF
--- a/convene-web/app/models/blueprint.rb
+++ b/convene-web/app/models/blueprint.rb
@@ -29,7 +29,7 @@ class Blueprint
   def set_rooms
     space_attributes.fetch(:rooms, []).each do |room_attributes|
       room = space.rooms.find_or_initialize_by(name: room_attributes[:name])
-      room.update!(room_attributes.except(:name, :furniture_placements))
+      room.update!(room_attributes.merge(room.attributes.compact).except(:name, :furniture_placements))
       add_furniture(room, room_attributes)
     end
   end
@@ -40,7 +40,7 @@ class Blueprint
       furniture_placement = room.furniture_placements
                                 .find_or_initialize_by(slot: slot)
       furniture_placement
-        .update!(settings: furniture_placement.settings.merge(settings),
+        .update!(settings: settings.merge(furniture_placement.settings.compact),
                  furniture_kind: furniture)
     end
   end

--- a/convene-web/app/models/blueprint.rb
+++ b/convene-web/app/models/blueprint.rb
@@ -29,7 +29,7 @@ class Blueprint
   def set_rooms
     space_attributes.fetch(:rooms, []).each do |room_attributes|
       room = space.rooms.find_or_initialize_by(name: room_attributes[:name])
-      room.update!(room_attributes.merge(room.attributes.compact).except(:name, :furniture_placements))
+      room.update!(merge_non_empty(room_attributes, room.attributes).except(:name, :furniture_placements))
       add_furniture(room, room_attributes)
     end
   end
@@ -40,7 +40,7 @@ class Blueprint
       furniture_placement = room.furniture_placements
                                 .find_or_initialize_by(slot: slot)
       furniture_placement
-        .update!(settings: settings.merge(furniture_placement.settings.compact),
+        .update!(settings: merge_non_empty(settings, furniture_placement.settings),
                  furniture_kind: furniture)
     end
   end
@@ -49,7 +49,8 @@ class Blueprint
     space_attributes.fetch(:utility_hookups, []).each do |utility_hookup_attributes|
       utility_hookup = space.utility_hookups
                             .find_or_initialize_by(name: utility_hookup_attributes[:name])
-      utility_hookup.update!(utility_hookup_attributes.merge(utility_hookup.attributes.compact))
+
+      utility_hookup.update!(merge_non_empty(utility_hookup_attributes, utility_hookup.attributes))
     end
   end
 
@@ -84,6 +85,24 @@ class Blueprint
 
   def space_attributes
     client_attributes[:space]
+  end
+
+  # Normally, merge will clobber keys with values if there is a key with a nil
+  # or empty value. However, we don't want to do that here.
+  # @example
+  #   new = {  a: "ah", b: { c: :d } }
+  #   original = { "a" => nil, "b" => {} }
+  #   merge_non_empty(new, original)
+  #   # => { "a" => "ah", "b": { c: :d }}
+  private def merge_non_empty(left, right)
+    right = right.each_with_object({}) do |(k, v), r|
+      v = v.respond_to?(:compact) ? v.compact : v
+      next if v.blank?
+
+      r[k] = v
+    end.compact.with_indifferent_access
+
+    left.with_indifferent_access.merge(right.with_indifferent_access)
   end
 
   # @todo migrate this to a private configuration file!

--- a/convene-web/app/models/blueprint.rb
+++ b/convene-web/app/models/blueprint.rb
@@ -95,12 +95,9 @@ class Blueprint
   #   merge_non_empty(new, original)
   #   # => { "a" => "ah", "b": { c: :d }}
   private def merge_non_empty(left, right)
-    right = right.each_with_object({}) do |(k, v), r|
-      v = v.respond_to?(:compact) ? v.compact : v
-      next if v.blank?
-
-      r[k] = v
-    end.compact.with_indifferent_access
+    right.delete_if do |_key, value|
+      value.blank?
+    end
 
     left.with_indifferent_access.merge(right.with_indifferent_access)
   end

--- a/convene-web/app/models/blueprint.rb
+++ b/convene-web/app/models/blueprint.rb
@@ -49,7 +49,7 @@ class Blueprint
     space_attributes.fetch(:utility_hookups, []).each do |utility_hookup_attributes|
       utility_hookup = space.utility_hookups
                             .find_or_initialize_by(name: utility_hookup_attributes[:name])
-      utility_hookup.update!(utility_hookup_attributes)
+      utility_hookup.update!(utility_hookup_attributes.merge(utility_hookup.attributes.compact))
     end
   end
 

--- a/convene-web/app/models/utility_hookup.rb
+++ b/convene-web/app/models/utility_hookup.rb
@@ -18,6 +18,7 @@ class UtilityHookup < ApplicationRecord
   # Should match one of the keys in {Utilities::REGISTRY}
   # @return [String]
   attribute :utility_slug, :string
+  validates :utility_slug, presence: true
 
   # @return [String]
   attribute :status, :string, default: 'unavailable'

--- a/convene-web/spec/models/blueprint_spec.rb
+++ b/convene-web/spec/models/blueprint_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Blueprint do
+  EXAMPLE_CONFIG = {
+    client: {
+      name: 'Client A',
+      space: {
+        name: "Client A's Space",
+        members: [{ email: 'client-a@example.com' }],
+        rooms: [{
+          name: 'Room A',
+          access_level: :unlocked,
+          publicity_level: :listed
+        }],
+        utility_hookups: [
+          {
+            utility_slug: :plaid,
+            name: 'Plaid',
+            configuration: {}
+          }
+        ]
+      }
+    }
+  }.freeze
+  describe '#find_or_create' do
+    it 'respects the servers current settings' do
+      Blueprint.new(EXAMPLE_CONFIG).find_or_create!
+
+      space = Space.find_by(name: "Client A's Space")
+
+      # @todo add other examples of changing data after the
+      # blueprint has been applied
+      space.utility_hookups.first.update(utility_attributes: { client_id: '1234' })
+
+      Blueprint.new(EXAMPLE_CONFIG).find_or_create!
+
+      # @todo add other examples of confirming the changes
+      # were not overwritten
+      space.utility_hookups.reload
+      expect(space.utility_hookups.first.utility.client_id).to eql('1234')
+    end
+  end
+end

--- a/convene-web/spec/models/blueprint_spec.rb
+++ b/convene-web/spec/models/blueprint_spec.rb
@@ -12,7 +12,10 @@ RSpec.describe Blueprint do
         rooms: [{
           name: 'Room A',
           access_level: :unlocked,
-          publicity_level: :listed
+          publicity_level: :listed,
+          furniture_placements: {
+            markdown_text_block: { content: "Obi Swan Kenobi" }
+          }
         }],
         utility_hookups: [
           {
@@ -33,13 +36,16 @@ RSpec.describe Blueprint do
       # @todo add other examples of changing data after the
       # blueprint has been applied
       space.utility_hookups.first.update(utility_attributes: { client_id: '1234' })
+      space.rooms.update(publicity_level: :unlisted)
+      space.rooms.first.furniture_placements.first.update(furniture_attributes:{ content: "Hey there!" })
 
       Blueprint.new(EXAMPLE_CONFIG).find_or_create!
 
       # @todo add other examples of confirming the changes
       # were not overwritten
-      space.utility_hookups.reload
+      expect(space.rooms.reload.first).to be_unlisted
       expect(space.utility_hookups.first.utility.client_id).to eql('1234')
+      expect(space.rooms.first.furniture_placements.first.furniture.content).to eql("Hey there!")
     end
   end
 end

--- a/convene-web/spec/models/utility_hookup_spec.rb
+++ b/convene-web/spec/models/utility_hookup_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe UtilityHookup, type: :model do
+  it { is_expected.to validate_presence_of(:utility_slug) }
+
   describe '.new' do
     it 'accepts nested attributes for the utility' do
       uh = UtilityHookup.new(utility_slug: :jitsi, utility_attributes: { meet_domain: 'asdf' })


### PR DESCRIPTION
When running `bin/setup`, we re-apply the blueprint for the System Test space.

Thich was clobbering the Furniture Placements and Utility Hookups and other such changes.
Now it should not clobber changes made on the local system.