### PR TITLE
Update authentication guide to include one time code

### DIFF
--- a/convene-web/app/views/guides/_identification.md
+++ b/convene-web/app/views/guides/_identification.md
@@ -18,8 +18,9 @@ that [Neighborhood's] [Spaces].
 To switch from being a [Guest] to a [Neighbor], [Space Member], or [Space Owner]
 use the [Personal Navigation Menu] to sign in.
 
-You'll be asked to provide your email address, and follow the link we email you
-to confirm you are the person who has access to that email address.
+You'll be asked to provide your email address. Once you submit your email, we will
+email you with a link and a one time password. You may either enter the one time
+password or follow the link to confirm you are the owner of that email address.
 
 ### Set Up Your Profile
 

--- a/features/harness/SignInPage.js
+++ b/features/harness/SignInPage.js
@@ -13,8 +13,19 @@ class SignInPage extends Page {
   submitEmail(email) {
     return this.component("input[type=email]")
       .fillIn(email)
-      .then(() => this.component("input[type=submit]").click())
+      .then(() => this.submitButton().click())
       .then(() => this);
+  }
+
+  submitCode(code) {
+    return this.component('input[name="authenticated_session[one_time_password]"]')
+      .fillIn(code)
+      .then(() => this.submitButton().click())
+      .finally(() => this)
+  }
+
+  submitButton() {
+    return this.component("input[type=submit")
   }
 }
 

--- a/features/identification.feature
+++ b/features/identification.feature
@@ -77,13 +77,14 @@ Feature: Identification
     Then the Authenticated Person is treated as a Guest
 
   # An Emailed Code is a _Possession_ Verification Factor that demonstrates the
-  # person can at least _read_ the email address they are using to identiy
+  # person can at least _read_ the email address they are using to identify
   # themselves.
-  @built @unimplemented-steps
+  @built
   Scenario: Identity Verification via Emailed Code
-    Given a Guest has requested to Identify themselves via Email
-    When the Guest provides the Identification Code emailed to them
-    Then the Guest is Identified as themselves
+    Given an unauthenticated Space Member has requested to be identified via Email
+    When the unauthenticated Space Member provides the Identification Code emailed to them
+    Then the Space Member is Verified as the Owner of that Email Address
+    And the Space Member has become Authenticated
 
   @unstarted
   Scenario: People with Multiple Email Addresses

--- a/features/lib/Actor.js
+++ b/features/lib/Actor.js
@@ -41,6 +41,16 @@ class Actor {
   }
 
   /**
+   * The code a user can use to sign in
+   * @returns {Promise<string>}
+   */
+   async authenticationCode() {
+    const email = await this.emailServer().lastEmailTo(this.email);
+
+    return email.text.match(/password is (\d+)/)[1]
+  }
+
+  /**
    * @returns {Promise<MailServerEmail[]>}
    */
   emails() {

--- a/features/steps/identification_steps.js
+++ b/features/steps/identification_steps.js
@@ -31,6 +31,12 @@ When(
   }
 );
 
+When('the unauthenticated {actor} provides the Identification Code emailed to them', function (actor) {
+
+  return actor.authenticationCode()
+    .then((code) => new SignInPage(this.driver).submitCode(code))
+});
+
 When("the Authenticated Person Signs Out", function () {
   return this.actor.signOut(this.driver)
 });


### PR DESCRIPTION
See: https://github.com/zinc-collective/convene/issues/159

This also un-pends the feature tests, and updates the test harness to
expose affordances for signing in via one-time-code.