### PR TITLE
Add an `.editorconfig` and `tmp`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+[*.rb]
+indent_style = space
+indent_size = 2
+
+# Tab indentation (no size specified)
+[Makefile]
+indent_style = tab

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ convene-web/public/packs/
 *log/
 
 features/test_reports/*.png
+tmp/*


### PR DESCRIPTION
.editorconfig lets us do fancy pants stuff like ensure everyone uses
two spaces; instead of tabs. The `tmp` folder is mostly so we have a
place we can put stuff.