### PR TITLE
Warm the app server before running feature tests

### DIFF
--- a/.github/workflows/test-convene-web.yml
+++ b/.github/workflows/test-convene-web.yml
@@ -106,7 +106,7 @@ jobs:
           # To wait for asset built
           # TODO: Start server in production mode
           curl system-test.zinc.local:8080/packs/manifest.json 1> /dev/null
-          curl system-test.zinc.local:3000 1> /dev/null
+          curl system-test.zinc.local:80 1> /dev/null
           bin/test
 
     - uses: actions/upload-artifact@v2

--- a/.github/workflows/test-convene-web.yml
+++ b/.github/workflows/test-convene-web.yml
@@ -106,6 +106,7 @@ jobs:
           # To wait for asset built
           # TODO: Start server in production mode
           curl system-test.zinc.local:8080/packs/manifest.json 1> /dev/null
+          curl system-test.zinc.local 1> /dev/null
           bin/test
 
     - uses: actions/upload-artifact@v2

--- a/.github/workflows/test-convene-web.yml
+++ b/.github/workflows/test-convene-web.yml
@@ -106,7 +106,7 @@ jobs:
           # To wait for asset built
           # TODO: Start server in production mode
           curl system-test.zinc.local:8080/packs/manifest.json 1> /dev/null
-          curl system-test.zinc.local 1> /dev/null
+          curl system-test.zinc.local:3000 1> /dev/null
           bin/test
 
     - uses: actions/upload-artifact@v2


### PR DESCRIPTION
We keep having CI failures that appear to be caused by the application server not having actually started up. This should hit the server before hand to make sure rails finishes loading everything.