### PR TITLE
Simplify authoring of Parameter Types

### DIFF
--- a/features/harness/SignInPage.js
+++ b/features/harness/SignInPage.js
@@ -11,7 +11,6 @@ class SignInPage extends Page {
   }
 
   submitEmail(email) {
-    if(!email) { raise `WTF ${email}` }
     return this.component("input[type=email]")
       .fillIn(email)
       .then(() => this.submitButton().click())

--- a/features/harness/SignInPage.js
+++ b/features/harness/SignInPage.js
@@ -11,6 +11,7 @@ class SignInPage extends Page {
   }
 
   submitEmail(email) {
+    if(!email) { raise `WTF ${email}` }
     return this.component("input[type=email]")
       .fillIn(email)
       .then(() => this.submitButton().click())

--- a/features/lib/Actor.js
+++ b/features/lib/Actor.js
@@ -8,9 +8,9 @@ const MailServer = require("./MailServer");
 const Space = require("./Space");
 
 class Actor {
-  constructor(type) {
+  constructor(type, email) {
     this.type = type;
-    this.email = `${type.replace(/\s/g, "-").toLowerCase()}@example.com`;
+    this.email = email
   }
 
   /**

--- a/features/steps/room_steps.js
+++ b/features/steps/room_steps.js
@@ -18,8 +18,8 @@ const {
 
 const assert = require("assert").strict;
 
-Given("a Space with {accessLevel} {room}", async function (accessLevel, room) {
-  let { space } = linkParameters({ accessLevel, room });
+Given("{a} {space} with {a} {accessLevel} {room}", async function (_, space, _, accessLevel, room) {
+  linkParameters({ accessLevel, room, space });
   this.space = await new SpacePage(this.driver, space).visit();
   const matchingRooms = await this.space.roomCardsWhere({ accessLevel });
   if (!matchingRooms.length > 0) {
@@ -51,14 +51,9 @@ Given("a Space with {accessLevel} {room}", async function (accessLevel, room) {
   }
 });
 
-Given("a Space with an {publicityLevel} Room", function (publicityLevel) {
-  // Write code here that turns the phrase above into concrete actions
-  return "pending";
-});
-
 When(
-  "a {actor} unlocks {accessLevel} {room} with {accessCode}",
-  async function (actor, accessLevel, room, accessCode) {
+  "{a} {actor} unlocks {a} {accessLevel} {room} with {a} {accessCode}",
+  async function (_, actor, _, accessLevel, room, _, accessCode) {
     const { space } = linkParameters({ room, accessLevel });
     await actor.signIn(this.driver, space);
 
@@ -70,8 +65,8 @@ When(
 );
 
 When(
-  "a {actor} locks {accessLevel} {room} with {accessCode}",
-  async function (actor, accessLevel, room, accessCode) {
+  "{a} {actor} locks {a} {accessLevel} {room} with {a} {accessCode}",
+  async function (_, actor, _, accessLevel, room, _, accessCode) {
     const { space } = linkParameters({ accessLevel, room });
     await actor.signIn(this.driver, space);
 
@@ -97,16 +92,8 @@ Then("the {actor} is not placed in the {room}", function (actor, room) {
 });
 
 Then(
-  "a {actor} may enter the Room without providing {accessCode}",
-  function (actor, accessCode) {
-    // Write code here that turns the phrase above into concrete actions
-    return "pending";
-  }
-);
-
-Then(
-  "a {actor} may not enter {accessLevel} {room} after providing {accessCode}",
-  async function (actor, accessLevel, room, accessCode) {
+  "{a} {actor} may not enter {a} {accessLevel} {room} after providing {a} {accessCode}",
+  async function (_, actor, _, accessLevel, room, _, accessCode) {
     linkParameters({ room, accessLevel });
 
     await this.driver.manage().deleteAllCookies();
@@ -121,8 +108,8 @@ Then(
 );
 
 Then(
-  "a {actor} may enter {accessLevel} {room} after providing {accessCode}",
-  async function (actor, accessLevel, room, accessCode) {
+  "{a} {actor} may enter {a} {accessLevel} {room} after providing {a} {accessCode}",
+  async function (_, actor, _, accessLevel, room, _, accessCode) {
     linkParameters({ room, accessLevel, accessCode });
     await this.driver.manage().deleteAllCookies();
 
@@ -148,8 +135,7 @@ Then(
   }
 );
 
-Then("the Room {accessLevel}", async function (accessLevel) {
-  const room = new Room("");
+Then("{a} {room} is {accessLevel}", async function (_, room, accessLevel) {
   const { space } = linkParameters({ room, accessLevel });
   await new SpacePage(this.driver, space).visit();
   if (accessLevel.level === "Locked") {
@@ -160,8 +146,8 @@ Then("the Room {accessLevel}", async function (accessLevel) {
 });
 
 Then(
-  "the {actor} is informed they need to set {accessCode} when they are locking a {room}",
-  async function (actor, accessCode, room) {
+  "{a} {actor} is informed they need to set {a} {accessCode} when they are locking {a} {room}",
+  async function (_, actor, _, accessCode, _, room) {
     const roomSettingPage = new RoomEditPage(this.driver);
     assert(await roomSettingPage.accessCodeError());
   }

--- a/features/steps/room_steps.js
+++ b/features/steps/room_steps.js
@@ -23,7 +23,7 @@ Given("{a} {space} with {a} {accessLevel} {room}", async function (_, space, _, 
   this.space = await new SpacePage(this.driver, space).visit();
   const matchingRooms = await this.space.roomCardsWhere({ accessLevel });
   if (!matchingRooms.length > 0) {
-    const spaceMember = new Actor("Space Member");
+    const spaceMember = new Actor("Space Member", 'space-member@example.com');
     const page = await spaceMember
       .signIn(this.driver, space)
       .then(() => new SpaceEditPage(this.driver, space).visit());

--- a/features/steps/space_steps.js
+++ b/features/steps/space_steps.js
@@ -3,16 +3,19 @@ const { RoomPage, SpacePage, SpaceEditPage } = require("../harness/Pages");
 
 const { linkParameters } = require("../lib");
 
-Given('a Space', function() {
-  // This space intentionally left blank... For now...
-  // TODO: Create a Space for each test instead of re-using the
-  //       System Test Space
+Given('{a} {space}', function(_, space) {
+  // @todo eventually let's hit an endpoint or create a Space with a factory
+  return true
 })
 
 Given('a Space with a Room', function() {
   // This space intentionally left blank... For now...
   // TODO: Create a Space for each test instead of re-using the
   //       System Test Space
+})
+
+Given('{a} {space} has {a} {actor}', function(_, space, _, actor) {
+  return true
 })
 
 Given('the {actor} is on the {space} Dashboard', async function (actor, space) {

--- a/features/steps/utility_hookup_steps.js
+++ b/features/steps/utility_hookup_steps.js
@@ -5,7 +5,7 @@ const { Actor, Space } = require("../lib");
 
 
 When("a Space Owner adds a Hookup to their Space", async function () {
-  this.actor = new Actor("Space Owner");
+  this.actor = new Actor("Space Owner", 'space-owner@example.com');
   await this.actor.signIn(this.driver);
   this.space = new Space("System Test");
 

--- a/features/support/parameter-types/accessCode.js
+++ b/features/support/parameter-types/accessCode.js
@@ -1,0 +1,8 @@
+const { defineParameterType } = require("@cucumber/cucumber");
+const { AccessCode } = require("../../lib");
+
+defineParameterType({
+  name: "accessCode",
+  regexp:/(correct |valid |wrong |empty )?Access Code/,
+  transformer: (validity = "") => new AccessCode(validity.trim()),
+});

--- a/features/support/parameter-types/accessLevel.js
+++ b/features/support/parameter-types/accessLevel.js
@@ -1,0 +1,11 @@
+const { AccessLevel } = require("../../lib");
+const { defineParameterType } = require("@cucumber/cucumber");
+
+// This matches steps based on the access control model
+// See: https://github.com/zinc-collective/convene/issues/40
+// See: https://github.com/zinc-collective/convene/issues/41
+defineParameterType({
+  name: "accessLevel",
+  regexp: /(Unlocked|Internal|Locked)/,
+  transformer: (level) => new AccessLevel(level),
+});

--- a/features/support/parameter-types/actor.js
+++ b/features/support/parameter-types/actor.js
@@ -10,6 +10,11 @@ const Actor = require('../../lib/Actor.js')
 // - Space Owner (Someone who is authenticated and has moderator rights within the Space)
 defineParameterType({
   name: "actor",
-  regexp: /(Guest|Space Member|Space Owner|Neighbor)/,
-  transformer: (type) => new Actor(type)
+  regexp: /(Guest|Space Member|Space Owner|Neighbor)( ".*")?/,
+  transformer: function(type, email) {
+    email = email || `${type.toLowerCase()
+      .replace(/\s/, '-')}@example.com`
+      .replace(/"/g,'')
+    return new Actor(type, email)
+  }
 });

--- a/features/support/parameter-types/articleAdjective.js
+++ b/features/support/parameter-types/articleAdjective.js
@@ -1,0 +1,6 @@
+const { defineParameterType } = require("@cucumber/cucumber");
+
+defineParameterType({
+  name: "a",
+  regexp: /(a|an|the)/,
+});

--- a/features/support/parameter-types/publicityLevel.js
+++ b/features/support/parameter-types/publicityLevel.js
@@ -1,0 +1,14 @@
+const { defineParameterType } = require("@cucumber/cucumber");
+
+// Defines whether a Room may be discovered or not.
+// See: https://github.com/zinc-collective/convene/issues/39
+defineParameterType({
+  name: "publicityLevel",
+  regexp: /(Unlisted|Listed)/,
+});
+
+class PublicityLevel {
+  constructor(level) {
+    this.level = level;
+  }
+}

--- a/features/support/parameter-types/room.js
+++ b/features/support/parameter-types/room.js
@@ -1,7 +1,6 @@
 const { defineParameterType } = require("@cucumber/cucumber");
 const { By } = require("selenium-webdriver");
-const { Room, AccessLevel, AccessCode, concatRegExp } = require("../../lib");
-const FLEXIBLE_ARTICLE_ADJECTIVES = /(an |the |is |a )/;
+const { Room } = require("../../lib");
 
 // This injects a Room class into steps with named rooms (i.e.) `the "Ada" Room` and
 // steps that mention `Room` in isolation.
@@ -21,38 +20,4 @@ defineParameterType({
   // class has a string provided to it.
   regexp: /("[^"]*" )?(Room)/,
   transformer: (roomName = "") => new Room(roomName.trim().replace(/"/g, "")),
-});
-
-// This matches steps based on the access control model
-// See: https://github.com/zinc-collective/convene/issues/40
-// See: https://github.com/zinc-collective/convene/issues/41
-defineParameterType({
-  name: "accessLevel",
-  regexp: concatRegExp(
-    FLEXIBLE_ARTICLE_ADJECTIVES,
-    /(Unlocked|Internal|Locked)/
-  ),
-  transformer: (_, level) => new AccessLevel(level),
-});
-
-// Defines whether a Room may be discovered or not.
-// See: https://github.com/zinc-collective/convene/issues/39
-defineParameterType({
-  name: "publicityLevel",
-  regexp: /(Unlisted|Listed)/,
-});
-
-class PublicityLevel {
-  constructor(level) {
-    this.level = level;
-  }
-}
-
-defineParameterType({
-  name: "accessCode",
-  regexp: concatRegExp(
-    FLEXIBLE_ARTICLE_ADJECTIVES,
-    /(correct |valid |wrong |empty )?Access Code/
-  ),
-  transformer: (_, validity = "") => new AccessCode(validity.trim()),
 });

--- a/features/support/parameter-types/space.js
+++ b/features/support/parameter-types/space.js
@@ -6,7 +6,6 @@ const Space = require('../../lib/Space');
 // isolation.
 defineParameterType({
   name: "space",
-  regexp: /"([^"]*)" ?Space/,
-  transformer: (space) => new Space(space),
+  regexp: /(".*" )?Space/,
+  transformer: (name = "System Test") => new Space(name.trim().replace(/\"/g,'')),
 });
-


### PR DESCRIPTION
Previously, we were including article ajdectives in our paramater type
matches. This was convenient, because we could write Gherkin where "an"
or "the" or "a" was interchangable, hooray!

However, it was also a bit of a pain because each parameter type wound
up wanting these article adjectives, which meant more complex regexes.
And the more complex regex's meant translating between Gherkin and step
definition became more difficult as well.

This introduces an `a` paramater type; so that steps can Gherkin can be
written with either `a` or `an` or `the` and still get matched to the
appropriate step definition; but without requiring each parameter type
to include it.

Co-authored-by: CJ Joulain <cjoulain@users.noreply.github.com>
Co-authored-by: Kelly Hong <KellyAH@users.noreply.github.com>