### PR TITLE
Remove unused access_level and access_code from Space and SpaceMembership

### DIFF
--- a/app/models/blueprint.rb
+++ b/app/models/blueprint.rb
@@ -109,7 +109,6 @@ class Blueprint
       space: {
         members: [{ email: 'zee@zinc.coop' }, { email: 'cheryl@zinc.coop' }],
         name: 'Zinc', branded_domain: 'meet.zinc.coop',
-        access_level: :unlocked,
         entrance: 'lobby',
         utility_hookups: [
           {

--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -44,23 +44,7 @@ class Space < ApplicationRecord
 
   belongs_to :entrance, class_name: 'Room', optional: true
 
-  # A Space's Access Level indicates what a participant must know in order to gain access.
-  # `unlocked` The participant does not need to know anything to gain access.
-  # `locked` Participants must know the Space's `access_code` to gain access.
-  attribute :access_level, :string
-
-  # A room's Access Code is a "secret" that, when known, grants access to the room.
-  attribute :access_code, :string
-
   scope :default, -> { friendly.find(Neighborhood.config.default_space_slug) }
-
-  def unlocked?
-    access_level&.to_sym != :locked
-  end
-
-  def locked?
-    access_level&.to_sym == :locked
-  end
 
   # @see {Utilities}
   # @see {UtilityHookup}

--- a/app/models/system_test_space.rb
+++ b/app/models/system_test_space.rb
@@ -28,7 +28,6 @@ class SystemTestSpace
       { utility_slug: :jitsi, name: 'Jitsi', configuration:
         { meet_domain: 'convene-videobridge-zinc.zinc.coop' } }
     ],
-    access_level: :unlocked,
     members: [{ email: 'space-owner@example.com' },
               { email: 'space-member@example.com' }],
     rooms: [

--- a/db/migrate/20211106220854_remove_space_access_level_code.rb
+++ b/db/migrate/20211106220854_remove_space_access_level_code.rb
@@ -1,0 +1,6 @@
+class RemoveSpaceAccessLevelCode < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :spaces, :access_level, :string
+    remove_column :spaces, :access_code, :string
+  end
+end

--- a/db/migrate/20211106222232_remove_access_code_from_memberships.rb
+++ b/db/migrate/20211106222232_remove_access_code_from_memberships.rb
@@ -1,0 +1,5 @@
+class RemoveAccessCodeFromMemberships < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :space_memberships, :access_code, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_06_220854) do
+ActiveRecord::Schema.define(version: 2021_11_06_222232) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -113,7 +113,6 @@ ActiveRecord::Schema.define(version: 2021_11_06_220854) do
   create_table "space_memberships", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "member_id"
     t.uuid "space_id"
-    t.string "access_code"
     t.index ["member_id"], name: "index_space_memberships_on_member_id"
     t.index ["space_id"], name: "index_space_memberships_on_space_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_11_011702) do
+ActiveRecord::Schema.define(version: 2021_11_06_220854) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -122,8 +122,6 @@ ActiveRecord::Schema.define(version: 2021_10_11_011702) do
     t.uuid "client_id"
     t.string "jitsi_meet_domain"
     t.string "name"
-    t.string "access_level"
-    t.string "access_code"
     t.string "slug"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/spec/models/demo_space_spec.rb
+++ b/spec/models/demo_space_spec.rb
@@ -9,8 +9,6 @@ RSpec.describe DemoSpace, type: :model do
         demo_space = DemoSpace.prepare
         aggregate_failures do
           expect(demo_space).to be_persisted
-          expect(demo_space).to be_unlocked
-          expect(demo_space.access_code).to be_nil
           expect(demo_space.name).to eql("Convene Demo")
           expect(demo_space.slug).to eql("convene-demo")
           expect(demo_space.jitsi_meet_domain).to eql("convene-videobridge-zinc.zinc.coop")


### PR DESCRIPTION
To simplify and clarify things a bit.