### PR TITLE
Something is causing method / constant lookup to go sideways

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -260,7 +260,7 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.4.2)
+    zeitwerk (2.5.1)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
Errors like `Superclass Mismatch` and `undefined method app_views_...`
are getting thrown every which way in a few hours of coding. I don't
quite get why this is, but I am hopeful that upgradine zeitwerk may
help?

Alternatively, we may want to dig into puma?