### PR TITLE
Unlisted rooms should still be accessible to everyone...

### DIFF
--- a/app/policies/room_policy.rb
+++ b/app/policies/room_policy.rb
@@ -20,7 +20,7 @@ class RoomPolicy < ApplicationPolicy
 
   class Scope < ApplicationScope
     def resolve
-      scope.listed
+      scope.all
     end
   end
 end

--- a/spec/factories/room.rb
+++ b/spec/factories/room.rb
@@ -8,6 +8,14 @@ FactoryBot.define do
       access_level { :internal }
     end
 
+    trait :listed do
+      publicity_level { 'listed' }
+    end
+
+    trait :unlisted do
+      publicity_level { 'unlisted' }
+    end
+
     trait :locked do
       access_level { :locked }
       access_code { 'secret' }

--- a/spec/policies/room_policy_spec.rb
+++ b/spec/policies/room_policy_spec.rb
@@ -42,4 +42,23 @@ RSpec.describe RoomPolicy do
     it { is_expected.to permit(member, room) }
     it { is_expected.not_to permit(non_member, room) }
   end
+
+  describe RoomPolicy::Scope do
+    it "includes all the rooms" do
+      space = create(:space)
+      internal_room = create(:room, :internal, space: space)
+      locked_room = create(:room, :locked, space: space)
+      unlocked_room = create(:room, :unlocked, space: space)
+      listed_room = create(:room, :listed, space: space)
+      unlisted_room = create(:room, :unlisted, space: space)
+
+      results = RoomPolicy::Scope.new(nil, space.rooms).resolve
+
+      expect(results).to include(internal_room)
+      expect(results).to include(locked_room)
+      expect(results).to include(unlocked_room)
+      expect(results).to include(unlisted_room)
+      expect(results).to include(listed_room)
+    end
+  end
 end


### PR DESCRIPTION
...just hidden from view.

See: https://github.com/zinc-collective/convene/issues/440

I can imagine a universe where 'listed' and 'unlisted' go away; and
instead the room picker becomes a piece of furniture that may or may not
be added, and tailored to show particular rooms.

However, in the meantime we do want to let people access unlisted rooms.