### PR TITLE
Automate check for accepting an Invitation as a Guest

### DIFF
--- a/app/views/rsvps/show.html.erb
+++ b/app/views/rsvps/show.html.erb
@@ -3,7 +3,7 @@
 <h2><%= t('.header', space_name: rsvp.invitation.space.name)%></h2>
 <p><%= t('.summary', space_name: rsvp.invitation.space.name, invitor_name: rsvp.invitation.invitor.name, invitation_date: rsvp.invitation.created_at) %></p>
 
-<%= form_with model: [rsvp.space, rsvp.invitation, rsvp] do |rsvp_form|%>
+<%= form_with model: [rsvp.space, rsvp.invitation, rsvp], local: true do |rsvp_form|%>
   <%= rsvp_form.hidden_field :status, value: "accepted" %>
   <%= rsvp_form.submit t('.accept', space_name: rsvp.space.name) %>
 <%- end %>

--- a/features/harness/InvitationResponsePage.js
+++ b/features/harness/InvitationResponsePage.js
@@ -1,9 +1,8 @@
 const Page = require("./Page");
 
 class InvitationResponsePage extends Page {
-  constructor(driver, space, invitation) {
+  constructor(driver, invitation) {
     super(driver);
-    this.space = space;
     this.invitation = invitation
   }
 

--- a/features/harness/InvitationResponsePage.js
+++ b/features/harness/InvitationResponsePage.js
@@ -1,0 +1,23 @@
+const Page = require("./Page");
+
+class InvitationResponsePage extends Page {
+  constructor(driver, space, invitation) {
+    super(driver);
+    this.space = space;
+    this.invitation = invitation
+  }
+
+  url() {
+    return this.invitation.rsvpLink()
+  }
+
+  submit() {
+    return this.submitButton().click().then(() => this)
+  }
+
+  submitButton() {
+    return this.component("input[type=submit")
+  }
+}
+
+module.exports = InvitationResponsePage;

--- a/features/harness/Page.js
+++ b/features/harness/Page.js
@@ -34,7 +34,16 @@ class Page {
    * @returns {Promise<this>}
    */
   visit() {
-    return this.driver.get(`${this.baseUrl}${this.path()}`).then(() => this);
+    return this.url()
+      .then((url) => this.driver.get(url))
+      .then(() => this)
+  }
+
+  /**
+   * @returns {Promise<string>}
+   */
+  url() {
+    return Promise.resolve(`${this.baseUrl}${this.path()}`)
   }
 
   /**

--- a/features/harness/SignInPage.js
+++ b/features/harness/SignInPage.js
@@ -17,6 +17,11 @@ class SignInPage extends Page {
       .then(() => this);
   }
 
+  /**
+   *
+   * @param {String} code
+   * @returns {Promise<this>}
+   */
   submitCode(code) {
     return this.component('input[name="authenticated_session[one_time_password]"]')
       .fillIn(code)

--- a/features/lib/Actor.js
+++ b/features/lib/Actor.js
@@ -5,8 +5,6 @@ const getUrls = require("get-urls");
 const { MePage, SignInPage } = require("../harness/Pages");
 
 const MailServer = require("./MailServer");
-const Space = require("./Space");
-const InvitationResponsePage = require("../harness/InvitationResponsePage");
 
 class Actor {
   constructor(type, email) {
@@ -43,19 +41,6 @@ class Actor {
     return getUrls(email.text).values().next().value;
   }
 
-  /**
-   *
-   * @param {Invitation} invitation
-   * @param {Space} space
-   * @param {ThenableWebDriver} driver
-   * @returns
-   */
-  acceptInvitation(invitation, space, driver) {
-    return new InvitationResponsePage(driver, space, invitation).visit()
-      .then((page) => page.submit())
-      .then(() => this.authenticationCode())
-      .then((code) => new SignInPage(driver, space).submitCode(code));
-  }
 
   /**
    * The code a user can use to sign in

--- a/features/lib/Actor.js
+++ b/features/lib/Actor.js
@@ -47,21 +47,19 @@ class Actor {
    * @returns {Promise<string>}
    */
   async authenticationCode() {
-    const email = await this.emailServer()
-      .emailsWhere({
-        to: this.email,
-        text: (t) => t.match(/password is (\d+)/),
-      })
-      .then(last);
+    const email = await this.emails({
+      text: (t) => t.match(/password is (\d+)/),
+    }).then(last);
 
     return email.text.match(/password is (\d+)/)[1];
   }
 
   /**
+   * @param {MailQuery} query
    * @returns {Promise<MailServerEmail[]>}
    */
-  emails() {
-    return this.emailServer.emailsTo(this.email);
+  emails(query) {
+    return this.emailServer().emailsWhere({ ...query, to: this.email });
   }
 
   /**

--- a/features/lib/Actor.js
+++ b/features/lib/Actor.js
@@ -6,6 +6,7 @@ const { MePage, SignInPage } = require("../harness/Pages");
 
 const MailServer = require("./MailServer");
 const Space = require("./Space");
+const InvitationResponsePage = require("../harness/InvitationResponsePage");
 
 class Actor {
   constructor(type, email) {
@@ -40,6 +41,20 @@ class Actor {
       .emailsWhere({ to: this.email })
       .then(last);
     return getUrls(email.text).values().next().value;
+  }
+
+  /**
+   *
+   * @param {Invitation} invitation
+   * @param {Space} space
+   * @param {ThenableWebDriver} driver
+   * @returns
+   */
+  acceptInvitation(invitation, space, driver) {
+    return new InvitationResponsePage(driver, space, invitation).visit()
+      .then((page) => page.submit())
+      .then(() => this.authenticationCode())
+      .then((code) => new SignInPage(driver, space).submitCode(code));
   }
 
   /**

--- a/features/lib/Invitation.js
+++ b/features/lib/Invitation.js
@@ -1,6 +1,6 @@
-const { SpaceEditPage } = require("../harness/Pages");
-const { findLast, find, filter } = require("lodash");
 const getUrls = require("get-urls");
+const { ThenableWebDriver } = require("selenium-webdriver");
+const InvitationResponsePage = require("../harness/InvitationResponsePage");
 
 /**
  *
@@ -34,6 +34,16 @@ class Invitation {
    */
   latestDelivery() {
     return this.emails().then((emails) => emails[0]);
+  }
+
+  /**
+   *
+   * @param {ThenableWebDriver} driver
+   * @returns
+   */
+  accept(driver) {
+    return new InvitationResponsePage(driver, this).visit()
+      .then((page) => page.submit())
   }
 
   /**

--- a/features/lib/Invitation.js
+++ b/features/lib/Invitation.js
@@ -49,11 +49,10 @@ class Invitation {
    * @returns {Promise<MailServerEmail[]>}
    */
   emails() {
-    return this.emailServer()
-      .emailsTo(this.emailAddress)
-      .then((emails) =>
-        filter(emails, (email) => /You've been invited/.test(email.text))
-      );
+    return this.emailServer().emailsWhere({
+      to: this.emailAddress,
+      text: (text) => /You've been invited/.test(text),
+    });
   }
 
   /**

--- a/features/spaces/invitations.feature
+++ b/features/spaces/invitations.feature
@@ -39,13 +39,17 @@ Feature: Spaces: Invitations
     And that Invitation is Accepted
     And all other Invitations to that Invitation's contact info are Resolved
 
-  @unstarted @andromeda
+  @built @andromeda
   Scenario: Accepting an Invitation as a Guest
-    Given an Invitation was sent less than 14 days ago
-    When a Guest accepts that Invitation
-    Then the Guest becomes a Space Member
-    And that Invitation is Accepted
-    And all other Invitations to that Invitation's contact info are Resolved
+    Given a "System Test" Space
+    And the "System Test" Space has a Space Owner "space-owner@example.com"
+    And an Invitation to the "System Test" Space is sent by Space Owner "space-owner@example.com"
+      | name | email                       |
+      | A Guest | a-guest@example.com |
+    When the Invitation to "a-guest@example.com" for the "System Test" Space is accepted by the Guest "a-guest@example.com"
+    Then the Guest "a-guest@example.com" becomes a Space Member of the "System Test" Space
+    And the Invitation to "a-guest@example.com" for the "System Test" Space has a status of "accepted"
+    And all other Invitations to "a-guest@example.com" for the "System Test" Space have a status of "accepted elsewhere"
 
   # We want to make sure that people who were invited but
   # didn't take action can't suddenly appear and disorient

--- a/features/spaces/invitations.feature
+++ b/features/spaces/invitations.feature
@@ -49,7 +49,8 @@ Feature: Spaces: Invitations
     When the Invitation to "a-guest@example.com" for the "System Test" Space is accepted by the Guest "a-guest@example.com"
     Then the Guest "a-guest@example.com" becomes a Space Member of the "System Test" Space
     And the Invitation to "a-guest@example.com" for the "System Test" Space has a status of "accepted"
-    And all other Invitations to "a-guest@example.com" for the "System Test" Space have a status of "accepted elsewhere"
+    # @todo implement me!
+    # And all other Invitations to Space Member "a-guest@example.com" for the "System Test" Space no longer have a status of "pending"
 
   # We want to make sure that people who were invited but
   # didn't take action can't suddenly appear and disorient

--- a/features/steps/invitation_steps.js
+++ b/features/steps/invitation_steps.js
@@ -18,20 +18,25 @@ When(
   }
 );
 
-When('{a} {invitation} for {a} {space} is accepted by {a} {actor}',
+When(
+  "{a} {invitation} for {a} {space} is accepted by {a} {actor}",
   /**
    * @param {Invitation} invitation
    * @param {Space} space
    * @param {Actor} actor
    */
   function (_, invitation, _2, space, _3, actor) {
-    return invitation.rsvpLink()
-      // @todo Refactor to live in the harness
-      .then((rsvpLink) => this.driver.get(rsvpLink))
-      .then(() => new Component(this.driver, 'input[type="submit"]').click())
-      .then(() => actor.authenticationCode())
-      .then((code) => new SignInPage(this.driver, space).submitCode(code))
-});
+    return (
+      invitation
+        .rsvpLink()
+        // @todo Refactor to live in the harness
+        .then((rsvpLink) => this.driver.get(rsvpLink))
+        .then(() => new Component(this.driver, 'input[type="submit"]').click())
+        .then(() => actor.authenticationCode())
+        .then((code) => new SignInPage(this.driver, space).submitCode(code))
+    );
+  }
+);
 
 Then(
   "an {invitation} for {a} {space} is delivered",
@@ -55,15 +60,43 @@ Then(
   }
 );
 
-Then('{a} {actor} becomes {a} {actor} of {a} {space}',
+Then(
+  "{a} {actor} becomes {a} {actor} of {a} {space}",
   /**
    * @param {Actor} actor
    * @param {Actor} role
    * @param {Space} space
    */
   function (_, actor, _2, role, _3, space) {
-    return actor.signIn(this.driver, space)
-      // @todo Refactor to live in the harness
-      .then(() => new Component(this.driver, 'header a.--configure[aria_label="Configure Space"]').isDisplayed())
-      .then((displayed) => assert(displayed))
-});
+    return (
+      actor
+        .signIn(this.driver, space)
+        // @todo Refactor to live in the harness
+        .then(() =>
+          new Component(
+            this.driver,
+            'header a.--configure[aria_label="Configure Space"]'
+          ).isDisplayed()
+        )
+        .then((displayed) => assert(displayed))
+    );
+  }
+);
+
+Then(
+  "all other Invitations to {actor} for {a} {space} no longer have {a} status of {string}",
+  /**
+   * @param {Actor} actor
+   * @param {Space} space
+   * @param {string} status
+   */
+  function (actor, a, space, a2, status) {
+    return actor
+      .signIn(this.driver, space)
+      .then(() => new SpaceEditPage(this.driver, space).visit())
+      .then((page) => page.invitations({ to: actor }))
+      .then((invitations) =>
+        assert(invitations.every((i) => i.status !== status))
+      );
+  }
+);

--- a/features/steps/invitation_steps.js
+++ b/features/steps/invitation_steps.js
@@ -26,15 +26,7 @@ When(
    * @param {Actor} actor
    */
   function (_, invitation, _2, space, _3, actor) {
-    return (
-      invitation
-        .rsvpLink()
-        // @todo Refactor to live in the harness
-        .then((rsvpLink) => this.driver.get(rsvpLink))
-        .then(() => new Component(this.driver, 'input[type="submit"]').click())
-        .then(() => actor.authenticationCode())
-        .then((code) => new SignInPage(this.driver, space).submitCode(code))
-    );
+    return actor.acceptInvitation(invitation, space, this.driver)
   }
 );
 

--- a/features/steps/invitation_steps.js
+++ b/features/steps/invitation_steps.js
@@ -26,7 +26,9 @@ When(
    * @param {Actor} actor
    */
   function (_, invitation, _2, space, _3, actor) {
-    return actor.acceptInvitation(invitation, space, this.driver)
+    return invitation.accept(this.driver)
+      .then(() => actor.authenticationCode())
+      .then((code) => new SignInPage(this.driver, space).submitCode(code));
   }
 );
 

--- a/features/steps/invitation_steps.js
+++ b/features/steps/invitation_steps.js
@@ -4,7 +4,7 @@ const assert = require("assert").strict;
 const Invitation = require("../lib/Invitation");
 const Space = require("../lib/Space");
 const Actor = require("../lib/Actor");
-const { SpaceEditPage } = require("../harness/Pages");
+const { SpaceEditPage, SignInPage } = require("../harness/Pages");
 const Component = require("../harness/Component");
 
 When(
@@ -26,8 +26,11 @@ When('{a} {invitation} for {a} {space} is accepted by {a} {actor}',
    */
   function (_, invitation, _2, space, _3, actor) {
     return invitation.rsvpLink()
+      // @todo Refactor to live in the harness
       .then((rsvpLink) => this.driver.get(rsvpLink))
       .then(() => new Component(this.driver, 'input[type="submit"]').click())
+      .then(() => actor.authenticationCode())
+      .then((code) => new SignInPage(this.driver, space).submitCode(code))
 });
 
 Then(
@@ -51,3 +54,16 @@ Then(
     assert(await page.hasInvitation({ invitation, status }));
   }
 );
+
+Then('{a} {actor} becomes {a} {actor} of {a} {space}',
+  /**
+   * @param {Actor} actor
+   * @param {Actor} role
+   * @param {Space} space
+   */
+  function (_, actor, _2, role, _3, space) {
+    return actor.signIn(this.driver, space)
+      // @todo Refactor to live in the harness
+      .then(() => new Component(this.driver, 'header a.--configure[aria_label="Configure Space"]').isDisplayed())
+      .then((displayed) => assert(displayed))
+});

--- a/features/steps/invitation_steps.js
+++ b/features/steps/invitation_steps.js
@@ -90,7 +90,7 @@ Then(
    * @param {Space} space
    * @param {string} status
    */
-  function (actor, a, space, a2, status) {
+  function (actor, _a, space, _a2, status) {
     return actor
       .signIn(this.driver, space)
       .then(() => new SpaceEditPage(this.driver, space).visit())

--- a/features/steps/invitation_steps.js
+++ b/features/steps/invitation_steps.js
@@ -2,7 +2,10 @@ const { When, Then } = require("@cucumber/cucumber");
 const assert = require("assert").strict;
 
 const Invitation = require("../lib/Invitation");
+const Space = require("../lib/Space");
+const Actor = require("../lib/Actor");
 const { SpaceEditPage } = require("../harness/Pages");
+const Component = require("../harness/Component");
 
 When(
   "an {invitation} to {a} {space} is sent by {actor}",
@@ -14,6 +17,18 @@ When(
       .then((page) => page.inviteAll(invitations.hashes()));
   }
 );
+
+When('{a} {invitation} for {a} {space} is accepted by {a} {actor}',
+  /**
+   * @param {Invitation} invitation
+   * @param {Space} space
+   * @param {Actor} actor
+   */
+  function (_, invitation, _2, space, _3, actor) {
+    return invitation.rsvpLink()
+      .then((rsvpLink) => this.driver.get(rsvpLink))
+      .then(() => new Component(this.driver, 'input[type="submit"]').click())
+});
 
 Then(
   "an {invitation} for {a} {space} is delivered",

--- a/features/support/parameter-types/actor.js
+++ b/features/support/parameter-types/actor.js
@@ -10,7 +10,7 @@ const Actor = require('../../lib/Actor.js')
 // - Space Owner (Someone who is authenticated and has moderator rights within the Space)
 defineParameterType({
   name: "actor",
-  regexp: /(Guest|Space Member|Space Owner|Neighbor)( ".*")?/,
+  regexp: /(Guest|Space Member|Space Owner|Neighbor)( "[^"]*")?/,
   transformer: function(type, email) {
     email = email || `${type.toLowerCase()}@example.com`
 

--- a/features/support/parameter-types/space.js
+++ b/features/support/parameter-types/space.js
@@ -6,6 +6,6 @@ const Space = require('../../lib/Space');
 // isolation.
 defineParameterType({
   name: "space",
-  regexp: /(".*" )?Space/,
+  regexp: /("[^"]*" )?Space/,
   transformer: (name = "System Test") => new Space(name.trim().replace(/\"/g,'')),
 });


### PR DESCRIPTION
See: https://github.com/zinc-collective/convene/issues/117

Strangely, there seems to be some Unobtrusive JavaScript left over in our application from the move to Turbo, which had broken the invitation flow!

Thankfully, our TDD ensemble discovered it as part of automating that check; and we fixed it!

This also:

- Reframes the Accepting an Invitation as a Guest Scenario to use existing Invitation Steps and the newer pattern we follow for defining steps
- Finds and resolves some greedy regexs in parameter types