### PR TITLE
Don't list unlisted rooms in Space

### DIFF
--- a/app/views/spaces/show.html.erb
+++ b/app/views/spaces/show.html.erb
@@ -1,6 +1,6 @@
 <% breadcrumb :root %>
 <div class="space-container card-list">
-  <% policy_scope(space.rooms).each do |room| %>
+  <% policy_scope(space.rooms.listed).each do |room| %>
     <%= render partial: 'spaces/room_card', locals: { room: room } %>
   <% end %>
 </div>

--- a/features/steps/room_steps.js
+++ b/features/steps/room_steps.js
@@ -82,8 +82,8 @@ When("the {actor} taps the {room} in the Room Picker", function (actor, room) {
 });
 
 Then("the {actor} is placed in the {room}", async function (actor, room) {
-  const roomPage = new RoomPage(this.driver, room);
-  assert(await roomPage.videoPanel().isDisplayed());
+  const currentPageUrl = await this.driver.getCurrentUrl();
+  assert(currentPageUrl.includes(room.slug));
 });
 
 Then("the {actor} is not placed in the {room}", function (actor, room) {


### PR DESCRIPTION
This PR fixes a small bug introduced in https://github.com/zinc-collective/convene/pull/441, by making unlisted rooms not listed (but accessible with a URL).

I also tweaked the feature tests to avoid assuming that rooms always have a video panel.

I believe this should fix the feature test failures we've been seeing.