### PR TITLE
Add Validation to Checks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,6 +89,10 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'shoulda-matchers', '~> 5.1'
   gem 'rails-controller-testing'
+
+  # Let the robots do the request/response faking.
+  gem 'vcr'
+  gem 'webmock'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,8 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
+    addressable (2.8.0)
+      public_suffix (>= 2.0.2, < 5.0)
     ar_outer_joins (0.2.0)
       activerecord (>= 3.2)
     bcrypt (3.1.16)
@@ -75,6 +77,8 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
     connection_pool (2.2.5)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     cssbundling-rails (1.0.0)
       railties (>= 6.0.0)
@@ -122,6 +126,7 @@ GEM
     gretel (4.4.0)
       actionview (>= 5.1, < 7.1)
       railties (>= 5.1, < 7.1)
+    hashdiff (1.0.1)
     i18n (1.8.11)
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.5)
@@ -158,6 +163,7 @@ GEM
     pry-byebug (3.9.0)
       byebug (~> 11.0)
       pry (~> 0.13.0)
+    public_suffix (4.0.6)
     puma (5.5.2)
       nio4r (~> 2.0)
     pundit (2.1.1)
@@ -202,6 +208,7 @@ GEM
       ffi (~> 1.0)
     redcarpet (3.5.1)
     redis (4.5.1)
+    rexml (3.2.5)
     rotp (6.2.0)
     rspec-core (3.10.1)
       rspec-support (~> 3.10.0)
@@ -262,11 +269,16 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
+    vcr (6.0.0)
     web-console (4.2.0)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webmock (3.14.0)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -309,7 +321,9 @@ DEPENDENCIES
   stimulus-rails
   turbo-rails
   tzinfo-data (~> 1.2021)
+  vcr
   web-console (~> 4.2)
+  webmock
 
 RUBY VERSION
    ruby 2.7.4p191

--- a/app/assets/stylesheets/components/form.scss
+++ b/app/assets/stylesheets/components/form.scss
@@ -19,7 +19,7 @@
       @apply block w-full;
     }
     label {
-      @apply text-sm font-medium leading-5 text-neutral-700;
+      @apply font-medium leading-5 text-neutral-700;
     }
     input[type="text"],
     input[type="email"],
@@ -34,11 +34,24 @@
         transition duration-150 ease-in-out;
 
       @screen sm {
-        @apply text-sm leading-5;
+        @apply leading-5;
       }
     }
     input {
       @apply appearance-none;
+    }
+
+    .field_with_errors {
+      input[type="text"],
+      input[type="email"],
+      input[type="password"],
+      input[type="search"],
+      input[type="number"],
+      input[type="tel"],
+      select,
+      textarea {
+        @apply border-red-300 bg-red-100;
+      }
     }
 
     textarea {
@@ -54,8 +67,8 @@
     input:disabled {
       @apply bg-neutral-200;
     }
-    .error-message {
-      @apply mt-1 px-4 italic text-red-500;
+    .field_with_errors {
+      @apply text-red-500;
     }
 
     footer {
@@ -77,25 +90,6 @@
       }
     }
   }
-}
-
-.access-code-form {
-  @apply m-auto flex flex-col;
-}
-.access-code-form__input {
-  @apply mt-4;
-}
-.access-code-form__input--error {
-  @apply border border-red-500;
-}
-.access-code-form__message {
-  @apply hidden;
-}
-.access-code-form__error-message {
-  @apply text-xs italic font-thin text-red-500;
-}
-.access-code-form__submit {
-  @apply mt-4;
 }
 
 .identification-form {

--- a/app/furniture/check_dropbox/_in_room.html.erb
+++ b/app/furniture/check_dropbox/_in_room.html.erb
@@ -1,12 +1,2 @@
-<h3>Check Dropbox</h3>
-<script src="https://cdn.plaid.com/link/v2/stable/link-initialize.js"></script>
 
-<turbo-frame id="check-dropbox" data-turbo="true">
-  <%= render "check_dropbox/checks/form", room: room, furniture: furniture, check: furniture.checks.new %>
-
-  <%- if policy(furniture.checks).index? %>
-    <p>
-    See <%= link_to "all checks", space_room_furniture_check_dropbox_checks_path(room.space, room) %>
-    </p>
-  <%- end %>
-</turbo-frame>
+<%= render "check_dropbox/checks/new", room: room, furniture: furniture, check: furniture.checks.new %>

--- a/app/furniture/check_dropbox/check.rb
+++ b/app/furniture/check_dropbox/check.rb
@@ -105,7 +105,7 @@ class CheckDropbox
     end
 
     def amount=(amount)
-      data['amount'] = amount&.to_i
+      data['amount'] = amount
     end
 
     def amount

--- a/app/furniture/check_dropbox/check.rb
+++ b/app/furniture/check_dropbox/check.rb
@@ -15,18 +15,10 @@ class CheckDropbox
     attr_accessor :public_token
     validates :payer_name, presence: true
     validates :payer_email, presence: true
-    validates :amount, presence: true
+    validates :amount, presence: true, numericality: { greater_than: 0 }
     validates :memo, presence: true
     validates :plaid_account_id, presence: true
-    validate :retrievable_from_plaid
-    # validates :plaid_item_id, presence: true
-    # validates :public_token, presence: true
-
-    def retrievable_from_plaid
-      return if public_token.present? || plaid_item_id.present?
-
-      errors.add(:public_token, "Pick ur bank account m8")
-    end
+    validates :plaid_item_id, presence: true
 
     READY_FOR_DEPOSIT = :ready_for_deposit
     UNCLEARED = :uncleared

--- a/app/furniture/check_dropbox/check.rb
+++ b/app/furniture/check_dropbox/check.rb
@@ -17,8 +17,16 @@ class CheckDropbox
     validates :payer_email, presence: true
     validates :amount, presence: true
     validates :memo, presence: true
+    validates :plaid_account_id, presence: true
+    validate :retrievable_from_plaid
     # validates :plaid_item_id, presence: true
     # validates :public_token, presence: true
+
+    def retrievable_from_plaid
+      return if public_token.present? || plaid_item_id.present?
+
+      errors.add(:public_token, "Pick ur bank account m8")
+    end
 
     READY_FOR_DEPOSIT = :ready_for_deposit
     UNCLEARED = :uncleared
@@ -109,7 +117,7 @@ class CheckDropbox
     end
 
     def amount
-      data['amount']&.to_i
+      data['amount']
     end
 
     def memo=(memo)

--- a/app/furniture/check_dropbox/check.rb
+++ b/app/furniture/check_dropbox/check.rb
@@ -14,7 +14,7 @@ class CheckDropbox
 
     attr_accessor :public_token
     validates :payer_name, presence: true
-    validates :payer_email, presence: true
+    validates :payer_email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }
     validates :amount, presence: true, numericality: { greater_than: 0 }
     validates :memo, presence: true
     validates :plaid_account_id, presence: true

--- a/app/furniture/check_dropbox/check_policy.rb
+++ b/app/furniture/check_dropbox/check_policy.rb
@@ -25,7 +25,7 @@ class CheckDropbox
     end
 
     def permitted_attributes
-      %i[payer_name payer_email amount memo public_token]
+      %i[payer_name payer_email amount memo public_token plaid_account_id account_description]
     end
 
     class Scope

--- a/app/furniture/check_dropbox/checks/_form.html.erb
+++ b/app/furniture/check_dropbox/checks/_form.html.erb
@@ -1,15 +1,24 @@
 <%= form_with model: [room.space, room, :furniture, check], data: { controller: "check-dropbox", check_dropbox_link_token: furniture.link_token_for(current_person) } do |check_form|%>
-  <div>
-    <%= check_form.label :pay_from do %>
-      <span data-check-dropbox-target="payFrom">
-        <button
-        data-action="click->check-dropbox#createLink">Choose bank account
-        </button>
-      </span>
-    <%- end %>
-    <%= check_form.hidden_field :public_token, data: { check_dropbox_target: "publicToken" } %>
-    <%= render "error", model: check_form.object, attribute: :public_token %>
-  </div>
+  <%- if check.public_token.blank? %>
+    <div>
+      <%= check_form.label :pay_from do %>
+        <span data-check-dropbox-target="payFrom">
+          <button
+          data-action="click->check-dropbox#createLink">Choose bank account
+          </button>
+        </span>
+      <%- end %>
+      <%= render "error", model: check_form.object, attribute: :public_token %>
+      <%= check_form.hidden_field :public_token, data: { check_dropbox_target: "publicToken" } %>
+      <%= check_form.hidden_field :plaid_account_id, data: { check_dropbox_target: "plaidAccountId" } %>
+      <%= check_form.hidden_field :account_description, data: { check_dropbox_target: "accountDescription" } %>
+    </div>
+  <%- else %>
+    <%= check.account_description %>
+    <%= check_form.hidden_field :public_token %>
+    <%= check_form.hidden_field :plaid_account_id %>
+    <%= check_form.hidden_field :account_description %>
+  <%- end %>
 
   <%= render "text_field", form: check_form, attribute: :amount %>
   <%= render "text_field", form: check_form, attribute: :payer_name %>

--- a/app/furniture/check_dropbox/checks/_form.html.erb
+++ b/app/furniture/check_dropbox/checks/_form.html.erb
@@ -8,7 +8,7 @@
           </button>
         </span>
       <%- end %>
-      <%= render "error", model: check_form.object, attribute: :public_token %>
+      <%= render "error", model: check_form.object, attribute: :plaid_item_id %>
       <%= check_form.hidden_field :public_token, data: { check_dropbox_target: "publicToken" }, autocomplete: "off" %>
       <%= check_form.hidden_field :plaid_account_id, data: { check_dropbox_target: "plaidAccountId" }, autocomplete: "off" %>
       <%= check_form.hidden_field :account_description, data: { check_dropbox_target: "accountDescription" }, autocomplete: "off" %>

--- a/app/furniture/check_dropbox/checks/_form.html.erb
+++ b/app/furniture/check_dropbox/checks/_form.html.erb
@@ -9,9 +9,9 @@
         </span>
       <%- end %>
       <%= render "error", model: check_form.object, attribute: :public_token %>
-      <%= check_form.hidden_field :public_token, data: { check_dropbox_target: "publicToken" } %>
-      <%= check_form.hidden_field :plaid_account_id, data: { check_dropbox_target: "plaidAccountId" } %>
-      <%= check_form.hidden_field :account_description, data: { check_dropbox_target: "accountDescription" } %>
+      <%= check_form.hidden_field :public_token, data: { check_dropbox_target: "publicToken" }, autocomplete: "off" %>
+      <%= check_form.hidden_field :plaid_account_id, data: { check_dropbox_target: "plaidAccountId" }, autocomplete: "off" %>
+      <%= check_form.hidden_field :account_description, data: { check_dropbox_target: "accountDescription" }, autocomplete: "off" %>
     </div>
   <%- else %>
     <%= check.account_description %>

--- a/app/furniture/check_dropbox/checks/_form.html.erb
+++ b/app/furniture/check_dropbox/checks/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: [room.space, room, :furniture, furniture.checks.new], data: { controller: "check-dropbox", check_dropbox_link_token: furniture.link_token_for(current_person) } do |check_form|%>
+<%= form_with model: [room.space, room, :furniture, check], data: { controller: "check-dropbox", check_dropbox_link_token: furniture.link_token_for(current_person) } do |check_form|%>
   <div>
     <%= check_form.label :pay_from do %>
       <span data-check-dropbox-target="payFrom">
@@ -8,29 +8,15 @@
       </span>
     <%- end %>
     <%= check_form.hidden_field :public_token, data: { check_dropbox_target: "publicToken" } %>
+    <%= render "error", model: check_form.object, attribute: :public_token %>
   </div>
 
-  <div>
-    <%= check_form.label :amount %>
-    <%= check_form.text_field :amount %>
-  </div>
+  <%= render "text_field", form: check_form, attribute: :amount %>
+  <%= render "text_field", form: check_form, attribute: :payer_name %>
+  <%= render "text_field", form: check_form, attribute: :payer_email %>
+  <%= render "text_field", form: check_form, attribute: :memo %>
 
   <div>
-    <%= check_form.label :payer_name %>
-    <%= check_form.text_field :payer_name %>
-  </div>
-
-  <div>
-    <%= check_form.label :payer_email %>
-    <%= check_form.text_field :payer_email %>
-  </div>
-
-  <div>
-    <%= check_form.label :memo %>
-    <%= check_form.text_field :memo %>
-  </div>
-
-  <div>
-    <%= check_form.submit disabled: true, data: { check_dropbox_target: "dropOffButton" } %>
+    <%= check_form.submit data: { check_dropbox_target: "dropOffButton" } %>
   </div>
 <%- end %>

--- a/app/furniture/check_dropbox/checks/_new.html.erb
+++ b/app/furniture/check_dropbox/checks/_new.html.erb
@@ -1,0 +1,12 @@
+<h3>Check Dropbox</h3>
+<script src="https://cdn.plaid.com/link/v2/stable/link-initialize.js"></script>
+
+<turbo-frame id="check-dropbox" data-turbo="true">
+  <%= render "check_dropbox/checks/form", room: room, furniture: furniture, check: check %>
+
+  <%- if policy(furniture.checks).index? %>
+    <p>
+    See <%= link_to "all checks", space_room_furniture_check_dropbox_checks_path(room.space, room) %>
+    </p>
+  <%- end %>
+</turbo-frame>

--- a/app/furniture/check_dropbox/checks/new.html.erb
+++ b/app/furniture/check_dropbox/checks/new.html.erb
@@ -1,12 +1,1 @@
-<h3>Check Dropbox</h3>
-<script src="https://cdn.plaid.com/link/v2/stable/link-initialize.js"></script>
-
-<turbo-frame id="check-dropbox" data-turbo="true">
-  <%= render "check_dropbox/checks/form", room: room, furniture: furniture, check: check %>
-
-  <%- if policy(furniture.checks).index? %>
-    <p>
-    See <%= link_to "all checks", space_room_furniture_check_dropbox_checks_path(room.space, room) %>
-    </p>
-  <%- end %>
-</turbo-frame>
+<%= render "check_dropbox/checks/new", room: room, furniture: furniture, check: check %>

--- a/app/furniture/check_dropbox/checks/new.html.erb
+++ b/app/furniture/check_dropbox/checks/new.html.erb
@@ -2,7 +2,7 @@
 <script src="https://cdn.plaid.com/link/v2/stable/link-initialize.js"></script>
 
 <turbo-frame id="check-dropbox" data-turbo="true">
-  <%= render "check_dropbox/checks/form", room: room, furniture: furniture, check: furniture.checks.new %>
+  <%= render "check_dropbox/checks/form", room: room, furniture: furniture, check: check %>
 
   <%- if policy(furniture.checks).index? %>
     <p>

--- a/app/furniture/check_dropbox/checks_controller.rb
+++ b/app/furniture/check_dropbox/checks_controller.rb
@@ -3,7 +3,9 @@
 class CheckDropbox
   class ChecksController < FurnitureController
     def create
-      check.save
+      return if check.save
+
+      render :new
     end
 
     def index; end

--- a/app/javascript/controllers/check_dropbox_controller.js
+++ b/app/javascript/controllers/check_dropbox_controller.js
@@ -1,20 +1,31 @@
-import { Controller } from "@hotwired/stimulus"
+import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  static targets = ["payFrom", "publicToken", "dropOffButton"];
+  static targets = [
+    "payFrom",
+    "publicToken",
+    "plaidAccountId",
+    "accountDescription",
+    "dropOffButton",
+  ];
 
   createLink(e) {
     e.preventDefault();
     const handler = Plaid.create({
-      token: this.data.get('linkToken'),
+      token: this.data.get("linkToken"),
       onSuccess: (publicToken, metadata) => {
-        console.log({ publicToken, metadata })
-        this.payFromTarget.innerHTML=`${metadata.institution.name} - ${metadata.account.name}: XXXX${metadata.account.mask}`
+        console.log({ publicToken, metadata });
+        const accountDescription = `${metadata.institution.name} - ${metadata.account.name}: XXXX${metadata.account.mask}`;
+        this.payFromTarget.innerHTML = accountDescription;
         this.dropOffButtonTarget.disabled = false;
-        this.publicTokenTarget.value = publicToken
+        this.accountDescriptionTarget.value = accountDescription;
+        this.publicTokenTarget.value = publicToken;
+        this.plaidAccountIdTarget.value = metadata.account_id;
       },
       onLoad: () => {},
-      onExit: (err, metadata) => {alert('womp womp')},
+      onExit: (err, metadata) => {
+        alert("womp womp");
+      },
       onEvent: (eventName, metadata) => {},
       receivedRedirectUri: null,
     });

--- a/app/lib/item.rb
+++ b/app/lib/item.rb
@@ -10,12 +10,17 @@ class Item
   include ActiveModel::Model
   include ActiveModel::Attributes
   include ActiveModel::AttributeAssignment
+  include ActiveModel::Validations
 
   # @return [ItemRecord]
   attr_accessor :item_record
 
   delegate :data, to: :item_record
   delegate :utilities, to: :item_record
+
+  def save
+    valid? ? save : false
+  end
   delegate :save, to: :item_record
   delegate :persisted?, to: :item_record
   delegate :space, to: :item_record

--- a/app/lib/item.rb
+++ b/app/lib/item.rb
@@ -15,7 +15,7 @@ class Item
   # @return [ItemRecord]
   attr_accessor :item_record
 
-  delegate :data, to: :item_record
+  delegate :data, :data=, to: :item_record
   delegate :utilities, to: :item_record
 
   def save

--- a/app/models/item_repository.rb
+++ b/app/models/item_repository.rb
@@ -6,9 +6,9 @@ class ItemRepository
 
   delegate :model_name, to: :type
 
-  delegate :size, :empty?, :present?,  to: :item_records
+  delegate :size, :empty?, :present?, to: :item_records
 
-  def initialize(type:, item_records:, space:)
+  def initialize(item_records:, space:, type: Item)
     self.type = type
     self.item_records = item_records
     self.space = space

--- a/app/utilities/plaid/plaid_utility.rb
+++ b/app/utilities/plaid/plaid_utility.rb
@@ -34,16 +34,11 @@ module Plaid
       response.link_token
     end
 
-    def account_number_for(access_token:, item_id:)
+    def auth_get(access_token:)
       request = sdk::AuthGetRequest.new(access_token: access_token)
       response = plaid_client.auth_get(request)
-      response.numbers.ach.find { |a| a.account_id = item_id }.account
-    end
 
-    def routing_number_for(access_token:, item_id:)
-      request = sdk::AuthGetRequest.new(access_token: access_token)
-      response = plaid_client.auth_get(request)
-      response.numbers.ach.find { |a| a.account_id = item_id }.account
+      response
     end
 
     def plaid_configuration

--- a/cassettes/check_dropbox/checks/create.yml
+++ b/cassettes/check_dropbox/checks/create.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://sandbox.plaid.com/item/public_token/exchange
+    body:
+      encoding: UTF-8
+      string: '{"public_token":"public-sandbox-14ee4677-e0ad-4ec0-8323-051af5ebfc67"}'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Plaid Ruby v14.12.0
+      Accept:
+      - application/json
+      Plaid-Client-Id:
+      - 602dc9bffec85e0011852119
+      Plaid-Version:
+      - '2020-09-14'
+      Plaid-Secret:
+      - 296b131b29e4e5b2ea0f45d159e7b7
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 13 Jan 2022 03:14:54 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '168'
+      Connection:
+      - keep-alive
+      Plaid-Version:
+      - '2020-09-14'
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "access_token": "access-sandbox-f05e31e3-4c78-45da-b50d-68d425fc1647",
+          "item_id": "r36L6N3b9ntvjD76mMZNivVqlNGaJ9tlBZq6m",
+          "request_id": "sfPiEVocStSVtmt"
+        }
+  recorded_at: Thu, 13 Jan 2022 03:14:54 GMT
+recorded_with: VCR 6.0.0

--- a/cassettes/check_dropbox/checks/index.yml
+++ b/cassettes/check_dropbox/checks/index.yml
@@ -1,0 +1,239 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://sandbox.plaid.com/auth/get
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"access-sandbox-f05e31e3-4c78-45da-b50d-68d425fc1647"}'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Plaid Ruby v14.12.0
+      Accept:
+      - application/json
+      Plaid-Client-Id:
+      - 602dc9bffec85e0011852119
+      Plaid-Version:
+      - '2020-09-14'
+      Plaid-Secret:
+      - 296b131b29e4e5b2ea0f45d159e7b7
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 13 Jan 2022 03:14:55 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1146'
+      Connection:
+      - keep-alive
+      Plaid-Version:
+      - '2020-09-14'
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "accounts": [
+            {
+              "account_id": "WdBoBqdrzDtjQ8dmv36afqyNdWMPjEtlvKbbA",
+              "balances": {
+                "available": 100,
+                "current": 110,
+                "iso_currency_code": "USD",
+                "limit": null,
+                "unofficial_currency_code": null
+              },
+              "mask": "0000",
+              "name": "Plaid Checking",
+              "official_name": "Plaid Gold Standard 0% Interest Checking",
+              "subtype": "checking",
+              "type": "depository"
+            },
+            {
+              "account_id": "AeoloyejpECoJ5aM48A3UpLKEANXPBC1yEppb",
+              "balances": {
+                "available": 200,
+                "current": 210,
+                "iso_currency_code": "USD",
+                "limit": null,
+                "unofficial_currency_code": null
+              },
+              "mask": "1111",
+              "name": "Plaid Saving",
+              "official_name": "Plaid Silver Standard 0.1% Interest Saving",
+              "subtype": "savings",
+              "type": "depository"
+            },
+            {
+              "account_id": "GpVGVKp1oDtDlzepVjMPtpQDqK5G6gC18yppz",
+              "balances": {
+                "available": null,
+                "current": 1000,
+                "iso_currency_code": "USD",
+                "limit": null,
+                "unofficial_currency_code": null
+              },
+              "mask": "2222",
+              "name": "Plaid CD",
+              "official_name": "Plaid Bronze Standard 0.2% Interest CD",
+              "subtype": "cd",
+              "type": "depository"
+            },
+            {
+              "account_id": "nK6X6xKWwntn4Xb7AV8DCnZJDdKXvmC6Ew551",
+              "balances": {
+                "available": null,
+                "current": 410,
+                "iso_currency_code": "USD",
+                "limit": 2000,
+                "unofficial_currency_code": null
+              },
+              "mask": "3333",
+              "name": "Plaid Credit Card",
+              "official_name": "Plaid Diamond 12.5% APR Interest Credit Card",
+              "subtype": "credit card",
+              "type": "credit"
+            },
+            {
+              "account_id": "b1RaRP17gWtwAZ1Jb6QeHwP3V1No6nsVzQkkD",
+              "balances": {
+                "available": 43200,
+                "current": 43200,
+                "iso_currency_code": "USD",
+                "limit": null,
+                "unofficial_currency_code": null
+              },
+              "mask": "4444",
+              "name": "Plaid Money Market",
+              "official_name": "Plaid Platinum Standard 1.85% Interest Money Market",
+              "subtype": "money market",
+              "type": "depository"
+            },
+            {
+              "account_id": "mq6e63qEbnHPaZbwX36MIP3jVaMlR9cLPzom1",
+              "balances": {
+                "available": null,
+                "current": 320.76,
+                "iso_currency_code": "USD",
+                "limit": null,
+                "unofficial_currency_code": null
+              },
+              "mask": "5555",
+              "name": "Plaid IRA",
+              "official_name": null,
+              "subtype": "ira",
+              "type": "investment"
+            },
+            {
+              "account_id": "yj6a6JjB5nfln7pAqMBysL6rWkbJaliy5ea3j",
+              "balances": {
+                "available": null,
+                "current": 23631.9805,
+                "iso_currency_code": "USD",
+                "limit": null,
+                "unofficial_currency_code": null
+              },
+              "mask": "6666",
+              "name": "Plaid 401k",
+              "official_name": null,
+              "subtype": "401k",
+              "type": "investment"
+            },
+            {
+              "account_id": "MAn1ndAkoDUe3zpXDxrMhW78R9K4GAi9zVWlq",
+              "balances": {
+                "available": null,
+                "current": 65262,
+                "iso_currency_code": "USD",
+                "limit": null,
+                "unofficial_currency_code": null
+              },
+              "mask": "7777",
+              "name": "Plaid Student Loan",
+              "official_name": null,
+              "subtype": "student",
+              "type": "loan"
+            },
+            {
+              "account_id": "1GAeA7GnmEsbL6QNknoJUoNgG5d6Z3s53lkKx",
+              "balances": {
+                "available": null,
+                "current": 56302.06,
+                "iso_currency_code": "USD",
+                "limit": null,
+                "unofficial_currency_code": null
+              },
+              "mask": "8888",
+              "name": "Plaid Mortgage",
+              "official_name": null,
+              "subtype": "mortgage",
+              "type": "loan"
+            }
+          ],
+          "item": {
+            "available_products": [
+              "assets",
+              "balance",
+              "credit_details",
+              "income",
+              "investments",
+              "liabilities",
+              "transactions"
+            ],
+            "billed_products": [
+              "auth",
+              "identity"
+            ],
+            "consent_expiration_time": null,
+            "error": null,
+            "institution_id": "ins_3",
+            "item_id": "r36L6N3b9ntvjD76mMZNivVqlNGaJ9tlBZq6m",
+            "products": [
+              "auth",
+              "identity"
+            ],
+            "update_type": "background",
+            "webhook": ""
+          },
+          "numbers": {
+            "ach": [
+              {
+                "account": "1111222233330000",
+                "account_id": "WdBoBqdrzDtjQ8dmv36afqyNdWMPjEtlvKbbA",
+                "routing": "011401533",
+                "wire_routing": "021000021"
+              },
+              {
+                "account": "1111222233331111",
+                "account_id": "AeoloyejpECoJ5aM48A3UpLKEANXPBC1yEppb",
+                "routing": "011401533",
+                "wire_routing": "021000021"
+              }
+            ],
+            "bacs": [],
+            "eft": [],
+            "international": []
+          },
+          "request_id": "YjydPpJDdh6myeo"
+        }
+  recorded_at: Thu, 13 Jan 2022 03:14:55 GMT
+recorded_with: VCR 6.0.0

--- a/config/locales/furniture/check_dropbox/en.yml
+++ b/config/locales/furniture/check_dropbox/en.yml
@@ -1,0 +1,9 @@
+en:
+  activemodel:
+    errors:
+      models:
+        check_dropbox/check:
+          attributes:
+            plaid_item_id:
+              blank: choose a bank account
+

--- a/config/locales/furniture/check_dropbox/en.yml
+++ b/config/locales/furniture/check_dropbox/en.yml
@@ -6,4 +6,6 @@ en:
           attributes:
             plaid_item_id:
               blank: choose a bank account
+            payer_email:
+              invalid: must be a valid email address
 

--- a/spec/factories/furniture/check_dropbox.rb
+++ b/spec/factories/furniture/check_dropbox.rb
@@ -16,5 +16,11 @@ FactoryBot.define do
     sequence(:memo) { |i| "Check Memo #{i}" }
     sequence(:public_token) { |i| "Public Token #{i}" }
     association :space
+
+    trait :sort_of_real do
+      public_token { "public-sandbox-14ee4677-e0ad-4ec0-8323-051af5ebfc67" }
+      account_description { "Chase - Plaid Checking: XXXX0000" }
+      plaid_account_id { "WdBoBqdrzDtjQ8dmv36afqyNdWMPjEtlvKbbA" }
+    end
   end
 end

--- a/spec/factories/utilities/plaid.rb
+++ b/spec/factories/utilities/plaid.rb
@@ -5,8 +5,10 @@ FactoryBot.define do
     utility_slug { 'plaid' }
     configuration do
       {
-        'client_id' => 'a-fake-client-id',
-        'secret' => 'a-fake-secret',
+        # Use sandbox client id and secret if they are available, to
+        # make it possible to record VCR cassettes in tests.
+        'client_id' => ENV.fetch('PLAID_CLIENT_ID', 'a-fake-client-id'),
+        'secret' => ENV.fetch('PLAID_SECRET', 'a-fake-secret'),
         'environment' => 'sandbox'
       }
     end

--- a/spec/furniture/check_dropbox/check_spec.rb
+++ b/spec/furniture/check_dropbox/check_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe CheckDropbox::Check, type: :model do
+  subject { described_class.new(item_record: ItemRecord.new) }
+
+  describe '#payer_name' do
+    it { is_expected.to validate_presence_of(:payer_name) }
+  end
+
+  describe '#payer_email' do
+    it { is_expected.to validate_presence_of(:payer_email) }
+    it { is_expected.to allow_value('me@you.com').for(:payer_email) }
+    it { is_expected.to_not allow_value('bogus.com').for(:payer_email) }
+  end
+
+  describe '#amount' do
+    it { is_expected.to validate_presence_of(:amount) }
+    it { is_expected.to validate_numericality_of(:amount).is_greater_than(0) }
+  end
+
+  describe '#memo' do
+    it { is_expected.to validate_presence_of(:memo) }
+  end
+
+  describe '#plaid_account_id' do
+    it { is_expected.to validate_presence_of(:plaid_account_id) }
+  end
+
+  describe '#plaid_item_id' do
+    it { is_expected.to validate_presence_of(:plaid_item_id) }
+  end
+end

--- a/spec/furniture/check_dropbox/checks_request_spec.rb
+++ b/spec/furniture/check_dropbox/checks_request_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe '/spaces/:space_id/rooms/:room_id/furniture/check_dropbox/checks'
 
       expect(check.payer_name).to eql(check_attributes[:payer_name])
       expect(check.payer_email).to eql(check_attributes[:payer_email])
-      expect(check.amount).to eql(check_attributes[:amount])
+      expect(check.amount).to eql(check_attributes[:amount].to_s)
       expect(check.memo).to eql(check_attributes[:memo])
       expect(check.plaid_access_token).to include('access-sandbox')
       expect(check.plaid_item_id).to be_present

--- a/spec/furniture/check_dropbox/checks_request_spec.rb
+++ b/spec/furniture/check_dropbox/checks_request_spec.rb
@@ -10,38 +10,34 @@ RSpec.describe '/spaces/:space_id/rooms/:room_id/furniture/check_dropbox/checks'
   let(:neighbor) { FactoryBot.create(:person) }
   let(:space_member) { FactoryBot.create(:person, spaces: [space]) }
 
-  let(:fake_plaid) { instance_double(Plaid::PlaidUtility) }
-  before do
-    allow(Plaid::PlaidUtility).to receive(:new).and_return(fake_plaid)
-    allow(fake_plaid).to receive(:exchange_public_token) do |attrs|
-      double(access_token: "Access Token from #{attrs[:public_token]}",
-             item_id: "Item Id from #{attrs[:public_token]}")
-    end
-    allow(fake_plaid).to receive(:account_number_for).and_return('Account Number')
-    allow(fake_plaid).to receive(:routing_number_for).and_return('Routing Number')
-  end
-
   describe 'POST' do
     it 'creates a check' do
-      post "/spaces/#{space.id}/rooms/#{room.id}/furniture/check_dropbox/checks",
-           { params: { check_dropbox_check: { payer_name: 'Zee', payer_email: 'zee@example.com', amount: 100_00, memo: 'Example',
-                                public_token: 'Fake' } } }
+      check_attributes = attributes_for(:check_dropbox_check, :sort_of_real)
+      VCR.use_cassette('check_dropbox/checks/create') do
+        post "/spaces/#{space.id}/rooms/#{room.id}/furniture/check_dropbox/checks",
+             { params: { check_dropbox_check: check_attributes } }
+      end
 
       expect(check_dropbox.checks).not_to be_empty
 
       check = check_dropbox.checks.last
 
-      expect(check.payer_name).to eql('Zee')
-      expect(check.payer_email).to eql('zee@example.com')
-      expect(check.amount).to eql(100_00)
-      expect(check.memo).to eql('Example')
-      expect(check.plaid_access_token).to eql "Access Token from Fake"
-      expect(check.plaid_item_id).to eql "Item Id from Fake"
+      expect(check.payer_name).to eql(check_attributes[:payer_name])
+      expect(check.payer_email).to eql(check_attributes[:payer_email])
+      expect(check.amount).to eql(check_attributes[:amount])
+      expect(check.memo).to eql(check_attributes[:memo])
+      expect(check.plaid_access_token).to include('access-sandbox')
+      expect(check.plaid_item_id).to be_present
     end
   end
 
   describe 'GET' do
-    let!(:check) { check_dropbox.checks.create(FactoryBot.attributes_for(:check_dropbox_check)) }
+    let!(:check) {
+      VCR.use_cassette('check_dropbox/checks/create') do
+        check_dropbox.checks.create(attributes_for(:check_dropbox_check, :sort_of_real))
+      end
+    }
+
     it 'is a 404 for guests' do
       get "/spaces/#{space.id}/rooms/#{room.id}/furniture/check_dropbox/checks"
 
@@ -59,7 +55,9 @@ RSpec.describe '/spaces/:space_id/rooms/:room_id/furniture/check_dropbox/checks'
     it 'is a list of the checks for residents' do
       sign_in(space, space_member)
 
-      get "/spaces/#{space.id}/rooms/#{room.id}/furniture/check_dropbox/checks"
+      VCR.use_cassette('check_dropbox/checks/index') do
+        get "/spaces/#{space.id}/rooms/#{room.id}/furniture/check_dropbox/checks"
+      end
 
       expect(response).to be_ok
       expect(response).to(render_template(:index))

--- a/spec/models/item_repository_spec.rb
+++ b/spec/models/item_repository_spec.rb
@@ -4,28 +4,27 @@ require 'rails_helper'
 
 RSpec.describe ItemRepository do
   let(:item_repository) do
-    ItemRepository.new(type: CheckDropbox::Check, item_records: item_records, space: space)
+    ItemRepository.new(item_records: item_records, space: space)
   end
-  let(:type) { CheckDropbox::Check }
   let(:item_records) { location.item_records }
   let(:location) { FactoryBot.create(:furniture_placement) }
   let(:space) { location.space }
   describe '#new' do
     it 'instantiates an item record with the given attributes within the item records' do
-      item = item_repository.new(status: 'green')
+      item = item_repository.new(data: { some: 'stuff' })
 
-      expect(item.status).to eql(:green)
-      expect(item).to be_a(CheckDropbox::Check)
+      expect(item.data).to eq({ 'some' => 'stuff' })
+      expect(item).to be_a(Item)
       expect(location.item_records).to include(item.item_record)
     end
   end
 
   describe '#create' do
     it 'persist an item record with the given attributes within the item records' do
-      item = item_repository.create(status: 'green')
+      item = item_repository.create(data: { some: 'stuff' })
 
-      expect(item.status).to eql(:green)
-      expect(item).to be_a(CheckDropbox::Check)
+      expect(item.data).to include({ 'some' => 'stuff' })
+      expect(item).to be_a(Item)
       expect(location.item_records).to include(item.item_record)
       expect(item).to be_persisted
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'ffaker'
 require 'pundit/rspec'
 require 'simplecov'
+require 'vcr'
 
 SimpleCov.start do
   enable_coverage :branch
@@ -105,6 +106,11 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 =end
+end
+
+VCR.configure do |config|
+  config.cassette_library_dir = 'cassettes'
+  config.hook_into :webmock
 end
 
 $LOAD_PATH << File.join(__dir__, '../', 'app', 'lib')


### PR DESCRIPTION
See: https://github.com/zinc-collective/convene/issues/186

As we were doing a "cleanup" review of the interaction flow for the payment form, we realized that there are no validations on any of the data. This was in part because we were rushin', and also because the way we're doing Item as a thing independent of ItemRecord was making error handling a bit harder than if it were an ApplicationRecord instead of a Model.

- [x] Make saving the form actually work
- [x] [Independently merge in the changes for consolidating to attribute from field or attribute](https://github.com/zinc-collective/convene/pull/469)
- [x] `check_dropbox/_in_room`  and `check_dropbox/checks/new` are basically copies
- [x] get specs to 🟢 
  - [x] in `check_request_spec.rb`, the faking of `Plaid::PlaidUtility` in the `before` block needs to be ~~killed with fire~~ adjusted to match the new utility structure 
- [ ] Maybe? Figure out how to indicate that a piece of Furniture relies on a Utility that requires loading javascript asset(s); so that it's not something we have to write into each view that happens to use the utility.