### PR TITLE
Consolidate naming of local variables in form partials

### DIFF
--- a/app/furniture/markdown_text_block/_form.html.erb
+++ b/app/furniture/markdown_text_block/_form.html.erb
@@ -1,5 +1,5 @@
 <%= form.fields_for(:furniture) do |furniture_fields| %>
   <%= furniture_fields.label :content %>
   <%= furniture_fields.text_area :content %>
-  <%= render partial: "error", locals: { model: furniture_fields.object, field: :content } %>
+  <%= render partial: "error", locals: { model: furniture_fields.object, attribute: :content } %>
 <%- end %>

--- a/app/utilities/jitsi_utility/_form.html.erb
+++ b/app/utilities/jitsi_utility/_form.html.erb
@@ -2,5 +2,5 @@
 <%= form.fields_for(:utility) do |utility_fields| %>
   <%= utility_fields.label :meet_domain %>
   <%= utility_fields.text_field :meet_domain %>
-  <%= render partial: "error", locals: { model: form.object, field: :meet_domain } %>
+  <%= render partial: "error", locals: { model: form.object, attribute: :meet_domain } %>
 <%- end %>

--- a/app/views/application/_error.html.erb
+++ b/app/views/application/_error.html.erb
@@ -1,3 +1,3 @@
-<%- if model.errors[field].present? %>
-<p class="error-message"><%= model.errors[field].join(', ') %></p>
+<%- if model.errors.messages_for(attribute).present? %>
+  <p class="field_with_errors"><%= model.errors.messages_for(attribute).join(', ') %></p>
 <%- end %>

--- a/app/views/application/_password_field.html.erb
+++ b/app/views/application/_password_field.html.erb
@@ -1,3 +1,3 @@
 <%= form.label attribute %>
 <%= form.password_field attribute, value: form.object.send(attribute)  %>
-<%= render partial: "error", locals: { model: form.object, field: attribute } %>
+<%= render partial: "error", locals: { model: form.object, attribute: attribute } %>

--- a/app/views/application/_select.html.erb
+++ b/app/views/application/_select.html.erb
@@ -1,3 +1,3 @@
 <%= form.label attribute %>
 <%= form.select attribute, options, include_blank: include_blank %>
-<%= render partial: "error", locals: { model: form.object, field: attribute } %>
+<%= render partial: "error", locals: { model: form.object, attribute: attribute } %>

--- a/app/views/application/_text_field.html.erb
+++ b/app/views/application/_text_field.html.erb
@@ -1,3 +1,5 @@
-<%= form.label attribute %>
-<%= form.text_field attribute %>
-<%= render partial: "error", locals: { model: form.object, field: attribute } %>
+<div>
+  <%= form.label attribute %>
+  <%= form.text_field attribute %>
+  <%= render partial: "error", locals: { model: form.object, attribute: attribute } %>
+</div>

--- a/app/views/authenticated_sessions/_form.html.erb
+++ b/app/views/authenticated_sessions/_form.html.erb
@@ -4,14 +4,14 @@
       <%= form.hidden_field :contact_method, value: :email %>
       <%= form.label :contact_location %>
       <%= form.email_field :contact_location %>
-      <%= render partial: "error", locals: { model: form.object, field: :contact_location } %>
+      <%= render partial: "error", locals: { model: form.object, attribute: :contact_location } %>
     <% else %>
       <p>Check your email for a one-time password to complete the sign in process</p>
       <%= form.hidden_field :contact_method %>
       <%= form.hidden_field :contact_location %>
       <%= form.label :one_time_password %>
       <%= form.text_field :one_time_password %>
-      <%= render partial: "error", locals: { model: form.object, field: :one_time_password } %>
+      <%= render partial: "error", locals: { model: form.object, attribute: :one_time_password } %>
     <% end %>
     <%= form.submit %>
   </fieldset>

--- a/app/views/rooms/_form.html.erb
+++ b/app/views/rooms/_form.html.erb
@@ -3,13 +3,13 @@
     <div>
       <%= room_form.label :name %>
       <%= room_form.text_field :name %>
-      <%= render partial: "error", locals: { model: room, field: :name } %>
+      <%= render partial: "error", locals: { model: room, attribute: :name } %>
     </div>
 
     <div>
       <%= room_form.label :slug %>
       <%= room_form.text_field :slug %>
-      <%= render partial: "error", locals: { model: room, field: :slug } %>
+      <%= render partial: "error", locals: { model: room, attribute: :slug } %>
     </div>
 
     <h3>Privacy and Security</h3>
@@ -17,19 +17,19 @@
     <div>
      <%= room_form.label :publicity_level %>
      <%= room_form.select :publicity_level, Room::PUBLICITY_LEVELS.map(&:to_s) %>
-     <%= render partial: "error", locals: { model: room, field: :publicity_level } %>
+     <%= render partial: "error", locals: { model: room, attribute: :publicity_level } %>
     </div>
 
     <div>
       <%= room_form.label :access_level %>
       <%= room_form.select :access_level, ['locked', 'unlocked'], { class: "form-select" }, "data-action": "room-form#accessLevelToggle" %>
-      <%= render partial: "error", locals: { model: room, field: :access_level } %>
+      <%= render partial: "error", locals: { model: room, attribute: :access_level } %>
     </div>
 
     <div>
       <%= room_form.label :access_code %>
       <%= room_form.text_field :access_code, "data-target": "room-form.accessCode", disabled: !room.locked? %>
-      <%= render partial: "error", locals: { model: room, field: :access_code } %>
+      <%= render partial: "error", locals: { model: room, attribute: :access_code } %>
     </div>
 
     <footer>

--- a/app/views/spaces/edit.html.erb
+++ b/app/views/spaces/edit.html.erb
@@ -12,13 +12,13 @@
         <div>
           <%= invitation_form.label :name %>
           <%= invitation_form.text_field :name %>
-          <%= render partial: "error", locals: { model: invitation_form.object, field: :name } %>
+          <%= render partial: "error", locals: { model: invitation_form.object, attribute: :name } %>
         </div>
 
         <div>
           <%= invitation_form.label :email %>
           <%= invitation_form.text_field :email %>
-          <%= render partial: "error", locals: { model: invitation_form.object, field: :email } %>
+          <%= render partial: "error", locals: { model: invitation_form.object, attribute: :email } %>
         </div>
 
         <footer>

--- a/app/views/waiting_rooms/show.html.erb
+++ b/app/views/waiting_rooms/show.html.erb
@@ -7,12 +7,9 @@
   </div>
 
   <%= form_with model: waiting_room, url: space_room_waiting_room_path(waiting_room.space, waiting_room.room), class: "access-code-form", local: true do |form| %>
-    <%= form.label :access_code %>
-    <%= form.password_field :access_code, class: "access-code-form__input" %>
+    <%= render "password_field", form: form, attribute: :access_code%>
+
     <%= form.hidden_field :redirect_url %>
-    <%- if waiting_room.errors[:access_code].present? %>
-      <p class="access-code-form__error-message"><%= waiting_room.errors[:access_code].join(', ') %></p>
-    <%- end %>
     <footer>
       <%= form.submit class: "--neutral" %>
     </footer>

--- a/features/harness/WaitingRoomPage.js
+++ b/features/harness/WaitingRoomPage.js
@@ -37,7 +37,7 @@ class WaitingRoomPage extends RoomPage {
    * @returns {Component}
    */
   errors() {
-    return this.component("[class='access-code-form__error-message']");
+    return this.component(".field_with_errors");
   }
 }
 

--- a/features/steps/room_steps.js
+++ b/features/steps/room_steps.js
@@ -93,6 +93,13 @@ Then("the {actor} is not placed in the {room}", function (actor, room) {
 
 Then(
   "{a} {actor} may not enter {a} {accessLevel} {room} after providing {a} {accessCode}",
+  /**
+   *
+   * @param {Actor} actor
+   * @param {AccessLevel} accessLevel
+   * @param {Room} room
+   * @param {AccessCode} accessCode
+   */
   async function (_, actor, _, accessLevel, room, _, accessCode) {
     linkParameters({ room, accessLevel });
 


### PR DESCRIPTION
Pulled from [our work cleaning up the payment form](https://github.com/zinc-collective/convene/pull/463); this should make it a bit more consistent when working with partials.