### PR TITLE
Prevent `ParentClassMismatchError`

### DIFF
--- a/app/utilities/jitsi_utility.rb
+++ b/app/utilities/jitsi_utility.rb
@@ -15,9 +15,3 @@ class JitsiUtility < Utility
     super + [:meet_domain]
   end
 end
-
-class JitsiUtilityPolicy < UtilityPolicy
-  def permitted_params
-    [:meet_domain]
-  end
-end

--- a/app/utilities/jitsi_utility/jitsi_utility_policy.rb
+++ b/app/utilities/jitsi_utility/jitsi_utility_policy.rb
@@ -1,0 +1,7 @@
+class JitsiUtility < Utility
+  class JitsiUtilityPolicy < UtilityPolicy
+    def permitted_params
+      [:meet_domain]
+    end
+  end
+end

--- a/app/utilities/plaid_utility.rb
+++ b/app/utilities/plaid_utility.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-
 # Provides Plaid functionality to a {Space}
 # @see https://plaid.com
 class PlaidUtility < Utility
@@ -102,11 +101,5 @@ class PlaidUtility < Utility
   # @returns [::Plaid]
   def sdk
     ::Plaid
-  end
-end
-
-class PlaidUtilityPolicy < UtilityPolicy
-  def permitted_params
-    %i[environment secret client_id version]
   end
 end

--- a/app/utilities/plaid_utility/plaid_utility_policy.rb
+++ b/app/utilities/plaid_utility/plaid_utility_policy.rb
@@ -1,0 +1,7 @@
+class PlaidUtility < Utility
+  class PlaidUtilityPolicy < UtilityPolicy
+    def permitted_params
+      %i[environment secret client_id version]
+    end
+  end
+end


### PR DESCRIPTION
Turns out, having two classes in the same file with Zeitwerk is a very
not great idea.