### PR TITLE
Leverage existing retry package over handrolled one

### DIFF
--- a/features/lib/MailServer.js
+++ b/features/lib/MailServer.js
@@ -1,5 +1,6 @@
 const axios = require("axios");
 const { filter, last } = require("lodash");
+var promiseRetry = require('promise-retry');
 
 /**
  * Adapter connecting our test suite to our mail handler
@@ -22,21 +23,11 @@ class MailServer {
    * @returns {Promise<MailServerEmail[]>}
    */
   emailsTo(emailAddress) {
-    return this._emailsTo(emailAddress).then((emails) => {
-      if (emails.length > 0) {
-        return emails;
-      } else {
-        return new Promise((resolve) =>
-          setTimeout(() => this._emailsTo(emailAddress).then(resolve), 10)
-        );
-      }
-    });
-  }
-
-  _emailsTo(emailAddress) {
-    return this.emails().then((emails) =>
-      filter(emails, (email) => email.headers.to === emailAddress)
-    );
+    return promiseRetry((retry) => {
+      return this.emails()
+        .then((emails) => filter(emails, (email) => email.headers.to === emailAddress))
+        .then((emails) => emails.length > 0 ? emails : retry());
+    })
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "geckodriver": "^3.0.1",
     "get-urls": "^10.0.1",
     "lodash": "^4.17.21",
+    "promise-retry": "^2.0.1",
     "selenium-webdriver": "^4.1.0",
     "webpack-dev-server": "^4.7.1"
   },


### PR DESCRIPTION
See: https://github.com/zinc-collective/convene/commit/602cc9fa93b0b12b7eb06d553949efe2701cc3fa#diff-1c67ac0004ed4084600492cb9d08dff4296781c983078ac9423474d646617a23R30

When we first started writing this, it seemed reasonable to use `delay`
(which looks like it's not built into node, or cucumber-js, so I have no
idea where the global function even came from?!) to wait for 10ms and try
again; however that appears to have resulted in race conditions when moving to
setInterval; so let's try to leverage `retry-promise` so we don't have
to keep hand-rolling trying again.