### PR TITLE
Initial sketch of a "MediaBox"

### DIFF
--- a/app/furniture/media_box/README.md
+++ b/app/furniture/media_box/README.md
@@ -1,0 +1,11 @@
+# Media Box
+
+Own your own (or your neighborhood's) list of {book|music|other media} recommendations.
+
+For use cases, see [`features/furniture/media_box.feature`](../../../features/furniture/media_box.feature)
+
+We could start by focusing on the book recommendation use case, and think about ways to federate with [BookWyrm](https://github.com/bookwyrm-social) or perhaps cross-post.
+
+One big question to think about is: who provides and/or maintains the Source of Truth data for these recommendations (e.g. a database of all ISBNs and their metadata)? And, relatedly: how much do we care about there being a solid data source backing these recommendations? We could start with something like a controlled database and let people add to it, with some simple encouragement for de-duping when adding a new entry.
+
+For book data specifically, there are some open sources of data that we could start with, such as the Open Library (see: https://openlibrary.org/developers/dumps, https://github.com/LibrariesHacked/openlibrary-search)

--- a/features/furniture/media_box.feature
+++ b/features/furniture/media_box.feature
@@ -4,6 +4,25 @@ Feature: Furniture - MediaBox (🌰)
   # - Share your Reccommendations and AntiRecommendations!
   # - Generate Revenue for the Neighborhood through Affiliate Programs!
   #
+  # Each Space operates a MediaBox and own their Reviews of the Media; while the
+  # Neighborhood holds the information about how to acquire the pieces of Media
+  # in they're particular formats, and generates revenue by injecting affiliate
+  # marketing links into the Reviews/Recommendation results.
+  #
+  # Assuming the Neighborhood is operated as a Contributor/Community
+  # Co-operative; profits would flow back to Contributors as part of the regular
+  # Patronage redemptions, and back to the Community as Patronage Refunds or
+  # reduced prices.
+  #
+  # There are likely three main use cases:
+  # - "Reviewing Media" for people who like to keep a record and share what
+  #   they've read/listened to/watched
+  # - "Finding Media" for people who are like "What do I wanna watch/read/listen
+  #   to?"
+  # - "Reading Media Reviews" for people who want a more in-depth way of
+  #   evaluating potential media choices.
+  # - "Acquiring Media" once people have made a "I want this!" decision.
+  #
   # Data Prototype: https://airtable.com/shrUIIkF5Gnm6R5ff
   #
 

--- a/features/furniture/media_box.feature
+++ b/features/furniture/media_box.feature
@@ -61,6 +61,7 @@ Feature: Furniture - MediaBox (🌰)
 
   # This illustrates how revenue flows back into the organization operating the Convene instance.
   # @see features/vendor-affiliates.feature
+  @unstarted
   Scenario: Acquiring Media
     Given the Neighborhood has the following Affiliate Relationships:
       | vendor       |

--- a/features/furniture/mediabox.feature
+++ b/features/furniture/mediabox.feature
@@ -1,0 +1,20 @@
+Feature: Furniture - MediaBox (🌰)
+  - Find Media to Consume!
+  - Maintain a History of your media consumption!
+  - Share your Reccommendatins and AntiRecommendations!
+  - Generate Revenue for the Neighborhood through Affiliate Programs!
+
+  Data Prototype: https://airtable.com/shrUIIkF5Gnm6R5ff
+
+
+  @unstarted
+  Scenario: Finding Media to Consume
+
+  @unstarted
+  Scenario: Reviewing Media
+
+  @unstarted
+  Scenario: Reading Media Reviews
+
+
+

--- a/features/furniture/mediabox.feature
+++ b/features/furniture/mediabox.feature
@@ -40,6 +40,19 @@ Feature: Furniture - MediaBox (🌰)
       | Ancillary Justice         |
       | A Song for the Wild Built |
 
+  # This illustrates how revenue flows back into the organization operating the Convene instance.
+  # @see features/vendor-affiliates.feature
+  Scenario: Acquiring Media
+    Given the Neighborhood has the following Affiliate Relationships:
+      | vendor       |
+      | bookshop.org |
+    And the "Ancillary Justice" Media may be Acquired At:
+      | format    | link                                                       |
+      | paperback | https://bookshop.org/books/ancillary-justice/9780316246620 |
+      | ebook     | https://www.kobo.com/us/en/ebook/ancillary-justice-1       |
+    When Someone buys a copy of "Ancillary Justice" by following the "Bookshop.org" Get This Link
+    Then the Neighborhood Operator is granted the affiliate fee
+
 
   @unstarted
   Scenario: Reviewing Media

--- a/features/furniture/mediabox.feature
+++ b/features/furniture/mediabox.feature
@@ -1,14 +1,45 @@
 Feature: Furniture - MediaBox (🌰)
-  - Find Media to Consume!
-  - Maintain a History of your media consumption!
-  - Share your Reccommendatins and AntiRecommendations!
-  - Generate Revenue for the Neighborhood through Affiliate Programs!
+  # - Find Media to Consume!
+  # - Maintain a History of your media consumption!
+  # - Share your Reccommendations and AntiRecommendations!
+  # - Generate Revenue for the Neighborhood through Affiliate Programs!
+  #
+  # Data Prototype: https://airtable.com/shrUIIkF5Gnm6R5ff
+  #
 
-  Data Prototype: https://airtable.com/shrUIIkF5Gnm6R5ff
+
+  Background:
+    Given a Space with the "MediaBox Demo" Room
+    And the "MediaBox" Furniture is in the "MediaBox Demo" Room
+    And the Neighborhood's MediaBoxes have the following Reviews:
+      | media                     | recommendation | format    | themes                                                                            | content warnings                                |
+      | A Song for the Wild Built | yes            | audiobook | fiction,speculative fiction,solarpunk, artificial sentience, tea                  |                                                 |
+      | Ancillary Justice         | yes            | ebook     | fiction,speculative fiction,tea,chosen family,genderfuckery, artificial sentience | military violence, violence                     |
+      | An Unkindness of Ghosts   | yes            | ebook     | gritty, fiction,speculative fiction,genderfuckery,personal liberation             | familial trauma, sexual violence, racial trauma |
 
 
+  # A MediaBox may provide Recommendations based upon the Users in-the-moment curiosity, prior consumption, and
+  # future intentions. The basic interaction flow uses a search box which can be expanded into weighted tag filter
+  # groups for format, thematic content, content warnings, or creator identity.
+  #
+  # A MediaBox's Recommendation Engine may be tuned by a Resident, giving Neighbors and Visitors further curated
+  # results.
+  #
+  # Note: There is clearly a fractal of interesting nuance to explore here; which may be best defined in
+  # `features/furniture/mediabox/search.feature`
   @unstarted
-  Scenario: Finding Media to Consume
+  Scenario: Finding Media
+    When the MediaBox is asked for Recommendations with the following Filters:
+      | query              | *                                              |
+      | formats[]          | audiobook,ebook                                |
+      | themes[]           | gritty--,liberation+,fiction                   |
+      | identities[]       | white--,masculine-,cooperative+,human+,b corp+ |
+      | content warnings[] | !sexual violence                               |
+    Then the Recommendations are:
+      | media                     |
+      | Ancillary Justice         |
+      | A Song for the Wild Built |
+
 
   @unstarted
   Scenario: Reviewing Media

--- a/features/vendor-affiliates.feature
+++ b/features/vendor-affiliates.feature
@@ -1,0 +1,1 @@
+# @todo Sketch this out


### PR DESCRIPTION
This is kind of a "Seed" of an idea; but wouldn't it be cool if people could write their reviews of particular pieces of media; including content warnings, thematic elements, and whether or not they endorse it; and Convene offered links to buy/rent the media in a way that generated affiliate revenue at the Neighborhood level?

There are likely three main use cases:

- "Reviewing Media" for people who like to keep a record and share what they've read/listened to/watched 
- "Finding Media" for people who are like "What do I wanna watch/read/listen to?"
- "Reading Media Reviews" for people who want a more in-depth way of evaluating potential media choices.
- "Acquiring Media" once people have made a "I want this!" decision.

Each Space operates a MediaBox and own their Reviews of the Media; while the Neighborhood holds the information about how to acquire the pieces of Media in they're particular formats, and generates revenue by injecting affiliate marketing links into the Reviews/Recommendation results. 

Assuming the Neighborhood is operated as a Contributor/Community Co-operative; profits would flow back to Contributors as part of the regular Patronage redemptions, and back to the Community as Patronage Refunds or reduced prices.
 
