### PR TITLE
Use just Turbo, not UJS

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,6 +1,4 @@
 // Entry point for the build script in your package.json
-
-require("@rails/ujs").start()
 require("@rails/activestorage").start()
 
 require("./channels")

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "@hotwired/turbo-rails": "^7.1.1",
     "@rails/actioncable": "^7.0.2",
     "@rails/activestorage": "^7.0.2",
-    "@rails/ujs": "^6.1.4",
     "@tailwindcss/typography": "^0.5.2",
     "@webpack-cli/serve": "^1.6.1",
     "autoprefixer": "^10.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -277,11 +277,6 @@
   dependencies:
     spark-md5 "^3.0.1"
 
-"@rails/ujs@^6.1.4":
-  version "6.1.4"
-  resolved "https://registry.yarnpkg.com/@rails/ujs/-/ujs-6.1.4.tgz#093d5341595a02089ed309dec40f3c37da7b1b10"
-  integrity sha512-O3lEzL5DYbxppMdsFSw36e4BHIlfz/xusynwXGv3l2lhSlvah41qviRpsoAlKXxl37nZAqK+UUF5cnGGK45Mfw==
-
 "@sindresorhus/is@^4.0.0":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.0.1.tgz#d26729db850fa327b7cacc5522252194404226f5"


### PR DESCRIPTION
While UJS and Turbo are compatible, they serve similar roles and we
don't (intentionally) use UJS anywhere.