### PR TITLE
Github is sad because ~16.13 does not include 16.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Community owned tools that bring people together, both online and off",
   "main": "index.js",
   "engines": {
-    "node": "~16.13",
-    "yarn": "~1.22"
+    "node": "^16.13",
+    "yarn": "^1.22"
   },
   "scripts": {
     "build": "webpack --config webpack.config.js",


### PR DESCRIPTION
Builds be like:

```
yarn install v1.22.17
[1/5] Validating package.json...
error convene@0.1.0: The engine "node" is incompatible with this module. Expected version "~16.13". Got "16.14.0"
error Found incompatible module.
```
But I think `^16.13` means `>16.13 <17.0`