### PR TITLE
Rails-ujs is probably safe to bump to 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@hotwired/turbo-rails": "^7.1.1",
     "@rails/actioncable": "^7.0.2",
     "@rails/activestorage": "^7.0.2",
-    "@rails/ujs": "^6.1.4",
+    "@rails/ujs": "^7.0.2",
     "@tailwindcss/typography": "^0.5.2",
     "@webpack-cli/serve": "^1.6.1",
     "autoprefixer": "^10.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -277,10 +277,10 @@
   dependencies:
     spark-md5 "^3.0.1"
 
-"@rails/ujs@^6.1.4":
-  version "6.1.4"
-  resolved "https://registry.yarnpkg.com/@rails/ujs/-/ujs-6.1.4.tgz#093d5341595a02089ed309dec40f3c37da7b1b10"
-  integrity sha512-O3lEzL5DYbxppMdsFSw36e4BHIlfz/xusynwXGv3l2lhSlvah41qviRpsoAlKXxl37nZAqK+UUF5cnGGK45Mfw==
+"@rails/ujs@^7.0.2":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@rails/ujs/-/ujs-7.0.2.tgz#6e0f843fb810b23ce1c33457b27e0accce6755e4"
+  integrity sha512-eAn41MQI6z9Yj4RVAIL9qzYorHRM22hPJp9MR86ra62UmcAsI3HEkIgeguN2qWJRxUbztLer+T4fycmTqB/Osw==
 
 "@sindresorhus/is@^4.0.0":
   version "4.0.1"


### PR DESCRIPTION
In https://github.com/zinc-collective/convene/pull/495, we thought we
didn't want to jump from 6 to 7 without bumping Rails first.

We also thought that maybe we didn't even need UJS, because we have no
use-cases where we are explicitely using it.

However, after removing UJS
https://github.com/zinc-collective/convene/pull/576 we discovered that
we _do_ use it for signing people out!

We did a review of the changelog and the commits between 6.X and 7.0 for
ujs, and they seemed computationally meaningless; so we think it's safe
to just bump and defer the deletion.

Co-authored-by: Kelly Hong <KellyAH@users.noreply.github.com>
Co-authored-by: Neer Malathapa <nirmalathapa@users.noreply.github.com>
Co-authored-by: Zee Spencer <zspencer@users.noreply.github.com>
Co-authored-by: Naomi Quinones <naomiquinones@users.noreply.github.com>