### PR TITLE
Invitations include name _or_ email of the Invitor

### DIFF
--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -26,9 +26,9 @@ class Invitation < ApplicationRecord
     status.to_sym == :accepted
   end
 
-  def invitor_display_name
-    invitor.display_name
-  end
+  # @!method invitor_display_name
+  #   @see Person#display_name
+  delegate :display_name, to: :invitor, prefix: true
 
   attribute :last_sent_at, :datetime
   attribute :created_at, :datetime

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -28,7 +28,7 @@ class Invitation < ApplicationRecord
 
   # @!method invitor_display_name
   #   @see Person#display_name
-  delegate :display_name, to: :invitor, prefix: true
+  delegate :display_name, to: :invitor, prefix: true, allow_nil: true
 
   attribute :last_sent_at, :datetime
   attribute :created_at, :datetime

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -26,6 +26,10 @@ class Invitation < ApplicationRecord
     status.to_sym == :accepted
   end
 
+  def invitor_display_name
+    invitor.display_name
+  end
+
   attribute :last_sent_at, :datetime
   attribute :created_at, :datetime
   attribute :updated_at, :datetime

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -24,7 +24,9 @@ class Person < ApplicationRecord
   end
 
   def display_name
-    name || email
+    return name if name.present?
+
+    email
   end
 
   def authenticated?

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -23,6 +23,10 @@ class Person < ApplicationRecord
     false
   end
 
+  def display_name
+    name || email
+  end
+
   def authenticated?
     true
   end

--- a/app/views/rsvps/show.html.erb
+++ b/app/views/rsvps/show.html.erb
@@ -1,7 +1,7 @@
 <% breadcrumb :rsvp, rsvp %>
 
 <h2><%= t('.header', space_name: rsvp.invitation.space.name)%></h2>
-<p><%= t('.summary', space_name: rsvp.invitation.space.name, invitor_name: rsvp.invitation.invitor.name, invitation_date: rsvp.invitation.created_at) %></p>
+<p><%= t('.summary', space_name: rsvp.invitation.space.name, invitor_name: rsvp.invitation.invitor_display_name, invitation_date: rsvp.invitation.created_at) %></p>
 
 <%= form_with model: [rsvp.space, rsvp.invitation, rsvp], local: true do |rsvp_form|%>
   <%= rsvp_form.hidden_field :status, value: "accepted" %>

--- a/app/views/space_invitation_mailer/space_invitation_email.text.erb
+++ b/app/views/space_invitation_mailer/space_invitation_email.text.erb
@@ -1,6 +1,6 @@
 Hi <%= @invitation.name %>,
 
-You've been invited to <%= @invitation.space.name %> by <%= @invitation.invitor.name %>.
+You've been invited to <%= @invitation.space.name %> by <%= @invitation.invitor_display_name %>.
 
 You may RSVP to this invitation at <%= space_invitation_rsvp_url(@invitation.space, @invitation) %>.
 

--- a/features/spaces/invitations.feature
+++ b/features/spaces/invitations.feature
@@ -31,6 +31,19 @@ Feature: Spaces: Invitations
     When a new Invitation is sent to that Invitation's contact info
     And the old Invitation can not still be accepted
 
+
+  @unstarted @andromeda
+  Scenario: Invitations remain even if the Invitor was Removed from the Space
+    Given a "System Test" Space
+    And the "System Test" Space has a Space Owner "soon-to-leave@example.com"
+    And an Invitation to the "System Test" Space is sent by Space Owner "soon-to-leave@example.com"
+      | name | email                       |
+      | Aang | aang-the-avatar@example.com |
+    And the "System Test" Space removes the Space Owner "soon-to-leave@example.com"
+    When the Invitation to "aang-the-avatar@example.com" is Accepted
+    Then the "System Test" Space has a Space Member "aang-the-avatar@example.com"
+
+
   @unstarted @andromeda
   Scenario: Accepting an Invitation as a Neighbor
     Given an Invitation was sent to a Neighbor

--- a/features/spaces/moderation.feature
+++ b/features/spaces/moderation.feature
@@ -1,0 +1,20 @@
+Feature: Spaces: Moderation
+
+
+  @unstarted @andromeda
+  Scenario: Removing Space Members
+    Given a "System Test" Space
+    And the "System Test" Space has a Space Owner "space-owner@example.com"
+    And the "System Test" Space has a Space Member "bad-actor@example.com"
+    And an Invitation to the "System Test" Space is sent by Space Member "bad-actor@example.com"
+      | name | email                       |
+      | Aang | aang-the-avatar@example.com |
+    And an Invitation to the "System Test" Space is sent by Space Member "bad-actor@example.com"
+      | name | email                       |
+      | Katara | katara-the-waterbender@example.com |
+    And an Invitation to "aang-the-avatar@example.com" the "System Test" Space is accepted
+    When the Space Member "bad-actor@example.com" is removed from the "System Test" Space by the Space Owner "space-owner@example.com"
+    # We thought that maybe instead of explicitely removing invitations and members, we would
+    # start by letting them know who else that person invited.
+    Then the Space Owner "space-owner@example.com" is encouraged to investigate the Space Member "aang-the-avatar@example.com"
+    Then the Space Owner "space-owner@example.com" is encouraged to investigate the Invitation to "katara-the-waterbender@example.com"

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -8,4 +8,12 @@ RSpec.describe Invitation, type: :model do
   it { is_expected.to validate_presence_of(:email) }
   it { is_expected.to validate_inclusion_of(:status).in_array(Invitation::STATUSES) }
   it { is_expected.to validate_presence_of(:name) }
+
+  describe '#invitor_display_name' do
+    it 'is the invitors display name' do
+      invitor = build(:person)
+      invitation = build(:invitation, invitor: invitor)
+      expect(invitation.invitor_display_name).to eq(invitor.display_name)
+    end
+  end
 end

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -15,5 +15,10 @@ RSpec.describe Invitation, type: :model do
       invitation = build(:invitation, invitor: invitor)
       expect(invitation.invitor_display_name).to eq(invitor.display_name)
     end
+
+    it 'is empty when the invitor is not set' do
+      invitation = build(:invitation, invitor: nil)
+      expect(invitation.invitor_display_name).to be_blank
+    end
   end
 end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -5,6 +5,27 @@ require 'rails_helper'
 RSpec.describe Person, type: :model do
   it { is_expected.to have_many(:invitations).inverse_of(:invitor) }
 
+  describe '#display_name' do
+    it 'is blank when `name` and `email` are blank' do
+      expect(described_class.new(name: '', email: nil).display_name).to be_blank
+    end
+    it 'is the `name` when `name` is present and `email` is present' do
+      expect(
+        described_class.new(name: 'Naomi', email: 'naomi@example.com').display_name
+      ).to eq('Naomi')
+    end
+    it 'is the `email` when `name` is blank and `email` is present' do
+      expect(
+        described_class.new(name: '', email: 'naomi@example.com').display_name
+      ).to eq('naomi@example.com')
+    end
+    it 'is the `name` when `name` is present and `email` is blank' do
+      expect(
+        described_class.new(name: 'Naomi', email: nil).display_name
+      ).to eq('Naomi')
+    end
+  end
+
   describe '#member_of?' do
     let(:membership) { create(:space_membership) }
     let(:space) { membership.space }


### PR DESCRIPTION
See: https://github.com/zinc-collective/convene/issues/117#issuecomment-962519714

@anaulin had noticed that the invitation emails were left dangling after
"Invited by..." when the Invitor doesn't have a name.

We've pulled out a `display_name` method for the Person, and delegate it
explicitely in the `Invitation` as the `invitor_display_name`.

This gives us a seam for making more intelligent decisions about how we
present peoples names/emails/identities/etc in the application, but does
not exercise that seam to aggressively.