### PR TITLE
Also destroy Person's AuthenticationMethods and SpaceMemberships

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -5,10 +5,10 @@ class Person < ApplicationRecord
   validates :email, presence: true, uniqueness: { case_sensitive: false }
 
   # Joins the person to the spaces they are part of
-  has_many :space_memberships, inverse_of: :member, foreign_key: :member_id
+  has_many :space_memberships, inverse_of: :member, foreign_key: :member_id, dependent: :destroy_async
 
   # Ways for the person to sign in
-  has_many :authentication_methods
+  has_many :authentication_methods, inverse_of: :person, dependent: :destroy_async
 
   # The Spaces the Person is part of
   has_many :spaces, through: :space_memberships

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -4,6 +4,8 @@ require 'rails_helper'
 
 RSpec.describe Person, type: :model do
   it { is_expected.to have_many(:invitations).inverse_of(:invitor) }
+  it { is_expected.to have_many(:authentication_methods).inverse_of(:person).dependent(:destroy_async) }
+  it { is_expected.to have_many(:space_memberships).inverse_of(:member).dependent(:destroy_async) }
 
   describe '#display_name' do
     it 'is blank when `name` and `email` are blank' do


### PR DESCRIPTION
I was doing some poking at the data on my machine, deleted a person, and
discovered that some of their PII and Context sticks around when it
probably shouldn't.

Now when a Person is destroyed, their Space Membershipsand
Authentication Methods do as well.