### PR TITLE
Invitations: Redesign Invitations

### DIFF
--- a/app/controllers/rsvps_controller.rb
+++ b/app/controllers/rsvps_controller.rb
@@ -6,13 +6,16 @@ class RsvpsController < ApplicationController
   end
 
   def update
-    rsvp.update(rsvp_params)
+    if rsvp.update(rsvp_params)
+      redirect_to rsvp.space, notice: t('.success', space_name: rsvp.space.name)
+    end
   end
 
   def rsvp_params
     params.require(:rsvp).permit(:status, :one_time_password)
   end
 
+  # @return [Rsvp]
   helper_method def rsvp
     @rsvp ||= Rsvp.new(invitation: invitation).tap { |rsvp| authorize(rsvp) }
   end

--- a/app/controllers/rsvps_controller.rb
+++ b/app/controllers/rsvps_controller.rb
@@ -7,11 +7,10 @@ class RsvpsController < ApplicationController
 
   def update
     rsvp.update(rsvp_params)
-    redirect_to new_space_authenticated_session_path(invitation.space, authenticated_session: { contact_method: :email, contact_location: invitation.email })
   end
 
   def rsvp_params
-    params.require(:rsvp).permit(:status)
+    params.require(:rsvp).permit(:status, :one_time_password)
   end
 
   helper_method def rsvp

--- a/app/models/authentication_method.rb
+++ b/app/models/authentication_method.rb
@@ -34,6 +34,10 @@ class AuthenticationMethod < ApplicationRecord
     totp.verify(one_time_password).present?
   end
 
+  def verify!(one_time_password)
+    verify?(one_time_password) && confirm!
+  end
+
   def one_time_password
     totp.at(last_one_time_password_at)
   end

--- a/app/models/blueprint.rb
+++ b/app/models/blueprint.rb
@@ -29,7 +29,7 @@ class Blueprint
   def set_rooms
     space_attributes.fetch(:rooms, []).each do |room_attributes|
       room = space.rooms.find_or_initialize_by(name: room_attributes[:name])
-      room.update!(merge_non_empty(room_attributes, room.attributes).except(:name, :furniture_placements))
+      room.update!(merge_non_empty(room.attributes, room_attributes).except(:name, :furniture_placements))
       add_furniture(room, room_attributes)
     end
   end

--- a/app/models/rsvp.rb
+++ b/app/models/rsvp.rb
@@ -20,6 +20,7 @@ class Rsvp
       person.space_memberships.create(space: invitation.space)
     else
       authentication_method.send_one_time_password!(invitation.space)
+      false
     end
   end
 

--- a/app/models/rsvp.rb
+++ b/app/models/rsvp.rb
@@ -4,20 +4,23 @@ class Rsvp
   include ActiveModel::Model
 
   attr_accessor :invitation
+
   delegate :space, to: :invitation
 
   def update(attributes)
     person = Person.create_with(name: invitation.name).find_or_create_by(email: invitation.email)
 
-    authentication_method = person.authentication_methods.find_or_create_by(contact_method: :email, contact_location: invitation.email)
+    authentication_method = person.authentication_methods.find_or_create_by(contact_method: :email,
+                                                                            contact_location: invitation.email)
 
-    if person.previously_new_record?
+    authentication_method.verify!(attributes[:one_time_password]) if attributes[:one_time_password]
+    if authentication_method.confirmed?
       invitation.update(status: attributes[:status])
 
       person.space_memberships.create(space: invitation.space)
+    else
+      authentication_method.send_one_time_password!(invitation.space)
     end
-
-    authentication_method.send_one_time_password!(invitation.space)
   end
 
   # Overload `persisted?` so the Rails url build won't try to pluralize rsvps.

--- a/app/views/rsvps/update.html.erb
+++ b/app/views/rsvps/update.html.erb
@@ -1,0 +1,10 @@
+<% breadcrumb :rsvp, rsvp %>
+
+<h2><%= t('.header', email: rsvp.invitation.email)%></h2>
+<p><%= t('.summary', invitor_name: rsvp.invitation.invitor_display_name) %></p>
+
+<%= form_with model: [rsvp.space, rsvp.invitation, rsvp], local: true do |rsvp_form|%>
+  <%= rsvp_form.hidden_field :status, value: "accepted" %>
+  <%= render "text_field", form: rsvp_form, attribute: :one_time_password %>
+  <%= rsvp_form.submit t('.accept', space_name: rsvp.space.name) %>
+<%- end %>

--- a/config/locales/rsvp/en.yml
+++ b/config/locales/rsvp/en.yml
@@ -6,6 +6,6 @@ en:
       accept: "Join %{space_name}"
       ignore: "Ignore this invitation"
     update:
-      header: "Confirm your access to the email address '${email}'"
+      header: "Confirm your access to the email address '%{email}'"
       summary: "Let's make sure you really are the person %{invitor_name} thinks you are!"
       accept: "Confirm and Join %{space_name}"

--- a/config/locales/rsvp/en.yml
+++ b/config/locales/rsvp/en.yml
@@ -5,3 +5,7 @@ en:
       summary: "You were invited to '%{space_name}' by %{invitor_name} on %{invitation_date}"
       accept: "Join %{space_name}"
       ignore: "Ignore this invitation"
+    update:
+      header: "Confirm your access to the email address '${email}'"
+      summary: "Let's make sure you really are the person %{invitor_name} thinks you are!"
+      accept: "Confirm and Join %{space_name}"

--- a/config/locales/rsvp/en.yml
+++ b/config/locales/rsvp/en.yml
@@ -7,5 +7,6 @@ en:
       ignore: "Ignore this invitation"
     update:
       header: "Confirm your access to the email address '%{email}'"
-      summary: "Let's make sure you really are the person %{invitor_name} thinks you are!"
+      summary: "Let's make sure you really are the person %{invitor_name} thinks you are! We've sent you an email with a passcode that will expire in 10 minutes."
       accept: "Confirm and Join %{space_name}"
+      success: "Yay! Welcome to %{space_name} 🎉"

--- a/features/harness/SignInPage.js
+++ b/features/harness/SignInPage.js
@@ -23,7 +23,7 @@ class SignInPage extends Page {
    * @returns {Promise<this>}
    */
   submitCode(code) {
-    return this.component('input[name="authenticated_session[one_time_password]"]')
+    return this.component('input[name*="[one_time_password]"]')
       .fillIn(code)
       .then(() => this.submitButton().click())
       .finally(() => this)

--- a/features/lib/Actor.js
+++ b/features/lib/Actor.js
@@ -41,17 +41,14 @@ class Actor {
     return getUrls(email.text).values().next().value;
   }
 
-
   /**
    * The code a user can use to sign in
    * @returns {Promise<string>}
    */
   async authenticationCode() {
-    const email = await this.emails({
-      text: (t) => t.match(/password is (\d+)/),
-    }).then(last);
-
-    return email.text.match(/password is (\d+)/)[1];
+    return this.emails({ text: (t) => t.match(/password is (\d+)/) })
+      .then(last)
+      .then((email) => email.text.match(/password is (\d+)/)[1]);
   }
 
   /**

--- a/features/lib/Api.js
+++ b/features/lib/Api.js
@@ -4,6 +4,7 @@ const Room = require("./Room");
 const applyCaseMiddleware = require("axios-case-converter").default;
 const Space = require("./Space");
 const AuthenticationMethod = require("./AuthenticationMethod");
+const SpaceMembership = require("./SpaceMembership");
 class Api {
   constructor(host, apiKey) {
     this.host = host;
@@ -44,7 +45,18 @@ class Api {
     return new Repository({
       client: this,
       endpoint: "/authentication_methods",
-      model: AuthenticationMethod
+      model: AuthenticationMethod,
+    });
+  }
+
+  /**
+   * @returns {Repository}
+   */
+  spaceMemberships() {
+    return new Repository({
+      client: this,
+      endpoint: "/space_memberships",
+      model: SpaceMembership,
     });
   }
 
@@ -111,4 +123,4 @@ class Repository {
     const data = response.data[camelCase(model.name)] || response.data;
     return new model(data);
   }
-}
+git}

--- a/features/lib/Api.js
+++ b/features/lib/Api.js
@@ -123,4 +123,4 @@ class Repository {
     const data = response.data[camelCase(model.name)] || response.data;
     return new model(data);
   }
-git}
+}

--- a/features/lib/Api.js
+++ b/features/lib/Api.js
@@ -3,6 +3,7 @@ const { camelCase } = require("change-case");
 const Room = require("./Room");
 const applyCaseMiddleware = require("axios-case-converter").default;
 const Space = require("./Space");
+const AuthenticationMethod = require("./AuthenticationMethod");
 class Api {
   constructor(host, apiKey) {
     this.host = host;
@@ -33,6 +34,18 @@ class Api {
    */
   rooms(space) {
     return new Repository({ client: this, endpoint: `/spaces/${space.slug}/rooms`, model: Room });
+  }
+
+  /**
+   *
+   * @returns {Repository}
+   */
+  authenticationMethods() {
+    return new Repository({
+      client: this,
+      endpoint: "/authentication_methods",
+      model: AuthenticationMethod
+    });
   }
 
   post(path, model) {

--- a/features/lib/Api.js
+++ b/features/lib/Api.js
@@ -1,10 +1,10 @@
 const axios = require("axios");
-const { camelCase } = require("change-case");
-const Room = require("./Room");
 const applyCaseMiddleware = require("axios-case-converter").default;
 const Space = require("./Space");
+const Room = require("./Room");
 const AuthenticationMethod = require("./AuthenticationMethod");
 const SpaceMembership = require("./SpaceMembership");
+const { camelCase } = require("lodash");
 class Api {
   constructor(host, apiKey) {
     this.host = host;

--- a/features/lib/AuthenticationMethod.js
+++ b/features/lib/AuthenticationMethod.js
@@ -1,0 +1,19 @@
+
+class AuthenticationMethod {
+  constructor({ contactMethod, contactLocation} ) {
+    this.contactMethod = contactMethod
+    this.contactLocation = contactLocation
+  }
+
+  asParams() {
+    return {
+      authenticationMethod: {
+        contactMethod: this.contactMethod,
+        contactLocation: this.contactLocation,
+      }
+    }
+
+  }
+}
+
+module.exports = AuthenticationMethod;

--- a/features/lib/AuthenticationMethod.js
+++ b/features/lib/AuthenticationMethod.js
@@ -1,8 +1,10 @@
 
 class AuthenticationMethod {
-  constructor({ contactMethod, contactLocation} ) {
+  constructor({ id, contactMethod, contactLocation, person }) {
+    this.id = id
     this.contactMethod = contactMethod
     this.contactLocation = contactLocation
+    this.person = person
   }
 
   asParams() {

--- a/features/lib/Space.js
+++ b/features/lib/Space.js
@@ -11,6 +11,12 @@ class Space {
       space: { name: this.name, slug: this.slug, blueprint: 'system_test', clientAttributes: { name: this.name } }
     }
   }
+
+  asParams() {
+    return {
+      space: { name: this.name, slug: this.slug }
+    }
+  }
 }
 
 module.exports = Space;

--- a/features/lib/Space.js
+++ b/features/lib/Space.js
@@ -11,12 +11,6 @@ class Space {
       space: { name: this.name, slug: this.slug, blueprint: 'system_test', clientAttributes: { name: this.name } }
     }
   }
-
-  asParams() {
-    return {
-      space: { name: this.name, slug: this.slug }
-    }
-  }
 }
 
 module.exports = Space;

--- a/features/lib/SpaceMembership.js
+++ b/features/lib/SpaceMembership.js
@@ -1,0 +1,15 @@
+class SpaceMembership {
+  constructor({ space, person }) {
+    this.space = space
+    this.person = person
+  }
+
+  asParams() {
+    return {
+      spaceId: this.space.id,
+      personId: this.person.id
+    }
+  }
+}
+
+module.exports = SpaceMembership;

--- a/features/lib/SpaceMembership.js
+++ b/features/lib/SpaceMembership.js
@@ -1,13 +1,13 @@
 class SpaceMembership {
-  constructor({ space, person }) {
+  constructor({ space, member }) {
     this.space = space
-    this.person = person
+    this.member = member
   }
 
   asParams() {
     return {
       spaceId: this.space.id,
-      personId: this.person.id
+      memberId: this.member.id
     }
   }
 }

--- a/features/rooms/locking-and-unlocking-rooms.feature
+++ b/features/rooms/locking-and-unlocking-rooms.feature
@@ -25,11 +25,11 @@ Feature: Locked Rooms
   # https://xd.adobe.com/view/fd425dbe-5384-44c9-997a-eeee6e886a86-a811/screen/04ee266e-931b-4bde-bcf9-af94c7ac444e
   @built
   Scenario: Entering a Locked Room
-    Given a Space with a Locked Room
-    Then a Space Member may enter the Locked Room after providing the correct Access Code
-    And a Space Member may not enter the Locked Room after providing the wrong Access Code
-    And a Guest may enter the Locked Room after providing the correct Access Code
-    And a Guest may not enter the Locked Room after providing the wrong Access Code
+    Given the "System Test" Space with a Locked Room
+    Then a Space Member may enter the Locked Room in the "System Test" Space after providing the correct Access Code
+    And a Space Member may not enter the Locked Room in the "System Test" Space after providing the wrong Access Code
+    And a Guest may enter the Locked Room in the "System Test" Space after providing the correct Access Code
+    And a Guest may not enter the Locked Room in the "System Test" Space after providing the wrong Access Code
 
   # Wireframe:
   # https://xd.adobe.com/view/fd425dbe-5384-44c9-997a-eeee6e886a86-a811/screen/847810bf-5d62-4131-a70d-d9efdfadb334

--- a/features/rooms/locking-and-unlocking-rooms.feature
+++ b/features/rooms/locking-and-unlocking-rooms.feature
@@ -17,6 +17,10 @@ Feature: Locked Rooms
   The following scenarios illustrate how these permissions play out
   based upon who is accessing rooms with which access level.
 
+  Background:
+    Given a "System Test" Space
+    And the "System Test" Space has a Space Owner "space-owner@example.com"
+
   # Wireframe:
   # https://xd.adobe.com/view/fd425dbe-5384-44c9-997a-eeee6e886a86-a811/screen/04ee266e-931b-4bde-bcf9-af94c7ac444e
   @built
@@ -31,8 +35,8 @@ Feature: Locked Rooms
   # https://xd.adobe.com/view/fd425dbe-5384-44c9-997a-eeee6e886a86-a811/screen/847810bf-5d62-4131-a70d-d9efdfadb334
   @built
   Scenario: Locking an Unlocked Room
-    Given a Space with an Unlocked Room
-    When a Space Member locks the Unlocked Room with a valid Access Code
+    Given the "System Test" Space with an Unlocked Room
+    When the Space Owner "space-owner@example.com" locks the Unlocked Room in the "System Test" Space with a valid Access Code
     Then the Room is Locked
 
   # This is a "sad path" scenario, that we expect to delete once we
@@ -41,8 +45,8 @@ Feature: Locked Rooms
   # usage of form builders that expose error information.
   @built
   Scenario: Locking an Unlocked Room without setting a Access Code
-    Given a Space with an Unlocked Room
-    When a Space Member locks the Unlocked Room with an empty Access Code
+    Given the "System Test" Space with an Unlocked Room
+    When the Space Owner "space-owner@example.com" locks the Unlocked Room in the "System Test" Space with an empty Access Code
     Then the Space Member is informed they need to set a Access Code when they are locking a Room
     And the Room is Unlocked
 
@@ -51,6 +55,6 @@ Feature: Locked Rooms
   # https://xd.adobe.com/view/fd425dbe-5384-44c9-997a-eeee6e886a86-a811/screen/847810bf-5d62-4131-a70d-d9efdfadb334
   @built
   Scenario: Unlocking a Locked Room
-  Given a Space with a Locked Room
-  When a Space Member unlocks the Locked Room with the correct Access Code
+  Given the "System Test" Space with a Locked Room
+  When the Space Owner "space-owner@example.com" unlocks the Locked Room in the "System Test" Space with the correct Access Code
   Then the Room is Unlocked

--- a/features/spaces/invitations.feature
+++ b/features/spaces/invitations.feature
@@ -1,10 +1,12 @@
 Feature: Spaces: Invitations
   Invitations allow Space Owners to bring additional people into the Space
 
-  @built @andromeda
-  Scenario: Inviting new Members via Email
+  Background:
     Given a "System Test" Space
     And the "System Test" Space has a Space Owner "space-owner@example.com"
+
+  @built @andromeda
+  Scenario: Inviting new Members via Email
     When an Invitation to the "System Test" Space is sent by Space Owner "space-owner@example.com"
       | name | email                       |
       | Aang | aang-the-avatar@example.com |
@@ -12,73 +14,41 @@ Feature: Spaces: Invitations
     And the Invitation to "aang-the-avatar@example.com" for the "System Test" Space has a status of "pending"
 
 
-  # We create new Invitation(s) when inviting someone again,
-  # so that we have a record of how many times someone was
-  # invited.
+  # We create new Invitation(s) when inviting someone again, so that we have a record of how many times someone was
+  # invited. We allow people to accept any of the un-expired invitations that they have been sent.
   @built @unimplemented-steps @andromeda
   Scenario: Re-inviting before an Invitation Expires
-    Given an Invitation was sent less than 14 days ago
-    When a Space Owner re-invites that Invitation's contact info
-    Then a new Invitation is sent
-    # We decided allowing people to accept any of the un-Expired invitations
-    # that they have been sent was better for the UX than invalidating
-    # duplicate Invitations.
-    And the old Invitation can still be accepted
+    Given an Invitation to the "System Test" Space was sent by Space Owner "space-owner@example.com"
+      | name | email                       | created_at  |
+      | Aang | aang-the-avatar@example.com | 13 days ago |
+    When an Invitation to the "System Test" Space is sent by Space Owner "space-owner@example.com"
+      | name | email                       |
+      | Aang | aang-the-avatar@example.com |
+    Then an Invitations to "aang-the-avatar@example.com" for the "System Test" Space is delivered
+    And two Invitations to "aang-the-avatar@example.com" for the "System Test" Space have a status of "pending"
 
   @built @unimplemented-steps @andromeda
   Scenario: Re-inviting a Member after their Invitation Expires
-    Given an Invitation was sent 15 days ago
-    When a new Invitation is sent to that Invitation's contact info
-    And the old Invitation can not still be accepted
+    Given an Invitation to the "System Test" Space was sent by Space Owner "space-owner@example.com"
+      | name | email                       | created_at  |
+      | Aang | aang-the-avatar@example.com | 15 days ago |
+    When an Invitation to the "System Test" Space is sent by Space Owner "space-owner@example.com"
+      | name | email                       |
+      | Aang | aang-the-avatar@example.com |
+    Then an Invitations to "aang-the-avatar@example.com" for the "System Test" Space is delivered
+    And an Invitation to "aang-the-avatar@example.com" for the "System Test" Space has a status of "pending"
+    And an Invitation to "aang-the-avatar@example.com" for the "System Test" Space has a status of "expired"
 
 
   @unstarted @andromeda
   Scenario: Invitations remain even if the Invitor was Removed from the Space
-    Given a "System Test" Space
-    And the "System Test" Space has a Space Owner "soon-to-leave@example.com"
+    Given the "System Test" Space has a Space Owner "soon-to-leave@example.com"
     And an Invitation to the "System Test" Space is sent by Space Owner "soon-to-leave@example.com"
       | name | email                       |
       | Aang | aang-the-avatar@example.com |
     And the "System Test" Space removes the Space Owner "soon-to-leave@example.com"
     When the Invitation to "aang-the-avatar@example.com" is Accepted
     Then the "System Test" Space has a Space Member "aang-the-avatar@example.com"
-
-
-  @unstarted @andromeda
-  Scenario: Accepting an Invitation as a Neighbor
-    Given an Invitation was sent to a Neighbor
-    When the Neighbor accepts that Invitation
-    Then that Neighbor becomes a Space Member
-    And that Invitation is Accepted
-    And all other Invitations to that Invitation's contact info are Resolved
-
-  @built @andromeda
-  Scenario: Accepting an Invitation as a Guest
-    Given a "System Test" Space
-    And the "System Test" Space has a Space Owner "space-owner@example.com"
-    And an Invitation to the "System Test" Space is sent by Space Owner "space-owner@example.com"
-      | name | email                       |
-      | A Guest | a-guest@example.com |
-    When the Invitation to "a-guest@example.com" for the "System Test" Space is accepted by the Guest "a-guest@example.com"
-    Then the Guest "a-guest@example.com" becomes a Space Member of the "System Test" Space
-    And the Invitation to "a-guest@example.com" for the "System Test" Space has a status of "accepted"
-    # @todo implement me!
-    # And all other Invitations to Space Member "a-guest@example.com" for the "System Test" Space no longer have a status of "pending"
-
-  # We want to make sure that people who were invited but
-  # didn't take action can't suddenly appear and disorient
-  # or potentially disrupt the people who are in the Space.
-  @unstarted @andromeda
-  Scenario: Invitation Code Times out after 14 days
-    Given an Invitation was sent 15 days ago
-    Then that Invitation is Expired
-    And that Invitation cannot be Accepted
-
-  # We want to demonstrate that we care about folks having the
-  # affordances to prevent harassment or spam; so we want to provide
-  # an explicit option to block further invitations from the Space
-  @unstarted @andromeda
-  Scenario: Blocking Further Invitations
 
 
   @unstarted @unscheduled

--- a/features/spaces/invitations.feature
+++ b/features/spaces/invitations.feature
@@ -2,7 +2,7 @@ Feature: Spaces: Invitations
   Invitations allow Space Owners to bring additional people into the Space
 
   Background:
-    Given a "System Test" Space
+    Given a fresh "System Test" Space
     And the "System Test" Space has a Space Owner "space-owner@example.com"
 
   @built @andromeda

--- a/features/spaces/invitations.feature
+++ b/features/spaces/invitations.feature
@@ -2,7 +2,7 @@ Feature: Spaces: Invitations
   Invitations allow Space Owners to bring additional people into the Space
 
   Background:
-    Given a fresh "System Test" Space
+    Given a "System Test" Space
     And the "System Test" Space has a Space Owner "space-owner@example.com"
 
   @built @andromeda

--- a/features/spaces/invitations/responding_to_invitations.feature
+++ b/features/spaces/invitations/responding_to_invitations.feature
@@ -1,0 +1,51 @@
+Feature: Spaces: Invitations: Responding to Invitations
+  Once an Invitation is sent, it can be responded to. This allows the Invitee to:
+  - Accept the Invitation and become a Member of the Space
+  - Prevent further Invitations from the Space
+
+  Background:
+    Given a fresh "Team Avatar" Space
+    And the "Team Avatar" Space has a Space Owner "appa@example.com"
+
+  @unstarted @unimplemented-steps @andromeda
+  Scenario: Accepting an Invitation as a Neighbor
+    Given a fresh "Water Tribe" Space
+    And the "Water Tribe" Space has a Space Owner "katara@example.com"
+    And an Invitation to the "Team Avatar" Space is sent by Space Owner "appa@example.com"
+      | name   | email              |
+      | Katara | katara@example.com |
+    When the Invitation to "katara@example.com" for the "Team Avatar" Space is accepted by the Neighbor "katara@example.com"
+    Then the Neighbor "katara@example.com" becomes a Space Member of the "Team Avatar" Space
+    Then the Invitation to "katara@example.com" for the "Team Avatar" Space has a status of "accepted"
+
+  @built @andromeda
+  Scenario: Accepting an Invitation as a Guest
+    Given an Invitation to the "Team Avatar" Space is sent by Space Owner "appa@example.com"
+      | name    | email               |
+      | Zuko | zuko@example.com |
+    When the Invitation to "zuko@example.com" for the "Team Avatar" Space is accepted by the Guest "zuko@example.com"
+    Then the Guest "zuko@example.com" becomes a Space Member of the "Team Avatar" Space
+    And the Invitation to "zuko@example.com" for the "Team Avatar" Space has a status of "accepted"
+
+
+  @unstarted @unimplemented-steps
+  Scenario: Accepting an Invitation accepts all other outstanding invitations to that Guest
+  # @todo implement me! At present, the invitations just stick around as pending; but they probably shouldn't!
+  # And all other Invitations to Space Member "a-guest@example.com" for the "System Test" Space no longer have a status of "pending"
+
+  # We want to make sure that people who were invited but
+  # didn't take action can't suddenly appear and disorient
+  # or potentially disrupt the people who are in the Space.
+  @unstarted @andromeda
+  Scenario: Responding to an Expired Invitation
+    Given an Invitation was sent 15 days ago
+    Then that Invitation is Expired
+    And that Invitation cannot be Accepted
+
+
+
+  # We want to demonstrate that we care about folks having the
+  # affordances to prevent harassment or spam; so we want to provide
+  # an explicit option to block further invitations from the Space
+  @unstarted @andromeda
+  Scenario: Blocking Further Invitations

--- a/features/spaces/invitations/responding_to_invitations.feature
+++ b/features/spaces/invitations/responding_to_invitations.feature
@@ -4,12 +4,12 @@ Feature: Spaces: Invitations: Responding to Invitations
   - Prevent further Invitations from the Space
 
   Background:
-    Given a fresh "Team Avatar" Space
+    Given a "Team Avatar" Space
     And the "Team Avatar" Space has a Space Owner "appa@example.com"
 
   @unstarted @unimplemented-steps @andromeda
   Scenario: Accepting an Invitation as a Neighbor
-    Given a fresh "Water Tribe" Space
+    Given a "Water Tribe" Space
     And the "Water Tribe" Space has a Space Owner "katara@example.com"
     And an Invitation to the "Team Avatar" Space is sent by Space Owner "appa@example.com"
       | name   | email              |

--- a/features/spaces/invitations/responding_to_invitations.feature
+++ b/features/spaces/invitations/responding_to_invitations.feature
@@ -7,7 +7,7 @@ Feature: Spaces: Invitations: Responding to Invitations
     Given a "Team Avatar" Space
     And the "Team Avatar" Space has a Space Owner "appa@example.com"
 
-  @unstarted @unimplemented-steps @andromeda
+  @built @andromeda
   Scenario: Accepting an Invitation as a Neighbor
     Given a "Water Tribe" Space
     And the "Water Tribe" Space has a Space Owner "katara@example.com"

--- a/features/steps/invitation_steps.js
+++ b/features/steps/invitation_steps.js
@@ -11,10 +11,19 @@ When(
   "an {invitation} to {a} {space} is sent by {actor}",
   { timeout: 90000 },
   function (invitation, _, space, actor, invitations) {
+    /**
+     * @todo This feels like responsibility for our Invitation class
+     *       or the invitation parameter type?
+     */
+    const toSend = invitations.hashes().map((invitation) => {
+      invitation.email = this.upsertTestId(invitation.email);
+      return invitation;
+    });
+
     return actor
       .signIn(this.driver, space)
       .then(() => new SpaceEditPage(this.driver, space))
-      .then((page) => page.inviteAll(invitations.hashes()));
+      .then((page) => page.inviteAll(toSend));
   }
 );
 
@@ -26,7 +35,8 @@ When(
    * @param {Actor} actor
    */
   function (_, invitation, _2, space, _3, actor) {
-    return invitation.accept(this.driver)
+    return invitation
+      .accept(this.driver)
       .then(() => actor.authenticationCode())
       .then((code) => new SignInPage(this.driver, space).submitCode(code));
   }

--- a/features/steps/invitation_steps.js
+++ b/features/steps/invitation_steps.js
@@ -35,10 +35,11 @@ When(
    * @param {Actor} actor
    */
   function (_, invitation, _2, space, _3, actor) {
-    return invitation
-      .accept(this.driver)
+    return actor.signOut(this.driver)
+      .then(() => invitation.accept(this.driver))
       .then(() => actor.authenticationCode())
-      .then((code) => new SignInPage(this.driver, space).submitCode(code));
+      .then((code) => new SignInPage(this.driver, space).submitCode(code))
+      .then(() => console.log('woohoo!') )
   }
 );
 

--- a/features/steps/invitation_steps.js
+++ b/features/steps/invitation_steps.js
@@ -39,7 +39,6 @@ When(
       .then(() => invitation.accept(this.driver))
       .then(() => actor.authenticationCode())
       .then((code) => new SignInPage(this.driver, space).submitCode(code))
-      .then(() => console.log('woohoo!') )
   }
 );
 

--- a/features/steps/room_steps.js
+++ b/features/steps/room_steps.js
@@ -18,48 +18,34 @@ const {
 
 const assert = require("assert").strict;
 
-Given("{a} {space} with {a} {accessLevel} {room}", async function (_, space, _, accessLevel, room) {
-  linkParameters({ accessLevel, room, space });
-  this.space = await new SpacePage(this.driver, space).visit();
-  const matchingRooms = await this.space.roomCardsWhere({ accessLevel });
-  if (!matchingRooms.length > 0) {
-    const spaceMember = new Actor("Space Member", 'space-member@example.com');
-    const page = await spaceMember
-      .signIn(this.driver, space)
-      .then(() => new SpaceEditPage(this.driver, space).visit());
-
-    // @todo Sprout an API for editing a Space so we don't need to do it via
-    //       the UI
-    if (accessLevel.isLocked()) {
-      room.reinitialize(new AccessLevel("unlocked"));
-      await page
-        .roomCard(room)
-        .configure()
-        .then((page) => page.lock(new AccessCode("valid")));
-    } else {
-      room.reinitialize(new AccessLevel("locked"));
-      await page
-        .roomCard(room)
-        .configure()
-        .then((page) => page.unlock(new AccessCode("valid")));
+Given(
+  "{a} {space} with {a} {accessLevel} {room}",
+  async function (_, space, _, accessLevel, room) {
+    this.spaces = this.spaces || {};
+    if (this.spaces[space.name]) {
+      return;
     }
 
-    return this.space
-      .visit()
-      .then(() => this.space.roomCardsWhere({ accessLevel }))
-      .then((matchingRooms) => assert(matchingRooms.length > 0));
+    return this.api()
+      .spaces()
+      .create(space)
+      .then((space) => (this.spaces[space.name] = space));
   }
-});
+);
 
-When('{a} {actor} unlocks {a} {accessLevel} {room} in {a} {space} with {a} {accessCode}', function (a, actor, a2, accessLevel, room, a3, space, a4, accessCode) {
-  // @todo someday, it would be nice to consolidate the AccessLevel Parameter Type, since it's only ever used in context with a room
-  linkParameters({ room, accessLevel });
+When(
+  "{a} {actor} unlocks {a} {accessLevel} {room} in {a} {space} with {a} {accessCode}",
+  function (a, actor, a2, accessLevel, room, a3, space, a4, accessCode) {
+    // @todo someday, it would be nice to consolidate the AccessLevel Parameter Type, since it's only ever used in context with a room
+    linkParameters({ room, accessLevel });
 
-  return actor.signIn(this.driver, space)
-    .then(() => new SpaceEditPage(this.driver, space).visit())
-    .then((page) => page.roomCard(room).configure())
-    .then((page) => page.unlock(accessCode));
-});
+    return actor
+      .signIn(this.driver, space)
+      .then(() => new SpaceEditPage(this.driver, space).visit())
+      .then((page) => page.roomCard(room).configure())
+      .then((page) => page.unlock(accessCode));
+  }
+);
 
 When(
   "{a} {actor} locks {a} {accessLevel} {room} in {a} {space} with {a} {accessCode}",
@@ -89,40 +75,44 @@ Then("the {actor} is not placed in the {room}", function (actor, room) {
 });
 
 Then(
-  "{a} {actor} may not enter {a} {accessLevel} {room} after providing {a} {accessCode}",
+  "{a} {actor} may not enter {a} {accessLevel} {room} in {a} {space} after providing {a} {accessCode}",
   /**
    *
    * @param {Actor} actor
    * @param {AccessLevel} accessLevel
    * @param {Room} room
+   * @param {Space} space
    * @param {AccessCode} accessCode
    */
-  async function (_, actor, _, accessLevel, room, _, accessCode) {
+  function (_, _actor, _, accessLevel, room, _, space, _, accessCode) {
     linkParameters({ room, accessLevel });
 
-    await this.driver.manage().deleteAllCookies();
-
-    const waitingRoomPage = await this.space
-      .visit()
-      .then((spacePage) => spacePage.roomCard(room).enter(accessCode));
-
-    assert(await waitingRoomPage.isWaitingRoom());
-    assert(await waitingRoomPage.errors().isDisplayed());
+    return this.driver
+      .manage()
+      .deleteAllCookies()
+      .then(() => new SpacePage(this.driver, space).visit())
+      .then((spacePage) => spacePage.roomCard(room).enter(accessCode))
+      .then((waitingRoomPage) => {
+        return Promise.all([
+          waitingRoomPage.isWaitingRoom().then(assert),
+          waitingRoomPage.errors().isDisplayed().then(assert),
+        ]);
+      });
   }
 );
 
 Then(
-  "{a} {actor} may enter {a} {accessLevel} {room} after providing {a} {accessCode}",
-  async function (_, actor, _, accessLevel, room, _, accessCode) {
+  "{a} {actor} may enter {a} {accessLevel} {room} in {a} {space} after providing {a} {accessCode}",
+  function (_, actor, _, accessLevel, room, _, space, _, accessCode) {
     linkParameters({ room, accessLevel, accessCode });
-    await this.driver.manage().deleteAllCookies();
 
-    const isWaitingRoom = await this.space
-      .visit()
+    return this.driver
+      .manage()
+      .deleteAllCookies()
+      .then(() => new SpacePage(this.driver, space).visit())
       .then((spacePage) => spacePage.roomCard(room).enter(accessCode))
       .then((roomPage) => roomPage.isWaitingRoom())
-
-    assert(!isWaitingRoom);
+      .then((isWaitingRoom) => assert(!isWaitingRoom));
   }
 );
 

--- a/features/steps/room_steps.js
+++ b/features/steps/room_steps.js
@@ -51,23 +51,20 @@ Given("{a} {space} with {a} {accessLevel} {room}", async function (_, space, _, 
   }
 });
 
-When(
-  "{a} {actor} unlocks {a} {accessLevel} {room} with {a} {accessCode}",
-  async function (_, actor, _, accessLevel, room, _, accessCode) {
-    const { space } = linkParameters({ room, accessLevel });
-    await actor.signIn(this.driver, space);
+When('{a} {actor} unlocks {a} {accessLevel} {room} in {a} {space} with {a} {accessCode}', function (a, actor, a2, accessLevel, room, a3, space, a4, accessCode) {
+  // @todo someday, it would be nice to consolidate the AccessLevel Parameter Type, since it's only ever used in context with a room
+  linkParameters({ room, accessLevel });
 
-    return new SpaceEditPage(this.driver, space)
-      .visit()
-      .then((page) => page.roomCard(room).configure())
-      .then((page) => page.unlock(accessCode));
-  }
-);
+  return actor.signIn(this.driver, space)
+    .then(() => new SpaceEditPage(this.driver, space).visit())
+    .then((page) => page.roomCard(room).configure())
+    .then((page) => page.unlock(accessCode));
+});
 
 When(
-  "{a} {actor} locks {a} {accessLevel} {room} with {a} {accessCode}",
-  async function (_, actor, _, accessLevel, room, _, accessCode) {
-    const { space } = linkParameters({ accessLevel, room });
+  "{a} {actor} locks {a} {accessLevel} {room} in {a} {space} with {a} {accessCode}",
+  async function (_, actor, _, accessLevel, room, _a, space, _, accessCode) {
+    linkParameters({ accessLevel, room });
     await actor.signIn(this.driver, space);
 
     return new SpaceEditPage(this.driver, space)

--- a/features/steps/space_steps.js
+++ b/features/steps/space_steps.js
@@ -9,7 +9,15 @@ const crypto = require("crypto");
 
 
 Given("{a} {space}", function (_, space) {
-  return this.api().spaces().create(space);
+  this.spaces = this.spaces || {};
+
+  return this.api().spaces().create(space)
+    .then(
+      ((space) => {
+        console.error('wtf');
+        return this.spaces[space.name] = space;
+      })
+  )
 });
 
 Given("a Space with a Room", function () {
@@ -32,6 +40,8 @@ Given(
     this.testId = this.testId || crypto.randomUUID();
     this.actors = this.actors || {};
     this.actors[actor.email] = actor;
+
+    space = this.spaces[space.name] || space;
     actor.email = `${this.testId}+${actor.email}`;
     const api = new Api(appUrl(), process.env.OPERATOR_API_KEY);
     const toCreate = new AuthenticationMethod({
@@ -42,11 +52,10 @@ Given(
     return api
       .authenticationMethods()
       .findOrCreateBy(toCreate)
-      .then((authenticationMethod) => authenticationMethod.person)
-      .then((person) =>
+      .then((authenticationMethod) =>
         api
           .spaceMemberships()
-          .findOrCreateBy(new SpaceMembership({ space, person }))
+          .findOrCreateBy(new SpaceMembership({ space, person: authenticationMethod.person }))
       );
   }
 );

--- a/features/steps/space_steps.js
+++ b/features/steps/space_steps.js
@@ -8,9 +8,31 @@ Given("{a} {space}", function (_, space) {
   return this.api().spaces().create(space);
 });
 
-Given("{a} {space} has {a} {actor}", function (_, space, _, actor) {
-  return true;
+Given("a Space with a Room", function () {
+  // This space intentionally left blank... For now...
+  // TODO: Create a Space for each test instead of re-using the
+  //       System Test Space
 });
+
+Given(
+  "{a} {space} has {a} {actor}",
+  /**
+   *
+   * @param {*} _
+   * @param {Space} space
+   * @param {*} _
+   * @param {Actor} actor
+   * @returns
+   */
+  function (_, space, _, actor) {
+    const api = new Api(appUrl(), process.env.OPERATOR_API_KEY);
+    console.log({ space, actor, api })
+    return api.authenticationMethods()
+      .findOrCreateBy({ contactMethod: 'email', contactLocation: actor.email })
+      .then((authenticationMethod) => authenticationMethod.person)
+      .then((person) => api.spaceMemberships.findOrCreateBy({ space, person }))
+  }
+);
 
 Given("the {actor} is on the {space} Dashboard", async function (actor, space) {
   this.space = new SpacePage(this.driver, space);

--- a/features/steps/space_steps.js
+++ b/features/steps/space_steps.js
@@ -3,6 +3,7 @@ const { RoomPage, SpacePage, SpaceEditPage } = require("../harness/Pages");
 const { linkParameters, Actor, Space } = require("../lib");
 const appUrl = require("../lib/appUrl");
 const { Api } = require("../lib/Api");
+const AuthenticationMethod = require("../lib/AuthenticationMethod");
 
 Given("{a} {space}", function (_, space) {
   return this.api().spaces().create(space);
@@ -26,10 +27,13 @@ Given(
    */
   function (_, space, _, actor) {
     const api = new Api(appUrl(), process.env.OPERATOR_API_KEY);
-    console.log({ space, actor, api })
+    console.log({ space, actor })
     return api.authenticationMethods()
-      .findOrCreateBy({ contactMethod: 'email', contactLocation: actor.email })
-      .then((authenticationMethod) => authenticationMethod.person)
+      .findOrCreateBy(new AuthenticationMethod({ contactMethod: 'email', contactLocation: actor.email }))
+      .then(
+        (authenticationMethod) =>
+          authenticationMethod.person
+      )
       .then((person) => api.spaceMemberships.findOrCreateBy({ space, person }))
   }
 );

--- a/features/steps/space_steps.js
+++ b/features/steps/space_steps.js
@@ -37,7 +37,6 @@ Given(
     this.actors[actor.email] = actor;
 
     space = this.spaces[space.name] || space;
-    actor.email = `${this.testId()}+${actor.email}`;
     const api = new Api(appUrl(), process.env.OPERATOR_API_KEY);
     const toCreate = new AuthenticationMethod({
       contactMethod: "email",

--- a/features/steps/space_steps.js
+++ b/features/steps/space_steps.js
@@ -14,7 +14,6 @@ Given("{a} {space}", function (_, space) {
   return this.api().spaces().create(space)
     .then(
       ((space) => {
-        console.error('wtf');
         return this.spaces[space.name] = space;
       })
   )

--- a/features/steps/space_steps.js
+++ b/features/steps/space_steps.js
@@ -51,7 +51,7 @@ Given(
         api
           .spaceMemberships()
           .findOrCreateBy(
-            new SpaceMembership({ space, person: authenticationMethod.person })
+            new SpaceMembership({ space, member: authenticationMethod.person })
           )
       );
   }

--- a/features/steps/space_steps.js
+++ b/features/steps/space_steps.js
@@ -7,16 +7,13 @@ const AuthenticationMethod = require("../lib/AuthenticationMethod");
 const SpaceMembership = require("../lib/SpaceMembership");
 const crypto = require("crypto");
 
-
 Given("{a} {space}", function (_, space) {
   this.spaces = this.spaces || {};
 
-  return this.api().spaces().create(space)
-    .then(
-      ((space) => {
-        return this.spaces[space.name] = space;
-      })
-  )
+  return this.api()
+    .spaces()
+    .create(space)
+    .then((space) => (this.spaces[space.name] = space));
 });
 
 Given("a Space with a Room", function () {
@@ -36,12 +33,11 @@ Given(
    * @returns
    */
   function (_, space, _, actor) {
-    this.testId = this.testId || crypto.randomUUID();
     this.actors = this.actors || {};
     this.actors[actor.email] = actor;
 
     space = this.spaces[space.name] || space;
-    actor.email = `${this.testId}+${actor.email}`;
+    actor.email = `${this.testId()}+${actor.email}`;
     const api = new Api(appUrl(), process.env.OPERATOR_API_KEY);
     const toCreate = new AuthenticationMethod({
       contactMethod: "email",
@@ -54,7 +50,9 @@ Given(
       .then((authenticationMethod) =>
         api
           .spaceMemberships()
-          .findOrCreateBy(new SpaceMembership({ space, person: authenticationMethod.person }))
+          .findOrCreateBy(
+            new SpaceMembership({ space, person: authenticationMethod.person })
+          )
       );
   }
 );
@@ -64,19 +62,21 @@ Given("the {actor} is on the {space} Dashboard", async function (actor, space) {
   await this.space.visit();
 });
 
-When('{a} {actor} visits {a} {space}',
-/**
- * @this {CustomWorld}
- * @param {*} _a
- * @param {Actor} actor
- * @param {*} _a2
- * @param {Space} space
- * @returns
- */
-function (_a, actor, _a2, space) {
-  this.space = new SpacePage(this.driver, space);
-  return this.space.visit();
-});
+When(
+  "{a} {actor} visits {a} {space}",
+  /**
+   * @this {CustomWorld}
+   * @param {*} _a
+   * @param {Actor} actor
+   * @param {*} _a2
+   * @param {Space} space
+   * @returns
+   */
+  function (_a, actor, _a2, space) {
+    this.space = new SpacePage(this.driver, space);
+    return this.space.visit();
+  }
+);
 
 Given(
   "the {actor} is in the {space} and in the {room}",

--- a/features/support/CustomWorld.js
+++ b/features/support/CustomWorld.js
@@ -21,5 +21,18 @@ class CustomWorld {
   testId() {
     return this._testId = this._testId || crypto.randomUUID();
   }
+
+  /**
+   * Ensures email addresses are all traceable back to the same test
+   * This isolates our tests, eliminates race conditions, and makes things easier to diagnose
+   * @param {string} email
+   * @returns string
+   */
+   upsertTestId(email) {
+    if (!email) {
+      return email;
+    }
+    return email.replace("@", `-${this.testId()}@`);
+  }
 }
 exports.CustomWorld = CustomWorld;

--- a/features/support/env.js
+++ b/features/support/env.js
@@ -1,35 +1,39 @@
-require('dotenv').config()
-const fse = require('fs-extra');
-const { setWorldConstructor, BeforeAll, AfterAll, After, setDefaultTimeout, Status } = require('@cucumber/cucumber');
+require("dotenv").config();
+const fse = require("fs-extra");
+const {
+  setWorldConstructor,
+  BeforeAll,
+  AfterAll,
+  After,
+  setDefaultTimeout,
+  Status,
+} = require("@cucumber/cucumber");
 
-const appUrl = require('../lib/appUrl');
+const appUrl = require("../lib/appUrl");
 const { CustomWorld } = require("./CustomWorld");
-let { driver } = require('./driver')
-
-
-
+let { driver } = require("./driver");
 
 setWorldConstructor(CustomWorld);
 
-After(function(testCase) {
+After(function (testCase) {
   if (testCase.result.status == Status.FAILED) {
-    return driver.takeScreenshot().then( screenShot => {
-      const filePath = `features/test_reports/${testCase.pickle.name.split(' ').join('_')}.png`;
-      fse.outputFile(filePath, screenShot, { encoding: 'base64' }, err => {
-        if (err) console.log(err)
-        console.log("Screenshot created: ", filePath)
+    return driver.takeScreenshot().then((screenShot) => {
+      const filePath = `features/test_reports/${testCase.pickle.name
+        .split(" ")
+        .join("_")}.png`;
+      fse.outputFile(filePath, screenShot, { encoding: "base64" }, (err) => {
+        if (err) console.log(err);
+        console.log("Screenshot created: ", filePath);
       });
     });
   }
 });
 
-
-BeforeAll(function() {
-  return driver.get(appUrl())
+BeforeAll(function () {
+  return driver.get(appUrl());
 });
 
-
-AfterAll(function() {
+AfterAll(function () {
   driver.quit();
 });
 

--- a/features/support/parameter-types/actor.js
+++ b/features/support/parameter-types/actor.js
@@ -1,5 +1,5 @@
 const { defineParameterType } = require("@cucumber/cucumber");
-const Actor = require('../../lib/Actor.js')
+const Actor = require("../../lib/Actor.js");
 
 // Actors are the people or sytems our test suite emulates as it
 // interacts with Convene.
@@ -11,9 +11,24 @@ const Actor = require('../../lib/Actor.js')
 defineParameterType({
   name: "actor",
   regexp: /(Guest|Space Member|Space Owner|Neighbor)( "[^"]*")?/,
-  transformer: function(type, email) {
-    email = this.upsertTestId(email || `${type.toLowerCase()}@example.com`)
+  transformer: function (actorType, email) {
+    email = formatEmail(actorType, email);
 
-    return new Actor(type, email.trim().replace(/\s/, '-').replace(/"/g,''))
-  }
+    if (actorType !== "Guest") {
+      email = this.upsertTestId(email);
+    }
+
+    return new Actor(actorType, email);
+  },
 });
+
+/**
+ * Infers the email from the actorType if necessary; then removes the string matching regex slop.
+ * @param {String} actorType
+ * @param {undefined|String} email
+ * @returns {String} the email
+ */
+function formatEmail(actorType, email = undefined) {
+  email = email || `${actorType.toLowerCase()}@example.com`;
+  return email.trim().replace(/\s/, "-").replace(/"/g, "");
+}

--- a/features/support/parameter-types/actor.js
+++ b/features/support/parameter-types/actor.js
@@ -14,7 +14,7 @@ defineParameterType({
   transformer: function (actorType, email) {
     email = formatEmail(actorType, email);
 
-    if (actorType !== "Guest") {
+    if (email !== "guest@example.com") {
       email = this.upsertTestId(email);
     }
 

--- a/features/support/parameter-types/actor.js
+++ b/features/support/parameter-types/actor.js
@@ -12,7 +12,7 @@ defineParameterType({
   name: "actor",
   regexp: /(Guest|Space Member|Space Owner|Neighbor)( "[^"]*")?/,
   transformer: function(type, email) {
-    email = email || `${type.toLowerCase()}@example.com`
+    email = this.upsertTestId(email || `${type.toLowerCase()}@example.com`)
 
     return new Actor(type, email.trim().replace(/\s/, '-').replace(/"/g,''))
   }

--- a/features/support/parameter-types/invitation.js
+++ b/features/support/parameter-types/invitation.js
@@ -5,7 +5,8 @@ defineParameterType({
   name: "invitation",
   regexp: /Invitation( to "[^"]*")?/,
   transformer: function(a, b, c) {
-    const emailAddress = a ? a.match(/to "([^"]*)"/)[1] : undefined
+    let emailAddress = this.upsertTestId(a ? a.match(/to "([^"]*)"/)[1] : undefined)
+
     return new Invitation(emailAddress)
   }
 });

--- a/spec/factories/authentication_methods.rb
+++ b/spec/factories/authentication_methods.rb
@@ -6,5 +6,6 @@ FactoryBot.define do
 
     contact_method { :email }
     contact_location { person.email }
+    last_one_time_password_at { Time.now }
   end
 end

--- a/spec/models/blueprint_spec.rb
+++ b/spec/models/blueprint_spec.rb
@@ -32,14 +32,13 @@ RSpec.describe Blueprint do
       # @todo add other examples of changing data after the
       # blueprint has been applied
       space.utility_hookups.first.update(utility_attributes: { client_id: '1234' })
-      space.rooms.update(publicity_level: :unlisted)
+
       space.rooms.first.furniture_placements.first.update(furniture_attributes: { content: 'Hey there!' })
 
       Blueprint.new(EXAMPLE_CONFIG).find_or_create!
 
       # @todo add other examples of confirming the changes
       # were not overwritten
-      expect(space.rooms.reload.first).to be_unlisted
       expect(space.utility_hookups.first.utility.client_id).to eql('1234')
       expect(space.rooms.first.furniture_placements.first.furniture.content).to eql('Hey there!')
     end

--- a/spec/requests/authentication_methods_request_spec.rb
+++ b/spec/requests/authentication_methods_request_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe '/authentication_methods/', type: :request do
                    person: { id: person.id })
         end
       end
+
       response '422', 'authentication method invalid' do
         let(:existing_authentication_method) { create(:authentication_method) }
         let(:attributes) do

--- a/spec/requests/spaces/invitations/rsvp_spec.rb
+++ b/spec/requests/spaces/invitations/rsvp_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe '/spaces/:space_id/invitations/:invitation_id/rsvp', type: :reque
                                             contact_location: invitation.email)
 
           expect(authentication_method.confirmed_at).to be_blank
+          expect(response).to render_template(:update)
         end
       end
 
@@ -62,6 +63,8 @@ RSpec.describe '/spaces/:space_id/invitations/:invitation_id/rsvp', type: :reque
                                             contact_location: invitation.email)
 
           expect(authentication_method).to be_confirmed
+          expect(response).to redirect_to(space)
+          expect(flash[:notice]).to eq(I18n.t('rsvps.update.success', space_name: space.name))
         end
       end
     end

--- a/spec/requests/spaces/invitations/rsvp_spec.rb
+++ b/spec/requests/spaces/invitations/rsvp_spec.rb
@@ -7,27 +7,19 @@ RSpec.describe '/spaces/:space_id/invitations/:invitation_id/rsvp', type: :reque
   let(:neighbor) { create(:neighbor) }
   let(:invitation) { create(:invitation) }
   describe 'GET /spaces/:space_id/invitations/:invitation_id/rsvp' do
-    context 'as a guest' do
-      it 'Does not require them to sign in' do
-        get space_invitation_rsvp_path(space, invitation)
+    it 'Does not require people to sign in' do
+      get space_invitation_rsvp_path(space, invitation)
 
-        expect(response).to be_ok
-        expect(response).to render_template(:show)
-        expect(assigns(:invitation)).to eql(invitation)
-      end
-    end
-
-    context 'as a neighbor' do
-    end
-
-    context 'as a space member' do
+      expect(response).to be_ok
+      expect(response).to render_template(:show)
+      expect(assigns(:invitation)).to eql(invitation)
     end
   end
 
   describe 'PUT /spaces/:space_id/invitations/:invitation_id/rsvp' do
     context 'as a guest' do
-      context 'whose email is unique within the system' do
-        it 'registers them when they accept the invitation' do
+      context 'who does not include the one-time-code' do
+        it 'doesnt complete the invitation' do
           expect do
             put space_invitation_rsvp_path(space, invitation),
                 params: { rsvp: { status: :accepted } }
@@ -35,18 +27,32 @@ RSpec.describe '/spaces/:space_id/invitations/:invitation_id/rsvp', type: :reque
 
           person = Person.find_by!(email: invitation.email)
 
-          expect(invitation.reload).to be_accepted
+          expect(invitation.reload).not_to be_accepted
+          expect(person.space_memberships
+              .find_by(space: space)).not_to be_present
 
-          expect(response).to redirect_to(
-            new_space_authenticated_session_path(space,
-                                                 params: {
-                                                   authenticated_session:
-                                                  {
-                                                    contact_method: :email,
-                                                    contact_location: person.email
-                                                  }
-                                                 })
-          )
+          authentication_method = person
+                                  .authentication_methods
+                                  .find_by!(contact_method: :email,
+                                            contact_location: invitation.email)
+
+          expect(authentication_method.confirmed_at).to be_blank
+        end
+      end
+
+      context 'who does include the one-time code proving they are who they say they are' do
+        it 'completes the invitation and confirms their authentication method' do
+          person = create(:person, email: invitation.email)
+          authentication_method = create(:authentication_method, person: person)
+
+          expect do
+            put space_invitation_rsvp_path(space, invitation),
+                params: { rsvp: { status: :accepted, one_time_password: authentication_method.one_time_password } }
+          end.not_to have_enqueued_mail(AuthenticatedSessionMailer, :one_time_password_email)
+
+          person = Person.find_by!(email: invitation.email)
+
+          expect(invitation.reload).to be_accepted
           expect(person.space_memberships
               .find_by(space: space)).to be_present
 
@@ -55,7 +61,7 @@ RSpec.describe '/spaces/:space_id/invitations/:invitation_id/rsvp', type: :reque
                                   .find_by!(contact_method: :email,
                                             contact_location: invitation.email)
 
-          expect(authentication_method.confirmed_at).to be_blank
+          expect(authentication_method).to be_confirmed
         end
       end
     end
@@ -73,17 +79,6 @@ RSpec.describe '/spaces/:space_id/invitations/:invitation_id/rsvp', type: :reque
         end.to have_enqueued_mail(
           AuthenticatedSessionMailer, :one_time_password_email
         ).with(neighbor.authentication_methods.first, space)
-
-        expect(response).to redirect_to(
-          new_space_authenticated_session_path(space,
-                                               params: {
-                                                 authenticated_session:
-                                                {
-                                                  contact_method: :email,
-                                                  contact_location: neighbor.email
-                                                }
-                                               })
-        )
 
         # @todo - can we assert there's a flash message?
         # @todo - Maybe we want to require signing in when showing the


### PR DESCRIPTION
There were some strange behaviors with how Invitations work, in particular:

- We never confirmed that Guests had access to the email address; we just assumed if they had the link they were totally the right person. That's not a good idea; so we made it necessary for them to confirm their access to the email address by using a OneTimePassword
- Neighbors couldn't accept Invitations at all; which seemed not-great.
- Once an Invitation was accepted, the user  was just kinda left hanging.

This resolves those rough edges, as well as fleshes out the full feature test suite for inviting people to a Space.

See: https://github.com/zinc-collective/convene/issues/117

- [x] Define the Scenario for inviting a Neighbor to become a Member of a different Space more precisely
- [x] Adjust the test framework so that we can use parameterized space and space member names
  - [x] Create AuthenticationMethod API endpoint (and merge it independently!) (#630)
  - [x] Fix Spaces API endpoint, because it doesn't return any data!
  - [x] ~Create Person API Endpoint (and merge it independently!) [See Review](https://github.com/zinc-collective/convene/pull/630#discussion_r844568812)~
  - [x] Create SpaceMembership API Endpoint (and merge it independently!)
  - [x] Figure out how to uniquify the Actor email / Space Name + Slug on Create
  - [x] Figure out how to share Spaces/Actors/etc. between Steps in the same Scenario
- [x] Get it Green!
  - [x] Tidy up the UI
- [x] Refactor
  - [x] ~~Stop piggybacking on the AuthenticationMethod email, when it's an Invitation Email (which has a different endpoint)~~
  - [x] ~~Pull the `this.actors[..]` warehouse into the `actor` parameter type~~
  - [x] ~~Set `last_authentication_method_at` on create of AuthenticationMethod~~