### PR TITLE
Sprout EmbeddedForm independent of Space Registration

### DIFF
--- a/app/assets/stylesheets/base/layout.scss
+++ b/app/assets/stylesheets/base/layout.scss
@@ -5,7 +5,7 @@
   }
 
   main {
-    @apply mx-2 flex-1;
+    @apply mx-2 flex-1 flex flex-col;
     > :last-child {
       @apply mb-2;
     }

--- a/app/assets/stylesheets/components/form.scss
+++ b/app/assets/stylesheets/components/form.scss
@@ -21,12 +21,14 @@
     label {
       @apply font-medium leading-5 text-neutral-700;
     }
-    input[type="text"],
+
     input[type="email"],
+    input[type="number"],
     input[type="password"],
     input[type="search"],
-    input[type="number"],
     input[type="tel"],
+    input[type="text"],
+    input[type="url"],
     select,
     textarea {
       @apply py-2 px-4
@@ -42,12 +44,13 @@
     }
 
     .field_with_errors {
-      input[type="text"],
       input[type="email"],
+      input[type="number"],
       input[type="password"],
       input[type="search"],
-      input[type="number"],
       input[type="tel"],
+      input[type="text"],
+      input[type="url"],
       select,
       textarea {
         @apply border-red-300 bg-red-100;

--- a/app/furniture/embedded_form.rb
+++ b/app/furniture/embedded_form.rb
@@ -1,0 +1,15 @@
+class EmbeddedForm
+  include Placeable
+
+  def form_url=(form_url)
+    settings['form_url'] = form_url
+  end
+
+  def form_url
+    settings['form_url']
+  end
+
+  def attribute_names
+    super + ['form_url']
+  end
+end

--- a/app/furniture/embedded_form/_form.html.erb
+++ b/app/furniture/embedded_form/_form.html.erb
@@ -1,0 +1,7 @@
+<%-
+# @todo expect a `form` that is already using the fields for,
+# so we don't do it every time
+%>
+<%= form.fields_for(:furniture) do |furniture_fields| %>
+  <%= render "url_field", attribute: :form_url, form: furniture_fields %>
+<%- end %>

--- a/app/furniture/embedded_form/_in_room.html.erb
+++ b/app/furniture/embedded_form/_in_room.html.erb
@@ -1,0 +1,1 @@
+<iframe class="w-full max-w-prose mx-auto aspect-[5/6]" src="<%= furniture.form_url%>" onmousewheel=""></iframe>

--- a/app/furniture/furniture.rb
+++ b/app/furniture/furniture.rb
@@ -8,6 +8,7 @@ module Furniture
     payment_form: PaymentForm,
     markdown_text_block: MarkdownTextBlock,
     video_bridge: VideoBridge,
+    embedded_form: EmbeddedForm,
     # @todo Run a rake task to move all the placements with the type `videobridge_by_jitsi` to `video_bridge`
     videobridge_by_jitsi: VideoBridge
   }.freeze

--- a/app/furniture/markdown_text_block.rb
+++ b/app/furniture/markdown_text_block.rb
@@ -16,6 +16,8 @@ class MarkdownTextBlock
     settings.fetch('content', '')
   end
 
+  # @todo can we make it so we don't need to define this?
+  # and the `settings.fetch` bits?
   def attribute_names
     super + ['content']
   end

--- a/app/views/application/_url_field.html.erb
+++ b/app/views/application/_url_field.html.erb
@@ -1,0 +1,5 @@
+<div>
+  <%= form.label attribute %>
+  <%= form.url_field attribute %>
+  <%= render partial: "error", locals: { model: form.object, attribute: attribute } %>
+</div>

--- a/features/furniture/embedded_form.feature
+++ b/features/furniture/embedded_form.feature
@@ -1,0 +1,2 @@
+# https://github.com/zinc-collective/convene/issues/619
+Feature: Embedded Forms


### PR DESCRIPTION
Squashed commit of the following:

commit 6054b87ce21f8a07084d9ccd00f3d0c0c1fedcf6
Author: Zee Spencer <zspencer@users.noreply.github.com>
Date:   Wed Mar 9 20:05:15 2022 -0800

    Add some todos for cleanup

commit ede2fbff74f634756b5ba6dfa7a76f765ea20307
Author: Zee Spencer <zspencer@users.noreply.github.com>
Date:   Wed Mar 9 19:58:10 2022 -0800

    Sprout `EmbeddableForm` Furniture

    As we begin this, we thought that it makes sense to start down the path
    of using a generic piece of Furniture, so that we're catfooding what the
    customer experience for other Spaces look like.

    So we've sprouted a piece of furniture that can embed a form from
    Airtable right into a Space! MAGIC!

    Co-authored-by: Ana Ulin <ana@ulin.org>

commit 76b59e4b47b033882882ab93a24e778df14f2851
Author: Zee Spencer <zspencer@users.noreply.github.com>
Date:   Wed Mar 9 19:23:08 2022 -0800

    Reframe acquiring a space to include the Waitlist

    We took some time to sketch out a little bit about what the "onboarding"
    experience looks like for Convene (and theoretically, "Products" built
    on Convene that want to use a "waitlist" for letting people into their
    product.)

    Next step: Sprout the furniture?

    See: https://github.com/zinc-collective/convene/issues/8

    Co-authored-by: Ana Ulin <ana@ulin.org>