### PR TITLE
Sprout API for Creating Authentication Methods

### DIFF
--- a/app/controllers/authentication_methods_controller.rb
+++ b/app/controllers/authentication_methods_controller.rb
@@ -4,6 +4,7 @@
 class AuthenticationMethodsController < ApplicationController
   def create
     skip_policy_scope
+    authentication_method_params = policy(AuthenticationMethod).permit(params)
     authentication_method = AuthenticationMethod.new(authentication_method_params)
     authorize(authentication_method)
     if authentication_method.save
@@ -11,9 +12,5 @@ class AuthenticationMethodsController < ApplicationController
     else
       render json: AuthenticationMethod::Serializer.new(authentication_method).to_json, status: :unprocessable_entity
     end
-  end
-
-  def authentication_method_params
-    params.require(:authentication_method).permit(:contact_method, :contact_location)
   end
 end

--- a/app/controllers/authentication_methods_controller.rb
+++ b/app/controllers/authentication_methods_controller.rb
@@ -6,14 +6,33 @@ class AuthenticationMethodsController < ApplicationController
     skip_policy_scope
     authentication_method = AuthenticationMethod.new(authentication_method_params)
     authorize(authentication_method)
-    authentication_method.save!
+    if authentication_method.save
+      render json: authentication_method_as_json(authentication_method)
+    else
+      render json: render_errors(authentication_method), status: :unprocessable_entity
+    end
+  end
 
-    render json: {
-      id: authentication_method.id,
-      contact_method: authentication_method.contact_method,
-      contact_location: authentication_method.contact_location,
-      person: {
-        id: authentication_method.person.id
+  private def render_errors(model)
+    {
+      errors: [{
+        title: t('.failure'),
+        detail: model.errors.full_messages.join('.')
+      }]
+    }
+  end
+
+  # @todo Maybe we want to try?
+  #       http://jsonapi-rb.org/guides/serialization/defining.html
+  private def authentication_method_as_json(authentication_method)
+    {
+      authentication_method: {
+        id: authentication_method.id,
+        contact_method: authentication_method.contact_method,
+        contact_location: authentication_method.contact_location,
+        person: {
+          id: authentication_method.person.id
+        }
       }
     }
   end

--- a/app/controllers/authentication_methods_controller.rb
+++ b/app/controllers/authentication_methods_controller.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Exposes CRUD actions for the {AuthenticationMethod} model.
+class AuthenticationMethodsController < ApplicationController
+  def create
+    skip_policy_scope
+    authentication_method = AuthenticationMethod.new(authentication_method_params)
+    authorize(authentication_method)
+    authentication_method.save!
+
+    render json: {
+      id: authentication_method.id,
+      contact_method: authentication_method.contact_method,
+      contact_location: authentication_method.contact_location,
+      person: {
+        id: authentication_method.person.id
+      }
+    }
+  end
+
+  def authentication_method_params
+    params.require(:authentication_method).permit(:contact_method, :contact_location)
+  end
+end

--- a/app/controllers/authentication_methods_controller.rb
+++ b/app/controllers/authentication_methods_controller.rb
@@ -7,34 +7,10 @@ class AuthenticationMethodsController < ApplicationController
     authentication_method = AuthenticationMethod.new(authentication_method_params)
     authorize(authentication_method)
     if authentication_method.save
-      render json: authentication_method_as_json(authentication_method)
+      render json: AuthenticationMethod::Serializer.new(authentication_method).to_json
     else
-      render json: render_errors(authentication_method), status: :unprocessable_entity
+      render json: AuthenticationMethod::Serializer.new(authentication_method).to_json, status: :unprocessable_entity
     end
-  end
-
-  private def render_errors(model)
-    {
-      errors: [{
-        title: t('.failure'),
-        detail: model.errors.full_messages.join('.')
-      }]
-    }
-  end
-
-  # @todo Maybe we want to try?
-  #       http://jsonapi-rb.org/guides/serialization/defining.html
-  private def authentication_method_as_json(authentication_method)
-    {
-      authentication_method: {
-        id: authentication_method.id,
-        contact_method: authentication_method.contact_method,
-        contact_location: authentication_method.contact_location,
-        person: {
-          id: authentication_method.person.id
-        }
-      }
-    }
   end
 
   def authentication_method_params

--- a/app/models/authentication_method.rb
+++ b/app/models/authentication_method.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # {People} can have multiple methods to authenticate, such as email addresses,
 # phone numbers, one-time passwords, etc.
 class AuthenticationMethod < ApplicationRecord
@@ -6,7 +8,9 @@ class AuthenticationMethod < ApplicationRecord
   attribute :contact_method, :string
   validates :contact_method, presence: true
   attribute :contact_location, :string
-  validates :contact_location, presence: true
+  validates :contact_location, presence: true,
+                               uniqueness: { case_sensitive: false,
+                                             scope: :contact_method }
 
   attribute :confirmed_at, :datetime
 

--- a/app/models/authentication_method.rb
+++ b/app/models/authentication_method.rb
@@ -20,6 +20,8 @@ class AuthenticationMethod < ApplicationRecord
     self.one_time_password_secret ||= ROTP::Base32.random
   end
 
+  # @todo This is dangerous because we're creating people incidentally
+  #       instead of intentionally...
   def set_person
     self.person ||= Person.find_or_create_by(email: contact_location)
   end

--- a/app/models/authentication_method/serializer.rb
+++ b/app/models/authentication_method/serializer.rb
@@ -1,0 +1,37 @@
+# @todo Maybe we want to try?
+# http://jsonapi-rb.org/guides/serialization/defining.html
+class AuthenticationMethod::Serializer
+  # @return [AuthenticatioMethod]
+  attr_accessor :authentication_method
+
+  def initialize(authentication_method)
+    @authentication_method = authentication_method
+  end
+
+  # @todo make this even more like JSON API?
+  #       https://jsonapi.org/format/1.1/#fetching-resources-responses
+  def to_json
+    {
+      errors: authentication_method.errors.map(&method(:error_json)),
+      authentication_method: {
+        id: authentication_method.id,
+        contact_method: authentication_method.contact_method,
+        contact_location: authentication_method.contact_location,
+        person: {
+          id: authentication_method.person.id
+        }
+      }
+    }
+  end
+
+  private def error_json(error)
+    {
+      code: error.type,
+      title: error.full_message,
+      detail: error.message,
+      source: {
+        pointer: "/#{error.base.model_name.param_key}/#{error.attribute}"
+      }
+    }
+  end
+end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# Parent class for Policies.
+# @see https://github.com/varvet/pundit#policies
 class ApplicationPolicy
   attr_reader :person, :object
 

--- a/app/policies/authentication_method_policy.rb
+++ b/app/policies/authentication_method_policy.rb
@@ -1,0 +1,7 @@
+class AuthenticationMethodPolicy < ApplicationPolicy
+  alias authentication_method object
+
+  def create?
+    person.operator?
+  end
+end

--- a/app/policies/authentication_method_policy.rb
+++ b/app/policies/authentication_method_policy.rb
@@ -1,7 +1,13 @@
+# frozen_string_literal: true
+
 class AuthenticationMethodPolicy < ApplicationPolicy
   alias authentication_method object
 
   def create?
     person.operator?
+  end
+
+  def permit(params)
+    params.require(:authentication_method).permit(:contact_method, :contact_location)
   end
 end

--- a/config/locales/authentication_method/en.yml
+++ b/config/locales/authentication_method/en.yml
@@ -1,4 +1,4 @@
 en:
   authentication_methods:
     create:
-      failure: "Authentication Method could not be saved"
+      failure: "Authentication Method could not be saved. 🙀"

--- a/config/locales/authentication_method/en.yml
+++ b/config/locales/authentication_method/en.yml
@@ -1,0 +1,4 @@
+en:
+  authentication_methods:
+    create:
+      failure: "Authentication Method could not be saved"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   root 'spaces#show'
 
+  resources :authentication_methods, only: %i[create]
+
   # get "/auth/:provider/callback", "sessions#create"
   # post "/auth/:provider/callback", "sessions#create"
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html

--- a/spec/factories/authentication_methods.rb
+++ b/spec/factories/authentication_methods.rb
@@ -2,9 +2,9 @@
 
 FactoryBot.define do
   factory :authentication_method do
+    association :person
+
     contact_method { :email }
     contact_location { person.email }
-
-    association :person
   end
 end

--- a/spec/models/authentication_method_spec.rb
+++ b/spec/models/authentication_method_spec.rb
@@ -13,17 +13,21 @@ RSpec.describe AuthenticationMethod, type: :model do
 
   describe '#contact_location' do
     it { is_expected.to validate_presence_of(:contact_location) }
+    it do
+      is_expected.to validate_uniqueness_of(:contact_location)
+        .case_insensitive.scoped_to(:contact_method)
+    end
   end
 
   describe '#verify?(one_time_password)' do
-    it 'is true when the OTP is fresh' do
+    it 'returns true when a valid, fresh OTP is used' do
       authentication_method.last_one_time_password_at = Time.now
       one_time_password = authentication_method.one_time_password
 
       expect(authentication_method.verify?(one_time_password)).to be_truthy
     end
 
-    it 'is false when the OTP is stale' do
+    it 'returns false when the OTP is stale' do
       authentication_method.last_one_time_password_at = 3.hours.ago
       one_time_password = authentication_method.one_time_password
 

--- a/spec/requests/authentication_methods_request_spec.rb
+++ b/spec/requests/authentication_methods_request_spec.rb
@@ -15,16 +15,43 @@ RSpec.describe '/authentication_methods/', type: :request do
              headers: authorization_headers,
              as: :json
 
-        # @todo Make sure the response includes the serialized person
-
-        authentication_method =
-          AuthenticationMethod.find_by(
-            params.slice(:contact_method, :contact_location)
-          )
+        authentication_method = AuthenticationMethod.find_by!(
+          params.slice(:contact_method, :contact_location)
+        )
 
         expect(authentication_method).to be_present
         expect(authentication_method.person).to be_present
         expect(authentication_method.person).to eq(person)
+
+        expect(json_response[:authentication_method])
+          .to eq({ id: authentication_method.id,
+                   contact_method: params[:contact_method].to_s,
+                   contact_location: params[:contact_location],
+                   person: { id: person.id } })
+      end
+
+      it 'returns validation errors when the authentication method cannot be saved' do
+        existing_authentication_method = create(:authentication_method)
+
+        post authentication_methods_path,
+             params: { authentication_method: {
+               contact_method: existing_authentication_method.contact_method,
+               contact_location: existing_authentication_method.contact_location
+             } },
+             headers: authorization_headers,
+             as: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json_response[:errors]).to eq(
+          [{
+            title: I18n.t('authentication_methods.create.failure'),
+            detail: 'Contact location has already been taken'
+          }]
+        )
+      end
+
+      def json_response
+        @json_response ||= JSON.parse(response.body, symbolize_names: true)
       end
     end
   end

--- a/spec/requests/authentication_methods_request_spec.rb
+++ b/spec/requests/authentication_methods_request_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe '/authentication_methods/', type: :request do
+  include ActiveJob::TestHelper
+
+  describe 'POST /authentication_methods/' do
+    context 'as an Operator using the API' do
+      it 'creates an AuthenticationMethod' do
+        person = create(:person)
+        params = attributes_for(:authentication_method, person: person)
+        post authentication_methods_path,
+             params: { authentication_method: params },
+             headers: authorization_headers,
+             as: :json
+
+        # @todo Make sure the response includes the serialized person
+
+        authentication_method =
+          AuthenticationMethod.find_by(
+            params.slice(:contact_method, :contact_location)
+          )
+
+        expect(authentication_method).to be_present
+        expect(authentication_method.person).to be_present
+        expect(authentication_method.person).to eq(person)
+      end
+    end
+  end
+end

--- a/spec/requests/authentication_methods_request_spec.rb
+++ b/spec/requests/authentication_methods_request_spec.rb
@@ -3,8 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe '/authentication_methods/', type: :request do
-  include ActiveJob::TestHelper
-
   describe 'POST /authentication_methods/' do
     context 'as an Operator using the API' do
       it 'creates an AuthenticationMethod' do

--- a/spec/requests/authentication_methods_request_spec.rb
+++ b/spec/requests/authentication_methods_request_spec.rb
@@ -42,12 +42,16 @@ RSpec.describe '/authentication_methods/', type: :request do
              as: :json
 
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(json_response[:errors]).to eq(
-          [{
-            title: I18n.t('authentication_methods.create.failure'),
-            detail: 'Contact location has already been taken'
-          }]
-        )
+
+        expected_error = ActiveModel::Error.new(AuthenticationMethod.new, :contact_location, :taken)
+
+        expect(json_response[:errors])
+          .to include({
+                        code: expected_error.type.to_s,
+                        title: expected_error.full_message,
+                        detail: expected_error.message,
+                        source: { pointer: '/authentication_method/contact_location' }
+                      })
       end
 
       def json_response

--- a/spec/requests/spaces_request_spec.rb
+++ b/spec/requests/spaces_request_spec.rb
@@ -5,12 +5,6 @@ require 'rails_helper'
 RSpec.describe '/spaces/', type: :request do
   include ActiveJob::TestHelper
 
-  def authorization_headers(token)
-    {
-      'HTTP_AUTHORIZATION' =>
-        ActionController::HttpAuthentication::Token.encode_credentials(token)
-    }
-  end
   describe 'DELETE /spaces/:space_slug/' do
     context 'as an Operator using the API' do
       it "deletes the space and all it's other bits" do
@@ -18,7 +12,7 @@ RSpec.describe '/spaces/', type: :request do
 
         space = Space.find_by(slug: 'system-test')
         delete space_path(space),
-               headers: authorization_headers(ENV['OPERATOR_API_KEY']),
+               headers: authorization_headers,
                as: :json
 
         perform_enqueued_jobs

--- a/spec/support/auth_helpers.rb
+++ b/spec/support/auth_helpers.rb
@@ -21,4 +21,11 @@ module AuthHelpers
 
     sign_in(space, member)
   end
+
+  def authorization_headers(token = ENV['OPERATOR_API_KEY'])
+    {
+      'HTTP_AUTHORIZATION' =>
+        ActionController::HttpAuthentication::Token.encode_credentials(token)
+    }
+  end
 end


### PR DESCRIPTION
The AuthenticationMethod API wants to be used in the feature tests to
make it a little bit easier to create People and authenticate as them
programmatically.

This pulls the work done in
https://github.com/zinc-collective/convene/pull/594 for exposing that
API out into it's own PR that we can merge independently, then rebase
into the feature branch for Invitations.

Co-authored-by: Kelly Hong <KellyAH@users.noreply.github.com>
Co-authored-by: Neer Malathapa <nirmalathapa@users.noreply.github.com>
Co-authored-by: Zee Spencer <zspencer@users.noreply.github.com>
Co-authored-by: Naomi Quinones <naomiquinones@users.noreply.github.com>