### PR TITLE
Use `dotenv` package to populate .env in Cucumber

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -7,4 +7,4 @@ set -e
 
 bin/rails assets:precompile
 bin/rake
-dotenv yarn run test
+yarn run test

--- a/features/support/env.js
+++ b/features/support/env.js
@@ -1,3 +1,4 @@
+require('dotenv').config()
 const fse = require('fs-extra');
 const { setWorldConstructor, BeforeAll, AfterAll, After, setDefaultTimeout, Status } = require('@cucumber/cucumber');
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@cucumber/cucumber": "^8.0.0",
     "@cucumber/pretty-formatter": "^1.0.0-alpha.2",
     "axios": "^0.26.1",
+    "dotenv": "^16.0.0",
     "fs-extra": "^10.0.1",
     "geckodriver": "^3.0.1",
     "get-urls": "^10.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1392,6 +1392,11 @@ dns-packet@^5.2.2:
   dependencies:
     "@leichtgewicht/ip-codec" "^2.0.1"
 
+dotenv@^16.0.0:
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.0.tgz#c619001253be89ebb638d027b609c75c26e47411"
+  integrity sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==
+
 duration@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/duration/-/duration-0.2.2.tgz#ddf149bc3bc6901150fe9017111d016b3357f529"


### PR DESCRIPTION
We noticed that in orer to run `yarn test` locally, we had to prefix it
with `dotenv yarn test`, which was kinda silly.

This makes it so running `yarn test` will load whatever is in `.env` for
us, hooray!

Co-authored-by: Neer Malathapa <nirmalathapa@users.noreply.github.com>
Co-authored-by: Naomi Quinones <naomiquinones@users.noreply.github.com>