### PR TITLE
Spaces: Use Spaces API to create a Space in Scenarios

### DIFF
--- a/app/models/system_test_space.rb
+++ b/app/models/system_test_space.rb
@@ -3,6 +3,7 @@
 # A Space that's accessible at both a branded domain and `/spaces/system-test/`:
 #  - http://system-test.zinc.local
 #  - http://localhost:3000/spaces/system-test/
+# @deprecated use blueprints instead when possible
 class SystemTestSpace
   # Creates the system test space on environments that include it by default,
   # such as review apps, test, and local dev environments.

--- a/features/lib/Api.js
+++ b/features/lib/Api.js
@@ -1,38 +1,57 @@
-const axios = require('axios');
+const axios = require("axios");
+const { camelCase } = require('change-case');
+const applyCaseMiddleware = require("axios-case-converter").default;
+const Space = require("./Space");
 class Api {
   constructor(host, apiKey) {
     this.host = host;
     this.apiKey = apiKey;
-    this.axios  = axios.create({
-        baseURL: host
-      });
+    this.axios = applyCaseMiddleware(
+      axios.create({
+        baseURL: host,
+      })
+    );
 
     // Alter defaults after instance has been created
-    this.axios.defaults.headers.common['Authorization'] = `Token token="${apiKey}"`;
-    this.axios.defaults.headers.common['Content-Type'] = 'application/json';
-    this.axios.defaults.headers.common['Accept'] = 'application/json';
+    this.axios.defaults.headers.common[
+      "Authorization"
+    ] = `Token token="${apiKey}"`;
+    this.axios.defaults.headers.common["Content-Type"] = "application/json";
+    this.axios.defaults.headers.common["Accept"] = "application/json";
   }
 
+  /**
+   * @returns {Repository}
+   */
   spaces() {
-    return new Repository({ client: this, endpoint: '/spaces' });
+    return new Repository({ client: this, endpoint: "/spaces", model: Space });
   }
 
   post(path, model) {
-    return this.axios.post(path, model).catch(function (error) {
+    return this.axios.post(path, model.asParams()).catch(function (error) {
       console.error(`Can't POST to ${path}`);
-      console.error(model);
+      console.error(model.asParams());
       throw error;
     });
   }
 }
 exports.Api = Api;
 class Repository {
-  constructor({ client, endpoint }) {
+  constructor({ client, endpoint, model }) {
     this.client = client;
     this.endpoint = endpoint;
+    this.model = model;
   }
 
-  create(model) {
-    return this.client.post(this.endpoint, model);
+  create(data) {
+    const model = this.model;
+    return this.client.post(this.endpoint, data).then(function (response) {
+      const data = response.data[camelCase(model.name)] || response.data;
+      return new model(data);
+    })
+  }
+
+  findOrCreateBy(data) {
+    return this.create(data);
   }
 }

--- a/features/lib/Api.js
+++ b/features/lib/Api.js
@@ -1,5 +1,5 @@
 const axios = require("axios");
-const { camelCase } = require('change-case');
+const { camelCase } = require("change-case");
 const applyCaseMiddleware = require("axios-case-converter").default;
 const Space = require("./Space");
 class Api {
@@ -48,7 +48,7 @@ class Repository {
     return this.client.post(this.endpoint, data).then(function (response) {
       const data = response.data[camelCase(model.name)] || response.data;
       return new model(data);
-    })
+    });
   }
 
   findOrCreateBy(data) {

--- a/features/lib/Invitation.js
+++ b/features/lib/Invitation.js
@@ -1,4 +1,5 @@
 const getUrls = require("get-urls");
+const { last } = require("lodash");
 const { ThenableWebDriver } = require("selenium-webdriver");
 const InvitationResponsePage = require("../harness/InvitationResponsePage");
 
@@ -33,7 +34,7 @@ class Invitation {
    * @returns {Promise<MailServerEmail>}
    */
   latestDelivery() {
-    return this.emails().then((emails) => emails[0]);
+    return this.emails().then(last);
   }
 
   /**

--- a/features/lib/Space.js
+++ b/features/lib/Space.js
@@ -1,10 +1,15 @@
 
 class Space {
-  constructor(spaceName) {
-    this.name = spaceName;
-    this.slug = spaceName.replace(/\s+/g, '-').toLowerCase();
-    this.blueprint = 'system_test'
-    this.client_attributes = { name: spaceName };
+  constructor({ name, slug, id }) {
+    this.name = name;
+    this.slug = slug || name.replace(/\s+/g, '-').toLowerCase();
+    this.id = id;
+  }
+
+  asParams() {
+    return {
+      space: { name: this.name, slug: this.slug, blueprint: 'system_test', clientAttributes: { name: this.name } }
+    }
   }
 }
 

--- a/features/lib/linkParameters.js
+++ b/features/lib/linkParameters.js
@@ -3,7 +3,7 @@ const Space = require("./Space");
  * Merges extracted parameter types together for convenience within step definitions
  */
 module.exports = function linkParameters({
-  space = new Space("System Test"),
+  space = new Space({ name: "System Test" }),
   accessLevel,
   room,
 }) {

--- a/features/rooms/discovering-rooms.feature
+++ b/features/rooms/discovering-rooms.feature
@@ -23,13 +23,13 @@ Feature: Discovering Rooms
   # Unlisted Rooms
   @built
   Scenario: Guest may not discover Unlisted Rooms
-    Given a fresh "System Test" Space
+    Given a "System Test" Space
     When the Guest is on the "System Test" Space Dashboard
     Then the Guest does not see the "Unlisted Room 1" Room's Door
 
   @built
   Scenario: Space Member may not discover Unlisted Room
-    Given a fresh "System Test" Space
+    Given a "System Test" Space
     When the Space Member is on the "System Test" Space Dashboard
     Then the Space Member does not see the "Unlisted Room 1" Room's Door
 

--- a/features/steps/identification_steps.js
+++ b/features/steps/identification_steps.js
@@ -9,7 +9,7 @@ Given(
   "an unauthenticated {actor} has requested to be identified via Email",
   async function (actor) {
     this.actor = actor;
-    const space = new Space("System Test");
+    const space = new Space({ name: "System Test" });
     const signInPage = await new SignInPage(this.driver, space).visit();
     return signInPage.submitEmail(actor.email);
   }
@@ -19,7 +19,7 @@ Given("a {actor} Authenticated Session",
 /** @param {Actor} actor */
 function (actor) {
   this.actor = actor;
-  const space = new Space("System Test");
+  const space = new Space({ name: "System Test" });
   return this.actor.signIn(this.driver, space)
 });
 

--- a/features/steps/space_steps.js
+++ b/features/steps/space_steps.js
@@ -5,19 +5,9 @@ const appUrl = require("../lib/appUrl");
 const { Api } = require("../lib/Api");
 
 Given("{a} {space}", function (_, space) {
-  return true;
-});
-
-Given("{a} fresh {space}", function (_, space) {
   const api = new Api(appUrl(), process.env.OPERATOR_API_KEY);
 
   return api.spaces().create(space);
-});
-
-Given("a Space with a Room", function () {
-  // This space intentionally left blank... For now...
-  // TODO: Create a Space for each test instead of re-using the
-  //       System Test Space
 });
 
 Given("{a} {space} has {a} {actor}", function (_, space, _, actor) {

--- a/features/steps/utility_hookup_steps.js
+++ b/features/steps/utility_hookup_steps.js
@@ -7,7 +7,7 @@ const { Actor, Space } = require("../lib");
 When("a Space Owner adds a Hookup to their Space", async function () {
   this.actor = new Actor("Space Owner", 'space-owner@example.com');
   await this.actor.signIn(this.driver);
-  this.space = new Space("System Test");
+  this.space = new Space({ name: "System Test" });
 
   const page = new SpaceEditPage(this.driver, this.space);
   await page.visit().then((p) => p.addUtilityHookup("Jitsi Meet"));

--- a/features/support/env.js
+++ b/features/support/env.js
@@ -1,4 +1,5 @@
 require('dotenv').config()
+const crypto = require("crypto");
 const fse = require('fs-extra');
 const { setWorldConstructor, BeforeAll, AfterAll, After, setDefaultTimeout, Status } = require('@cucumber/cucumber');
 
@@ -13,6 +14,10 @@ let driver;
 class CustomWorld {
   constructor() {
     this.driver = driver;
+  }
+
+  testId() {
+    return this._testId = this._testId || crypto.randomUUID();
   }
 }
 

--- a/features/support/parameter-types/space.js
+++ b/features/support/parameter-types/space.js
@@ -1,5 +1,5 @@
 const { defineParameterType } = require("@cucumber/cucumber");
-const Space = require('../../lib/Space');
+const Space = require("../../lib/Space");
 
 // This injects a Space class into steps with named Spaces (i.e.)
 // `the "Convene Demo" Space` and steps that mention `Space` in
@@ -7,5 +7,11 @@ const Space = require('../../lib/Space');
 defineParameterType({
   name: "space",
   regexp: /("[^"]*" )?Space/,
-  transformer: (name = "System Test") => new Space(name.trim().replace(/\"/g,'')),
+  transformer: function (name = "System Test") {
+    const tidyName = name.trim().replace(/\"/g, "");
+    this.spaces = this.spaces || {};
+    return (this.spaces[tidyName] =
+      this.spaces[tidyName] ||
+      new Space({ name: `${this.testId()} ${tidyName}` }));
+  },
 });

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "@cucumber/cucumber": "^8.1.2",
     "@cucumber/pretty-formatter": "^1.0.0-alpha.2",
     "axios": "^0.27.1",
+    "axios-case-converter": "^0.9.0",
+    "change-case": "^4.1.2",
     "dotenv": "^16.0.0",
     "fs-extra": "^10.1.0",
     "geckodriver": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -887,6 +887,16 @@ autoprefixer@^10.4.4, autoprefixer@^10.4.5:
     picocolors "^1.0.0"
     postcss-value-parser "^4.2.0"
 
+axios-case-converter@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/axios-case-converter/-/axios-case-converter-0.9.0.tgz#9f47f641ae3f8c04a5395370601342e4f8c33c77"
+  integrity sha512-G6tOanR1cdIrBtRyiPvR+xXyWCCZacSw8LtT8bmImvpye+XiyoOlLluz0N61IfetznNQ9BeMi5yA0rIyYDr8mQ==
+  dependencies:
+    camel-case "^4.1.1"
+    header-case "^2.0.3"
+    snake-case "^3.0.3"
+    tslib "^2.3.0"
+
 axios@^0.27.1:
   version "0.27.1"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.1.tgz#badcc8cc38cfa812320221b600776452141ea5d4"
@@ -1024,6 +1034,14 @@ cacheable-request@^7.0.1:
     normalize-url "^6.0.1"
     responselike "^2.0.0"
 
+camel-case@^4.1.1, camel-case@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-4.1.2.tgz#9728072a954f805228225a6deea6b38461e1bd5a"
+  integrity sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==
+  dependencies:
+    pascal-case "^3.1.2"
+    tslib "^2.0.3"
+
 camelcase-css@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/camelcase-css/-/camelcase-css-2.0.1.tgz#ee978f6947914cc30c6b44741b6ed1df7f043fd5"
@@ -1050,6 +1068,24 @@ chalk@^4.1.2:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
+
+change-case@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/change-case/-/change-case-4.1.2.tgz#fedfc5f136045e2398c0410ee441f95704641e12"
+  integrity sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==
+  dependencies:
+    camel-case "^4.1.2"
+    capital-case "^1.0.4"
+    constant-case "^3.0.4"
+    dot-case "^3.0.4"
+    header-case "^2.0.4"
+    no-case "^3.0.4"
+    param-case "^3.0.4"
+    pascal-case "^3.1.2"
+    path-case "^3.0.4"
+    sentence-case "^3.0.4"
+    snake-case "^3.0.4"
+    tslib "^2.0.3"
 
 chokidar@^3.3.0, chokidar@^3.5.3:
   version "3.5.3"
@@ -1213,6 +1249,15 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
+
+constant-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/constant-case/-/constant-case-3.0.4.tgz#3b84a9aeaf4cf31ec45e6bf5de91bdfb0589faf1"
+  integrity sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==
+  dependencies:
+    no-case "^3.0.4"
+    tslib "^2.0.3"
+    upper-case "^2.0.2"
 
 content-disposition@0.5.4:
   version "0.5.4"
@@ -1416,6 +1461,14 @@ dns-packet@^5.2.2:
   integrity sha512-spBwIj0TK0Ey3666GwIdWVfUpLyubpU53BTCu8iPn4r4oXd9O14Hjg3EHw3ts2oed77/SeckunUYCyRlSngqHw==
   dependencies:
     "@leichtgewicht/ip-codec" "^2.0.1"
+
+dot-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/dot-case/-/dot-case-3.0.4.tgz#9b2b670d00a431667a8a75ba29cd1b98809ce751"
+  integrity sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==
+  dependencies:
+    no-case "^3.0.4"
+    tslib "^2.0.3"
 
 dotenv@^16.0.0:
   version "16.0.0"
@@ -1927,6 +1980,14 @@ has@^1.0.3:
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   dependencies:
     function-bind "^1.1.1"
+
+header-case@^2.0.3, header-case@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/header-case/-/header-case-2.0.4.tgz#5a42e63b55177349cf405beb8d775acabb92c063"
+  integrity sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==
+  dependencies:
+    capital-case "^1.0.4"
+    tslib "^2.0.3"
 
 hpack.js@^2.1.6:
   version "2.1.6"
@@ -2851,10 +2912,34 @@ pako@~1.0.2:
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
   integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
 
+param-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/param-case/-/param-case-3.0.4.tgz#7d17fe4aa12bde34d4a77d91acfb6219caad01c5"
+  integrity sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==
+  dependencies:
+    dot-case "^3.0.4"
+    tslib "^2.0.3"
+
 parseurl@~1.3.2, parseurl@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
+
+pascal-case@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/pascal-case/-/pascal-case-3.1.2.tgz#b48e0ef2b98e205e7c1dae747d0b1508237660eb"
+  integrity sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==
+  dependencies:
+    no-case "^3.0.4"
+    tslib "^2.0.3"
+
+path-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/path-case/-/path-case-3.0.4.tgz#9168645334eb942658375c56f80b4c0cb5f82c6f"
+  integrity sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==
+  dependencies:
+    dot-case "^3.0.4"
+    tslib "^2.0.3"
 
 path-exists@^4.0.0:
   version "4.0.0"
@@ -3572,6 +3657,15 @@ send@0.17.2:
     range-parser "~1.2.1"
     statuses "~1.5.0"
 
+sentence-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/sentence-case/-/sentence-case-3.0.4.tgz#3645a7b8c117c787fde8702056225bb62a45131f"
+  integrity sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==
+  dependencies:
+    no-case "^3.0.4"
+    tslib "^2.0.3"
+    upper-case-first "^2.0.2"
+
 serialize-javascript@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.0.tgz#efae5d88f45d7924141da8b5c3a7a7e663fefeb8"
@@ -3660,6 +3754,14 @@ smart-buffer@^4.1.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae"
   integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
+
+snake-case@^3.0.3, snake-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/snake-case/-/snake-case-3.0.4.tgz#4f2bbd568e9935abdfd593f34c691dadb49c452c"
+  integrity sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==
+  dependencies:
+    dot-case "^3.0.4"
+    tslib "^2.0.3"
 
 sockjs@^0.3.21:
   version "0.3.21"
@@ -3970,7 +4072,7 @@ ts-dedent@^2.0.0:
   resolved "https://registry.yarnpkg.com/ts-dedent/-/ts-dedent-2.2.0.tgz#39e4bd297cd036292ae2394eb3412be63f563bb5"
   integrity sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==
 
-tslib@^2.0.3:
+tslib@^2.0.3, tslib@^2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
@@ -4021,6 +4123,13 @@ upper-case-first@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/upper-case-first/-/upper-case-first-2.0.2.tgz#992c3273f882abd19d1e02894cc147117f844324"
   integrity sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==
+  dependencies:
+    tslib "^2.0.3"
+
+upper-case@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-2.0.2.tgz#d89810823faab1df1549b7d97a76f8662bae6f7a"
+  integrity sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==
   dependencies:
     tslib "^2.0.3"
 


### PR DESCRIPTION
This swaps our scenarios to append test data to the local database, rather than re-use the `system-test` space over and over and over again.

It runs safely on CI, but if you run the test suite twice you start to see errors.

I believe this is because we're not applying a the `testId` to the Invitation Email, so when an invitation goes out it goes out to the same email address each time; which can result in race-conditions when following links.

It may be worth tilting at that windmill a bit more before merging; but I'm not sure.

Thoughts?