### PR TITLE
Collect responsibility for applying a Space::Blueprint

### DIFF
--- a/app/controllers/spaces_controller.rb
+++ b/app/controllers/spaces_controller.rb
@@ -20,12 +20,7 @@ class SpacesController < ApplicationController
     skip_policy_scope
     authorize(Client)
     authorize(Space)
-
-    if space_params[:blueprint].present?
-      Space.find_or_create_from_blueprint!(space_params)
-    else
-      Space.create_with(space_params).find_or_create_by!(name: space_params[:name])
-    end
+    Space::Factory.create(space_params)
   end
 
   def destroy

--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -63,14 +63,4 @@ class Space < ApplicationRecord
 
     Utilities.from_utility_hookup(jitsi_hookup).meet_domain
   end
-
-  def self.find_or_create_from_blueprint!(space_attributes)
-    blueprint_name = space_attributes.delete(:blueprint)
-    create_with(space_attributes).find_or_create_by!(name: space_attributes[:name]).tap do |space|
-      Blueprint.new(
-        client: { name: space.client.name, space: Blueprint::BLUEPRINTS[blueprint_name] },
-        space: space
-      ).find_or_create!
-    end
-  end
 end

--- a/app/models/space/factory.rb
+++ b/app/models/space/factory.rb
@@ -1,0 +1,15 @@
+class Space::Factory
+  def self.create(space_attributes)
+    blueprint_name = space_attributes.delete(:blueprint)
+    space = Space.create_with(space_attributes).find_or_create_by!(name: space_attributes[:name])
+
+    if blueprint_name.present?
+      Blueprint.new(
+        client: { name: space.client.name, space: Blueprint::BLUEPRINTS[blueprint_name] },
+        space: space
+      ).find_or_create!
+    end
+
+    space
+  end
+end

--- a/app/models/space/factory.rb
+++ b/app/models/space/factory.rb
@@ -1,11 +1,15 @@
+# frozen_string_literal: true
+
 class Space::Factory
   def self.create(space_attributes)
     blueprint_name = space_attributes.delete(:blueprint)
-    space = Space.create_with(space_attributes).find_or_create_by!(name: space_attributes[:name])
+    space = Space.create_with(space_attributes)
+                 .find_or_create_by!(name: space_attributes[:name])
 
     if blueprint_name.present?
       Blueprint.new(
-        client: { name: space.client.name, space: Blueprint::BLUEPRINTS[blueprint_name] },
+        client: { name: space.client.name,
+                  space: Blueprint::BLUEPRINTS[blueprint_name] },
         space: space
       ).find_or_create!
     end

--- a/spec/factories/space.rb
+++ b/spec/factories/space.rb
@@ -4,9 +4,14 @@ FactoryBot.define do
   factory :space do
     client
     name { FFaker::CheesyLingo.title }
+    slug { name.gsub(' ', '_').downcase.dasherize }
 
     trait :default do
       slug { Neighborhood.config.default_space_slug }
+    end
+
+    trait :with_client_attributes do
+      client_attributes { attributes_for(:client) }
     end
 
     trait :with_members do

--- a/spec/models/space/factory_spec.rb
+++ b/spec/models/space/factory_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Space::Factory do
+  describe '.create' do
+    it 'creates a Space from the given attributes' do
+      attributes = attributes_for(:space, :with_client_attributes)
+      space = Space::Factory.create(attributes)
+
+      expect(space).to be_persisted
+      expect(space.name).to eq(attributes[:name])
+      expect(space.slug).to eq(attributes[:slug])
+    end
+
+    # @todo this is probably dangerous?
+    it 'upserts if a Space has the provided name already' do
+      existing_space = create(:space)
+
+      attributes = attributes_for(:space, :with_client_attributes,
+                                  name: existing_space.name)
+      space = Space::Factory.create(attributes)
+
+      expect(space).to eql(existing_space)
+    end
+
+    it "applies the blueprint if it's provided" do
+      space = Space::Factory.create(attributes_for(:space, :with_client_attributes,
+                                                   blueprint: :system_test))
+
+      expect(space.rooms).to be_present
+      expect(space.utility_hookups).to be_present
+    end
+  end
+end


### PR DESCRIPTION
OK, so I agree that the callback system was probably a little fraught.

Complexity emerges at those seams.

It may make sense for us to pull the responsibility into a factory.

Now if we want to create a space without executing a pile of callbacks,
we can.

And if we want to keep the controllers focused on the secure translation
of the HTTP protocol into domain objects we can.

And it sides steps a `Service` class (which I find reminiscent of the
`Manager` classes of my JavaDays.