### PR TITLE
Sprout Space Membership API Endpoint

### DIFF
--- a/app/controllers/space_memberships_controller.rb
+++ b/app/controllers/space_memberships_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class SpaceMembershipsController < ApplicationController
+  def create
+    space_membership = SpaceMembership.new(space_membership_params)
+    authorize(space_membership)
+    if space_membership.save
+      render json: SpaceMembership::Serializer.new(space_membership).to_json, status: :created
+    else
+      render json: SpaceMembership::Serializer.new(space_membership).to_json, status: :unprocessable_entity
+    end
+  end
+
+  private def space_membership_params
+    params.require(:space_membership).permit(:space_id, :member_id)
+  end
+end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Invitation < ApplicationRecord
   belongs_to :space, inverse_of: :invitations
 

--- a/app/models/space_membership.rb
+++ b/app/models/space_membership.rb
@@ -1,7 +1,11 @@
+# frozen_string_literal: true
+
 class SpaceMembership < ApplicationRecord
   # Which space the person is in
   belongs_to :space
 
   # Which person is in the space
   belongs_to :member, class_name: :Person
+
+  validates :member, uniqueness: { scope: :space_id }
 end

--- a/app/models/space_membership/serializer.rb
+++ b/app/models/space_membership/serializer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class SpaceMembership::Serializer < ApplicationSerializer
+  # @return [SpaceMembership]
+  alias space_membership resource
+  def to_json(*_args)
+    super.merge(
+      space_membership: {
+        id: space_membership.id,
+        member: {
+          id: space_membership.member.id
+        },
+        space: {
+          id: space_membership.space.id
+        }
+      }
+    )
+  end
+end

--- a/app/policies/space_membership_policy.rb
+++ b/app/policies/space_membership_policy.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class SpaceMembershipPolicy < ApplicationPolicy
+  alias space_membership object
+  delegate :space, to: :space_membership
+  def create?
+    person.operator? || person_responding_to_invitation_to_space?
+  end
+
+  private def person_responding_to_invitation_to_space?
+    (space_membership.member.email == person.email && space.invitations.exists?(status: %i[sent pending], email: person.email))
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,8 @@ Rails.application.routes.draw do
     resources :utility_hookups, only: %I[create edit update destroy index]
   end
 
+  resources :space_memberships, only: %I[create]
+
   resource :me, only: %i[show], controller: 'me'
 
   resources :guides, only: %i[index show]

--- a/spec/models/space_membership_spec.rb
+++ b/spec/models/space_membership_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SpaceMembership, type: :model do
+  subject(:space_membership) { FactoryBot.build(:space_membership) }
+  describe '#member' do
+    it { is_expected.to belong_to(:member) }
+    it { is_expected.to validate_uniqueness_of(:member).scoped_to(:space_id) }
+  end
+
+  describe '#space' do
+    it { is_expected.to belong_to(:space) }
+  end
+end

--- a/spec/policies/space_membership_policy_spec.rb
+++ b/spec/policies/space_membership_policy_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SpaceMembershipPolicy do
+  subject(:policy) { described_class }
+  let(:space) { create(:space) }
+  let(:space_owner) do
+    create(:person, name: 'Space Owner').tap do |space_owner|
+      space.space_memberships.create!(member: space_owner)
+    end
+  end
+  let(:invitation) { create(:invitation, space: space, email: invitee_email, status: invitation_status) }
+  let(:invitee) { create(:person, name: invitee_name).tap { invitation } }
+  let(:invitee_name) { "Invitee #{SecureRandom.hex(4)}" }
+  let(:invitee_email) { "#{invitee_name.gsub(' ', '-')}@example.com".downcase }
+  let(:invitation_status) { :sent }
+
+  permissions :create? do
+    let(:space_membership) { build(:space_membership, member: invitee, space: space) }
+
+    it { is_expected.to permit(Operator.new, space_membership) }
+    it { is_expected.to permit(invitee, space_membership) }
+    it { is_expected.not_to permit(space_owner, space_membership) }
+    context 'when the invitation has expired' do
+      let(:invitation_status) { :expired }
+      it { is_expected.not_to permit(invitee, space_membership) }
+    end
+
+    context 'when the invitation is rejected' do
+      let(:invitation_status) { :rejected }
+      it { is_expected.not_to permit(invitee, space_membership) }
+    end
+
+    context 'when the invitation is accepted' do
+      let(:invitation_status) { :accepted }
+      it { is_expected.not_to permit(invitee, space_membership) }
+    end
+
+    context 'when the invitation is pending' do
+      let(:invitation_status) { :pending }
+      it { is_expected.to permit(invitee, space_membership) }
+    end
+
+    context 'when the space membership is not for the invitee' do
+      let(:space_membership) { build(:space_membership, space: space) }
+      it { is_expected.not_to permit(invitee, space_membership) }
+    end
+  end
+end

--- a/spec/requests/space_memberships_request_spec.rb
+++ b/spec/requests/space_memberships_request_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+
+RSpec.describe '/space_memberships/', type: :request do
+  path '/space_memberships' do
+    include ApiHelpers::Path
+    post 'Creates a SpaceMembership' do
+      tags 'SpaceMembership'
+      produces 'application/json'
+      consumes 'application/json'
+      security [api_key: []]
+
+      parameter name: :body, in: :body, schema: {
+        type: :object,
+        properties: {
+          space_membership: {
+            type: :object,
+            properties: {
+              member_id: { type: :string, example: 'a-uuid-for-a-person' },
+              space_id: { type: :string, example: 'a-uuid-for-space' }
+            },
+            required: %w[person_id space_id]
+          }
+        },
+        required: ['space_membership']
+      }
+      let(:api_key) { ENV['OPERATOR_API_KEY'] }
+      let(:Authorization) { encode_authorization_token(api_key) }
+      let(:body) { { space_membership: attributes } }
+      let(:person) { create(:person) }
+      let(:space) { create(:space) }
+
+      response '201', 'Space Membership Created' do
+        let(:attributes) { attributes_for(:space_membership, member_id: person.id, space_id: space.id) }
+        run_test! do |response|
+          data = response_data(response)
+
+          space_membership = SpaceMembership.find(data[:space_membership][:id])
+          expect(space_membership).to be_present
+          expect(space_membership.member).to be_present
+          expect(space_membership.member).to eq(person)
+
+          expect(data[:space_membership])
+            .to eq(id: space_membership.id,
+                   space: { id: space.id },
+                   member: { id: person.id })
+        end
+      end
+
+      response '422', 'Member already exists in Space' do
+        before { create(:space_membership, member: person, space: space) }
+        let(:attributes) { attributes_for(:space_membership, member_id: person.id, space_id: space.id) }
+
+        run_test!
+      end
+    end
+  end
+end


### PR DESCRIPTION
While doing test setup for the Invitation tests, we needed to create a
SpaceMembership via the API. However, there was no API for
SpaceMemberships.

This sprouts an initial API, with policy objects, serializers, etc. so
that SpaceMemberships may be created programmaticaly

Co-authored-by: Neer Malathapa <nirmalathapa@users.noreply.github.com>
Co-authored-by: Naomi Quinones <naomiquinones@users.noreply.github.com>