### PR TITLE
Furniture: Spotlight - Describe feature and sketch out steps

### DIFF
--- a/app/furniture/embedded_image.rb
+++ b/app/furniture/embedded_image.rb
@@ -6,7 +6,7 @@ class EmbeddedImage
   def self.append_routes(router)
     router.scope module: 'embedded_image' do
       router.resource :embedded_image, only: [:show] do
-        router.resource :image_file, only: %i[create update]
+        router.resources :image_files, only: %i[create update]
       end
     end
   end

--- a/features/furniture/spotlight.feature.md
+++ b/features/furniture/spotlight.feature.md
@@ -1,0 +1,52 @@
+# Furniture: Spotlight!
+
+Websites would be pretty boring without a way to highlight something really important.
+
+Whether a video highlighting your favorite book, a picture of the sunset, or a value-proposition
+with a mind-blowing animated GIF; Spotlights illuminate the best you have to offer!
+
+`@andromeda`
+
+## Scenario: Hero Image
+
+Hero' images<sup>[1] [2]</sup> are a mainstay of web design, providing a clear place for people who enter a space to direct their attention.
+
+Hero images are often used to convey the core value proposition of a product or service, highlight a particularly impressive piece of work on a portfolio, capture a viewers imagination, or direct their attention to a key call to action.
+
+Hero Images are automatically resized to maintain their aspect ratio while providing as high a resolution experience to visitors as possible.
+
+- Given an "Zee's Artist Portfolio" Space
+- And a "Spotlight" Furniture in the Entrance Hall to "Zee's Artist Portfolio" Space is configured with:
+  | file | adorable_kitten_12mp_16x9.heic |
+  | heading | Kittens Are The Best |
+  | summary | Everyone loves kittens. They're adorable! Look at them! They make you melt! How can you not love kittens?! |
+  | link_text | Scroll your way to happiness |
+  | link | //kitten-gallery |
+
+- Then a 1 megapixel 16x9 Spotlight of "adorable_kittens" is shown to Portrait Phone visits to "Zee's Artist Portfolio" Space
+- And a 4 megapixel 16x9 Spotlight of "adorable_kittens" is shown to Landscape Phone visits to "Zee's Artist Portfolio" Space
+- And a 2 megapixel 16x9 Spotlight of "adorable_kittens" is shown to Portrait Tablet visits to "Zee's Artist Portfolio" Space
+- And a 6 megapixel 16x9 Spotlight of "adorable_kittens" is shown to Landscape Tablet visits to "Zee's Artist Portfolio" Space
+
+[1]: https://design4users.com/hero-images-in-web-design/
+[2]: https://elementor.com/blog/hero-image/
+
+`@andromeda` `@unstarted`
+
+## Scenario: Hero Video
+
+While Hero _Images_ are quite common, many sites embed video to really showcase what's up.
+
+- Given an "Zee's Artist Portfolio" Space
+- And a "Spotlight" Furniture in the Entrance Hall to "Zee's Artist Portfolio" Space is configured with:
+  | file | adorable_kitten_12mp_16x9.mp4 |
+  | heading | Kittens Are The Best |
+  | summary | Everyone loves kittens. They're adorable! Look at them! They make you melt! How can you not love kittens?! |
+  | link_text | Scroll your way to happiness |
+  | link | //kitten-gallery |
+
+- Then Portrait Phone Guests see a 1.2 megapixel 16x9 Spotlight of "adorable_kittens" on "Zee's Artist Portfolio"
+- And Landscape Phone Guests see a 4 megapixel 16x9 Spotlight of "adorable_kittens" on "Zee's Artist Portfolio"
+- And Portrait Tablet Guests see a 2 megapixel 16x9 Spotlight of "adorable_kittens" on "Zee's Artist Portfolio"
+- And Landscape Tablet Guests see a 6 megapixel 16x9 Spotlight of "adorable_kittens" on "Zee's Artist Portfolio"
+to

--- a/features/lib/Furniture.js
+++ b/features/lib/Furniture.js
@@ -1,0 +1,14 @@
+const Model = require("./Model");
+
+class Furniture extends Model {
+  constructor({ type }) {
+    super();
+    this.type = type;
+  }
+
+  attributes() {
+    return { type: this.type }
+  }
+}
+
+module.exports = Furniture;

--- a/features/lib/Model.js
+++ b/features/lib/Model.js
@@ -1,0 +1,10 @@
+class Model {
+  assign(attributes) {
+    for(const attribute in attributes) {
+      this[attribute] = attributes[attribute];
+    }
+    return this
+  }
+}
+
+module.exports  = Model

--- a/features/lib/Room.js
+++ b/features/lib/Room.js
@@ -1,8 +1,7 @@
-const slugify = require ('./slugify');
-const AccessLevel = require('./AccessLevel')
+const slugify = require("./slugify");
+const AccessLevel = require("./AccessLevel");
 
 class Room {
-
   /**
    * @type {AccessLevel | undefined}
    */
@@ -11,29 +10,34 @@ class Room {
   /**
    * @param {string} roomName
    */
-  constructor({ name, slug, id}) {
+  constructor({ name, slug, id }) {
     this.name = name;
-    this.slug = slug || slugify(name);
-    this.id = id
+    this.slug = slug;
+    if (name !== "Room") {
+      this.slug = this.slug = slugify(name);
+    }
+    this.id = id;
   }
 
   reinitialize({ accessLevel }) {
-    this.accessLevel = accessLevel
+    this.accessLevel = accessLevel;
   }
 
   assign(attributes) {
-    for(const attribute in attributes) {
+    for (const attribute in attributes) {
       this[attribute] = attributes[attribute];
     }
-    return this
+    return this;
   }
   asParams() {
     return {
-    room: { name: this.name, slug: this.slug, furniturePlacementsAttributes: this.furniturePlacementsAttributes }
-    }
+      room: {
+        name: this.name,
+        slug: this.slug,
+        furniturePlacementsAttributes: this.furniturePlacementsAttributes,
+      },
+    };
   }
-
 }
-
 
 module.exports = Room;

--- a/features/steps/furniture/spotlight_steps.js
+++ b/features/steps/furniture/spotlight_steps.js
@@ -1,0 +1,5 @@
+const { Then } = require("@cucumber/cucumber");
+Then('{a} {spotlight} is shown to {device} visits to {space}', function (a, spotlight, device, space) {
+  // Write code here that turns the phrase above into concrete actions
+  return 'pending';
+});

--- a/features/steps/furniture_steps.js
+++ b/features/steps/furniture_steps.js
@@ -1,0 +1,20 @@
+const { Given, DataTable } = require("@cucumber/cucumber");
+Given('{a} {furniture} in {a} {entranceHall} to {space} is configured with:',
+/**
+ *
+ * @this {CustomWorld}asd
+ * @param {*} a
+ * @param {Furniture} furniture
+ * @param {*} a2
+ * @param {Room} entranceHall
+ * @param {Space} space
+ * @param {DataTable} dataTable
+ */
+function (_a, furniture, _a2, room, space, dataTable) {
+
+
+  return this.api()
+  .rooms(space)
+  .update(room.assign({
+    furniturePlacementsAttributes: [furniture.assign(dataTable.hashes()).attributes()] }))
+});

--- a/features/support/parameter-types/README.md
+++ b/features/support/parameter-types/README.md
@@ -27,7 +27,9 @@ The core nouns in Convene are:
 2. [Rooms], where people congregate to work together.
 3. [Spaces], which group Rooms and People for access and discoverability
    purposes.
+4. [Furniture] for human/computer interaction within a space.
 
 [actors]: ./actors.js
 [rooms]: ./rooms.js
 [spaces]: ./spaces.js
+[furniture]: ./furniture.js

--- a/features/support/parameter-types/devices.js
+++ b/features/support/parameter-types/devices.js
@@ -1,0 +1,11 @@
+const { defineParameterType } = require("@cucumber/cucumber");
+
+
+defineParameterType({
+  name: "device",
+  regexp: /(Portrait|Landscape) (Phone|Tablet)/,
+  transformer: function(orientation, device) {
+    console.log(arguments)
+    return { orientation, device }
+  }
+})

--- a/features/support/parameter-types/furniture.js
+++ b/features/support/parameter-types/furniture.js
@@ -1,0 +1,12 @@
+
+const { defineParameterType } = require("@cucumber/cucumber");
+const Furniture = require("../../lib/Furniture");
+
+
+defineParameterType({
+  name: "furniture",
+  regexp: /"(.*)" Furniture/,
+  transformer: function(type) {
+    return new Furniture({ type })
+  }
+});

--- a/features/support/parameter-types/furniture/spotlight.js
+++ b/features/support/parameter-types/furniture/spotlight.js
@@ -1,0 +1,11 @@
+const { defineParameterType } = require("@cucumber/cucumber");
+
+
+defineParameterType({
+  name: "spotlight",
+  regexp: /(\d+) megapixel (\d+x\d+) Spotlight of "([^"]*)"/,
+  transformer: function(a,b,c,d) {
+    console.log(arguments)
+    return { a, b,c, d}
+  }
+})


### PR DESCRIPTION
This builds on the infrastructure defined in the [Furniture: Livestream Owncast!](https://github.com/zinc-collective/convene/pull/669/files)
patch, which probably should be merged first (or I should decompose the
supporting bits)

Essentially, the "Image" furniture is a great start, but I'm hoping to
shift our design from the technical to the marketing / designer friendly
use-case.

Ideally, a Spotlight isn't just a hero image, but can also support the
little "Here's an icon + summary + call to action" that many sites use
to specify their value propositions.

By making the Spotlight responsible for exposing affordances like
alt-text, focal point, aspect ratio, etc. we can give folks who are
being intentional about the presentation of their digital storefront
with super-powers that help them get better conversion.