### PR TITLE
Add GitHub Action to automatically deploy to Heroku

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,18 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - master
+
+# Uses https://github.com/AkhileshNS/heroku-deploy to deploy to Heroku
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: akhileshns/heroku-deploy@v3.12.12
+        with:
+          heroku_api_key: ${{secrets.HEROKU_API_KEY}}
+          heroku_app_name: "convene-zinc-coop"
+          heroku_email: "ana@ulin.org"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy
 on:
   push:
     branches:
-      - master
+      - development
 
 # Uses https://github.com/AkhileshNS/heroku-deploy to deploy to Heroku
 jobs:


### PR DESCRIPTION
This is to replace the no-longer-working Heroku<->GitHub autodeploy.

For this to work, I'll need to set the `HEROKU_API_KEY` secret under Settings -> Secrets (I do not have access to this section of the settings at the moment).