### PR TITLE
Space Memberships API Endpoint handles invalid parameters gracefully

### DIFF
--- a/app/models/space_membership/serializer.rb
+++ b/app/models/space_membership/serializer.rb
@@ -8,10 +8,10 @@ class SpaceMembership::Serializer < ApplicationSerializer
       space_membership: {
         id: space_membership.id,
         member: {
-          id: space_membership.member.id
+          id: space_membership.member&.id
         },
         space: {
-          id: space_membership.space.id
+          id: space_membership.space&.id
         }
       }
     )

--- a/spec/requests/space_memberships_request_spec.rb
+++ b/spec/requests/space_memberships_request_spec.rb
@@ -54,6 +54,12 @@ RSpec.describe '/space_memberships/', type: :request do
 
         run_test!
       end
+
+      response '422', 'Required Attributes are not included' do
+        let(:attributes) { attributes_for(:space_membership, member_id: nil, space_id: nil) }
+
+        run_test!
+      end
     end
   end
 end


### PR DESCRIPTION
Turns out, our `SpaceMembership::Serializer` was not smert enough to
handle when space_id or member_id were missing; which was causing a sad
error.

Co-authored-by: Kelly Hong <KellyAH@users.noreply.github.com>
Co-authored-by: Neer Malathapa <nirmalathapa@users.noreply.github.com>