### PR TITLE
Embedded Forms can accept Any Airtable Form URL!

### DIFF
--- a/app/furniture/embedded_form.rb
+++ b/app/furniture/embedded_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class EmbeddedForm
   include Placeable
 
@@ -7,6 +9,14 @@ class EmbeddedForm
 
   def form_url
     settings['form_url']
+  end
+
+  def embeddable_form_url
+    form_id = form_url
+              .gsub('https://airtable.com/', '')
+              .gsub('/embed', '')
+
+    "https://airtable.com/embed/#{form_id}"
   end
 
   def attribute_names

--- a/app/furniture/embedded_form/_in_room.html.erb
+++ b/app/furniture/embedded_form/_in_room.html.erb
@@ -1,1 +1,1 @@
-<iframe class="w-full max-w-prose mx-auto aspect-[5/6]" src="<%= furniture.form_url%>" onmousewheel=""></iframe>
+<iframe class="w-full max-w-prose mx-auto aspect-[5/6]" src="<%= furniture.embeddable_form_url%>" onmousewheel=""></iframe>

--- a/spec/factories/furniture/embedded_form.rb
+++ b/spec/factories/furniture/embedded_form.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :embedded_form do
+    transient do
+      room { build(:room) }
+    end
+
+    placement do
+      association :furniture_placement, { furniture_kind: 'embedded_form', room: room }
+    end
+  end
+end

--- a/spec/furniture/embedded_form_spec.rb
+++ b/spec/furniture/embedded_form_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EmbeddedForm do
+  describe '#embeddable_form_url' do
+    it 'converts Airtable Share URLs into the Embed url' do
+      embedded_form = build(:embedded_form, form_url: 'https://airtable.com/shrCnrBzflvzDIlvg')
+      expect(embedded_form.embeddable_form_url).to eql('https://airtable.com/embed/shrCnrBzflvzDIlvg')
+
+      embedded_form =  build(:embedded_form, form_url: 'https://airtable.com/shrCnrBzflvzDIlvg/embed')
+      expect(embedded_form.embeddable_form_url).to eql('https://airtable.com/embed/shrCnrBzflvzDIlvg')
+    end
+  end
+end


### PR DESCRIPTION
https://github.com/zinc-collective/convene/issues/619

I got tired of having to go through the airtable menus to get the code
from their iframe embed document, and I wanted a win!