### PR TITLE
Rooms: Respect Furniture Placements' Ranks

### DIFF
--- a/app/views/rooms/_room.html.erb
+++ b/app/views/rooms/_room.html.erb
@@ -1,7 +1,7 @@
 <div class="flex flex-col content-between justify-end" data-turbo="true">
   <div class="grow">
     <section id="furniture_placements">
-      <%= render room.furniture_placements %>
+      <%= render room.furniture_placements.rank(:slot) %>
     </section>
 
     <%- if editing? %>


### PR DESCRIPTION
Furniture Placement's have a Slot, but the Slot doesn't get respected in ordering.