### PR TITLE
Invitations: Ignoring Invitations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,8 @@ gem 'gretel', '~> 4.4'
 # Postgres extensions for ActiveRecord
 # @see https://github.com/GeorgeKaraszi/ActiveRecordExtended
 gem 'active_record_extended', '~> 2.1'
+# Postgres enums
+gem 'activerecord-postgres_enum', '~> 2.0'
 # Support for models with "slots" or "positions"
 gem 'ranked-model', '~> 0.4.8'
 # Slug-based model lookup

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,9 @@ GEM
     activerecord (7.0.3.1)
       activemodel (= 7.0.3.1)
       activesupport (= 7.0.3.1)
+    activerecord-postgres_enum (2.0.1)
+      activerecord (>= 5.2)
+      pg
     activestorage (7.0.3.1)
       actionpack (= 7.0.3.1)
       activejob (= 7.0.3.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -354,6 +354,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_record_extended (~> 2.1)
+  activerecord-postgres_enum (~> 2.0)
   aws-sdk-s3 (~> 1.114)
   bcrypt (~> 3.1.18)
   bootsnap (~> 1.12)

--- a/app/assets/stylesheets/components/button.scss
+++ b/app/assets/stylesheets/components/button.scss
@@ -1,5 +1,5 @@
 @layer components {
-  [type="reset"], [type="button"], [type=submit], button, .button {
+  [type=reset], [type=button], [type=submit], button, .button {
     @apply font-bold py-2 px-4 my-1 rounded bg-primary-500 text-white text-center transition ease-in-out duration-150;
 
     &:hover {

--- a/app/controllers/rsvps_controller.rb
+++ b/app/controllers/rsvps_controller.rb
@@ -7,7 +7,11 @@ class RsvpsController < ApplicationController
 
   def update
     if rsvp.update(rsvp_params)
-      redirect_to rsvp.space, notice: t('.success', space_name: rsvp.space.name)
+      if rsvp.invitation.accepted?
+        redirect_to rsvp.space, notice: t('.success', space_name: rsvp.space.name)
+      else
+        render :show
+      end
     end
   end
 

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -38,4 +38,13 @@ class Invitation < ApplicationRecord
   attribute :last_sent_at, :datetime
   attribute :created_at, :datetime
   attribute :updated_at, :datetime
+
+  validate :not_ignored_space
+
+private
+  def not_ignored_space
+   return unless Invitation.ignored.where(space: space, email: email).exists?
+
+   errors.add(:email, :invitee_ignored_space)
+  end
 end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -20,14 +20,16 @@ class Invitation < ApplicationRecord
   # rejected - receivers rejected the invitation
   # expired - Invitation was sent too long ago
   # ignored - receiver ignored the invitation
-  STATUSES = %w[pending sent accepted rejected expired ignored].freeze
+  enum status: {
+    pending: "pending",
+    sent: "sent",
+    accepted: "accepted",
+    rejected: "rejected",
+    expired: "expired",
+    ignored: "ignored"
+  }
 
-  attribute :status, :string
-  validates :status, inclusion: STATUSES
-
-  def accepted?
-    status.to_sym == :accepted
-  end
+  validates :status, inclusion: { in: statuses.keys }
 
   # @!method invitor_display_name
   #   @see Person#display_name

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -19,7 +19,8 @@ class Invitation < ApplicationRecord
   # accepted - receiver accepted the invitation
   # rejected - receivers rejected the invitation
   # expired - Invitation was sent too long ago
-  STATUSES = %w[pending sent accepted rejected expired].freeze
+  # ignored - receiver ignored the invitation
+  STATUSES = %w[pending sent accepted rejected expired ignored].freeze
 
   attribute :status, :string
   validates :status, inclusion: STATUSES

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -43,6 +43,7 @@ class Invitation < ApplicationRecord
 
 private
   def not_ignored_space
+   return if will_save_change_to_attribute?(:status, from: "ignored")
    return unless Invitation.ignored.where(space: space, email: email).exists?
 
    errors.add(:email, :invitee_ignored_space)

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -13,7 +13,7 @@ class Person < ApplicationRecord
   # The Spaces the Person is part of
   has_many :spaces, through: :space_memberships
 
-  has_many :invitations, inverse_of: :invitor
+  has_many :invitations, inverse_of: :invitor, foreign_key: :invitor_id
 
   def member_of?(space)
     spaces.include?(space)

--- a/app/models/rsvp.rb
+++ b/app/models/rsvp.rb
@@ -8,6 +8,11 @@ class Rsvp
   delegate :space, to: :invitation
 
   def update(attributes)
+    if attributes[:status] == 'ignored'
+      invitation.update(status: attributes[:status])
+      return false
+    end
+
     person = Person.create_with(name: invitation.name).find_or_create_by(email: invitation.email)
 
     authentication_method = person.authentication_methods.find_or_create_by(contact_method: :email,

--- a/app/models/rsvp.rb
+++ b/app/models/rsvp.rb
@@ -8,9 +8,8 @@ class Rsvp
   delegate :space, to: :invitation
 
   def update(attributes)
-    if attributes[:status] == 'ignored'
-      invitation.update(status: attributes[:status])
-      return false
+    if %w[ignored sent].include?(attributes[:status])
+      return invitation.update(status: attributes[:status])
     end
 
     person = Person.create_with(name: invitation.name).find_or_create_by(email: invitation.email)

--- a/app/models/rsvp.rb
+++ b/app/models/rsvp.rb
@@ -22,9 +22,9 @@ class Rsvp
     if authentication_method.confirmed?
       invitation.update(status: attributes[:status])
 
-      person.space_memberships.create(space: invitation.space)
+      person.space_memberships.create(space: space)
     else
-      authentication_method.send_one_time_password!(invitation.space)
+      authentication_method.send_one_time_password!(space)
       false
     end
   end

--- a/app/views/rsvps/_ignored.html.erb
+++ b/app/views/rsvps/_ignored.html.erb
@@ -1,0 +1,10 @@
+<p>
+  <%= t('.ignored_message', space_name: rsvp.invitation.space.name) %>
+</p>
+<p>
+  <%= button_to t('.unignore'),
+                [rsvp.space, rsvp.invitation, rsvp],
+                params: { rsvp: { status: 'sent' } },
+                class: '--neutral w-full'
+  %>
+</p>

--- a/app/views/rsvps/_ignored.html.erb
+++ b/app/views/rsvps/_ignored.html.erb
@@ -1,8 +1,11 @@
+<h2>
+  <%= t('.header') %>
+</h2>
 <p>
-  <%= t('.ignored_message', space_name: rsvp.invitation.space.name) %>
+  <%= t('.summary', space_name: rsvp.invitation.space.name) %>
 </p>
 <p>
-  <%= button_to t('.unignore'),
+  <%= button_to t('.unignore', space_name: rsvp.invitation.space.name),
                 [rsvp.space, rsvp.invitation, rsvp],
                 params: { rsvp: { status: 'sent' } },
                 class: '--neutral w-full'

--- a/app/views/rsvps/show.html.erb
+++ b/app/views/rsvps/show.html.erb
@@ -1,6 +1,6 @@
 <% breadcrumb :rsvp, rsvp %>
 
-<% if rsvp.invitation.status == 'ignored' %>
+<% if rsvp.invitation.ignored? %>
   <p>
     <%= t('.ignored_message', space_name: rsvp.invitation.space.name) %>
   </p>

--- a/app/views/rsvps/show.html.erb
+++ b/app/views/rsvps/show.html.erb
@@ -14,6 +14,7 @@
   <%= button_to t('.ignore'),
                 [rsvp.space, rsvp.invitation, rsvp],
                 params: { rsvp: { status: 'ignored' } },
+                data: {testid: 'ignore' },
                 class: '--neutral w-full'
   %>
 <% end %>

--- a/app/views/rsvps/show.html.erb
+++ b/app/views/rsvps/show.html.erb
@@ -4,6 +4,12 @@
 <p><%= t('.summary', space_name: rsvp.invitation.space.name, invitor_name: rsvp.invitation.invitor_display_name, invitation_date: rsvp.invitation.created_at) %></p>
 
 <%= form_with model: [rsvp.space, rsvp.invitation, rsvp], local: true do |rsvp_form|%>
-  <%= rsvp_form.hidden_field :status, value: "accepted" %>
+  <%= rsvp_form.hidden_field :status, value: 'accepted' %>
   <%= rsvp_form.submit t('.accept', space_name: rsvp.space.name) %>
 <%- end %>
+
+<%= button_to t('.ignore'),
+              [rsvp.space, rsvp.invitation, rsvp],
+              params: { rsvp: { status: 'ignored' } },
+              class: '--neutral w-full'
+%>

--- a/app/views/rsvps/show.html.erb
+++ b/app/views/rsvps/show.html.erb
@@ -1,15 +1,21 @@
 <% breadcrumb :rsvp, rsvp %>
 
-<h2><%= t('.header', space_name: rsvp.invitation.space.name)%></h2>
-<p><%= t('.summary', space_name: rsvp.invitation.space.name, invitor_name: rsvp.invitation.invitor_display_name, invitation_date: rsvp.invitation.created_at) %></p>
+<% if rsvp.invitation.status == 'ignored' %>
+  <p>
+    <%= t('.ignored_message', space_name: rsvp.invitation.space.name) %>
+  </p>
+<% else %>
+  <h2><%= t('.header', space_name: rsvp.invitation.space.name)%></h2>
+  <p><%= t('.summary', space_name: rsvp.invitation.space.name, invitor_name: rsvp.invitation.invitor_display_name, invitation_date: rsvp.invitation.created_at) %></p>
 
-<%= form_with model: [rsvp.space, rsvp.invitation, rsvp], local: true do |rsvp_form|%>
-  <%= rsvp_form.hidden_field :status, value: 'accepted' %>
-  <%= rsvp_form.submit t('.accept', space_name: rsvp.space.name) %>
-<%- end %>
+  <%= form_with model: [rsvp.space, rsvp.invitation, rsvp], local: true do |rsvp_form|%>
+    <%= rsvp_form.hidden_field :status, value: 'accepted' %>
+    <%= rsvp_form.submit t('.accept', space_name: rsvp.space.name) %>
+  <%- end %>
 
-<%= button_to t('.ignore'),
-              [rsvp.space, rsvp.invitation, rsvp],
-              params: { rsvp: { status: 'ignored' } },
-              class: '--neutral w-full'
-%>
+  <%= button_to t('.ignore'),
+                [rsvp.space, rsvp.invitation, rsvp],
+                params: { rsvp: { status: 'ignored' } },
+                class: '--neutral w-full'
+  %>
+<% end %>

--- a/app/views/rsvps/show.html.erb
+++ b/app/views/rsvps/show.html.erb
@@ -1,9 +1,7 @@
 <% breadcrumb :rsvp, rsvp %>
 
 <% if rsvp.invitation.ignored? %>
-  <p>
-    <%= t('.ignored_message', space_name: rsvp.invitation.space.name) %>
-  </p>
+  <%= render partial: "ignored", locals: { rsvp: rsvp } %>
 <% else %>
   <h2><%= t('.header', space_name: rsvp.invitation.space.name)%></h2>
   <p><%= t('.summary', space_name: rsvp.invitation.space.name, invitor_name: rsvp.invitation.invitor_display_name, invitation_date: rsvp.invitation.created_at) %></p>

--- a/app/views/rsvps/update.html.erb
+++ b/app/views/rsvps/update.html.erb
@@ -1,10 +1,17 @@
 <% breadcrumb :rsvp, rsvp %>
 
-<h2><%= t('.header', email: rsvp.invitation.email)%></h2>
-<p><%= t('.summary', invitor_name: rsvp.invitation.invitor_display_name) %></p>
+<% if rsvp.invitation.status != 'ignored' %>
+  <h2><%= t('.header', email: rsvp.invitation.email)%></h2>
+  <p><%= t('.summary', invitor_name: rsvp.invitation.invitor_display_name) %></p>
 
-<%= form_with model: [rsvp.space, rsvp.invitation, rsvp], local: true do |rsvp_form|%>
-  <%= rsvp_form.hidden_field :status, value: "accepted" %>
-  <%= render "text_field", form: rsvp_form, attribute: :one_time_password %>
-  <%= rsvp_form.submit t('.accept', space_name: rsvp.space.name) %>
-<%- end %>
+  <%= form_with model: [rsvp.space, rsvp.invitation, rsvp], local: true do |rsvp_form|%>
+    <%= rsvp_form.hidden_field :status, value: "accepted" %>
+    <%= render "text_field", form: rsvp_form, attribute: :one_time_password %>
+    <%= rsvp_form.submit t('.accept', space_name: rsvp.space.name) %>
+  <%- end %>
+<% else %>
+  <p>
+    <%= t('.ignore', space_name: rsvp.space.name) %>
+  </p>
+
+<% end %>

--- a/app/views/rsvps/update.html.erb
+++ b/app/views/rsvps/update.html.erb
@@ -1,6 +1,8 @@
 <% breadcrumb :rsvp, rsvp %>
 
-<% if rsvp.invitation.status != 'ignored' %>
+<% if rsvp.invitation.ignored? %>
+  <%= render partial: "ignored", locals: { rsvp: rsvp } %>
+<% else %>
   <h2><%= t('.header', email: rsvp.invitation.email)%></h2>
   <p><%= t('.summary', invitor_name: rsvp.invitation.invitor_display_name) %></p>
 
@@ -9,9 +11,4 @@
     <%= render "text_field", form: rsvp_form, attribute: :one_time_password %>
     <%= rsvp_form.submit t('.accept', space_name: rsvp.space.name) %>
   <%- end %>
-<% else %>
-  <p>
-    <%= t('.ignore', space_name: rsvp.space.name) %>
-  </p>
-
 <% end %>

--- a/app/views/space_invitation_mailer/space_invitation_email.text.erb
+++ b/app/views/space_invitation_mailer/space_invitation_email.text.erb
@@ -2,7 +2,7 @@ Hi <%= @invitation.name %>,
 
 You've been invited to <%= @invitation.space.name %> by <%= @invitation.invitor_display_name %>.
 
-You may RSVP to this invitation at <%= space_invitation_rsvp_url(@invitation.space, @invitation) %>.
+You may view, accept or ignore this invitation at <%= space_invitation_rsvp_url(@invitation.space, @invitation) %>.
 
 We hope to see you there! 🥳🎈🎉
 

--- a/config/locales/rsvp/en.yml
+++ b/config/locales/rsvp/en.yml
@@ -10,3 +10,4 @@ en:
       summary: "Let's make sure you really are the person %{invitor_name} thinks you are! We've sent you an email with a passcode that will expire in 10 minutes."
       accept: "Confirm and Join %{space_name}"
       success: "Yay! Welcome to %{space_name} 🎉"
+      ignore: "You will receive no more invitations to %{space_name}"

--- a/config/locales/rsvp/en.yml
+++ b/config/locales/rsvp/en.yml
@@ -3,7 +3,7 @@ en:
     ignored:
       header: "You have ignored this invitation. 🤚"
       summary: "You will no longer receive invitations to %{space_name}."
-      unignore: "Reconsider joining  %{space_name} 💌"
+      unignore: "Allow invitations from  %{space_name} 💌"
     show:
       header: "You've been invited to '%{space_name}'!"
       summary: "You were invited to '%{space_name}' by %{invitor_name} on %{invitation_date}"

--- a/config/locales/rsvp/en.yml
+++ b/config/locales/rsvp/en.yml
@@ -5,6 +5,7 @@ en:
       summary: "You were invited to '%{space_name}' by %{invitor_name} on %{invitation_date}"
       accept: "Join %{space_name}"
       ignore: "Ignore this invitation"
+      ignored_message: "You have ignored this invitation. You will no longer receive invitations to %{space_name}."
     update:
       header: "Confirm your access to the email address '%{email}'"
       summary: "Let's make sure you really are the person %{invitor_name} thinks you are! We've sent you an email with a passcode that will expire in 10 minutes."

--- a/config/locales/rsvp/en.yml
+++ b/config/locales/rsvp/en.yml
@@ -1,8 +1,9 @@
 en:
   rsvps:
     ignored:
-      ignored_message: "You have ignored this invitation. You will no longer receive invitations to %{space_name}."
-      unignore: "Undo ignore"
+      header: "You have ignored this invitation. 🤚"
+      summary: "You will no longer receive invitations to %{space_name}."
+      unignore: "Reconsider joining  %{space_name} 💌"
     show:
       header: "You've been invited to '%{space_name}'!"
       summary: "You were invited to '%{space_name}' by %{invitor_name} on %{invitation_date}"

--- a/config/locales/rsvp/en.yml
+++ b/config/locales/rsvp/en.yml
@@ -1,14 +1,15 @@
 en:
   rsvps:
+    ignored:
+      ignored_message: "You have ignored this invitation. You will no longer receive invitations to %{space_name}."
+      unignore: "Undo ignore"
     show:
       header: "You've been invited to '%{space_name}'!"
       summary: "You were invited to '%{space_name}' by %{invitor_name} on %{invitation_date}"
       accept: "Join %{space_name}"
       ignore: "Ignore this invitation"
-      ignored_message: "You have ignored this invitation. You will no longer receive invitations to %{space_name}."
     update:
       header: "Confirm your access to the email address '%{email}'"
       summary: "Let's make sure you really are the person %{invitor_name} thinks you are! We've sent you an email with a passcode that will expire in 10 minutes."
       accept: "Confirm and Join %{space_name}"
       success: "Yay! Welcome to %{space_name} 🎉"
-      ignore: "You will receive no more invitations to %{space_name}"

--- a/cucumber.cjs
+++ b/cucumber.cjs
@@ -1,0 +1,1 @@
+module.exports = { default: '--publish-quiet' }

--- a/db/migrate/20220707003459_add_invitation_status_enum.rb
+++ b/db/migrate/20220707003459_add_invitation_status_enum.rb
@@ -1,0 +1,19 @@
+class AddInvitationStatusEnum < ActiveRecord::Migration[7.0]
+  # Copied from Invitation.status enum on 7/6/2022
+  STATUSES = {
+    pending: "pending",
+    sent: "sent",
+    accepted: "accepted",
+    rejected: "rejected",
+    expired: "expired",
+    ignored: "ignored"
+  }
+
+  def change
+    create_enum :invitation_status, STATUSES.values
+
+    remove_column :invitations, :status, :string
+
+    add_column :invitations, :status, :invitation_status, null: false, default: "pending"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_05_11_024831) do
+ActiveRecord::Schema[7.0].define(version: 2022_07_07_003459) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  create_enum :invitation_status, [
+    "pending",
+    "sent",
+    "accepted",
+    "rejected",
+    "expired",
+    "ignored",
+  ], force: :cascade
 
   create_table "active_storage_attachments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
@@ -89,11 +98,11 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_11_024831) do
     t.uuid "space_id"
     t.string "name", null: false
     t.string "email", null: false
-    t.string "status", default: "pending", null: false
     t.datetime "last_sent_at", precision: nil
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "invitor_id"
+    t.enum "status", default: "pending", null: false, enum_type: "invitation_status"
     t.index ["invitor_id"], name: "index_invitations_on_invitor_id"
     t.index ["space_id"], name: "index_invitations_on_space_id"
   end

--- a/features/harness/InvitationResponsePage.js
+++ b/features/harness/InvitationResponsePage.js
@@ -15,5 +15,8 @@ class InvitationResponsePage extends Page {
   submitButton() {
     return this.component("input[type=submit");
   }
+  ignoreButton() {
+    return this.component("[data-testid=ignore]");
+  }
 }
 export default InvitationResponsePage;

--- a/features/lib/Invitation.js
+++ b/features/lib/Invitation.js
@@ -36,13 +36,25 @@ class Invitation {
   /**
    *
    * @param {ThenableWebDriver} driver
-   * @returns
+   * @returns {Promise<InvitationResponsePage>}
    */
   accept(driver) {
     return new InvitationResponsePage(driver, this)
       .visit()
       .then((page) => page.submit());
   }
+  /**
+   *
+   * @param {ThenableWebDriver} driver
+   * @returns {Promise<InvitationResponsePage>}
+   */
+   ignore(driver) {
+    return new InvitationResponsePage(driver, this)
+      .visit()
+      .then((page) => page.ignoreButton().click());
+  }
+
+
   /**
    * @returns {Promise<String>}
    */

--- a/features/spaces/invitations.feature
+++ b/features/spaces/invitations.feature
@@ -39,7 +39,6 @@ Feature: Spaces: Invitations
     And an Invitation to "aang-the-avatar@example.com" for the "System Test" Space has a status of "pending"
     And an Invitation to "aang-the-avatar@example.com" for the "System Test" Space has a status of "expired"
 
-
   @unstarted @andromeda
   Scenario: Invitations remain even if the Invitor was Removed from the Space
     Given the "System Test" Space has a Space Owner "soon-to-leave@example.com"
@@ -50,8 +49,16 @@ Feature: Spaces: Invitations
     When the Invitation to "aang-the-avatar@example.com" is Accepted
     Then the "System Test" Space has a Space Member "aang-the-avatar@example.com"
 
-
   @unstarted @unscheduled
   Scenario: Inviting new Members via SMS
     When a Space Owner invites a new Space Member via SMS
     Then an Invitation is sent to that SMS
+
+  @unstarted @andromeda
+  Scenario: Ignoring invitations
+    Given an Invitation to the "System Test" Space was sent by Space Owner "space-owner@example.com"
+      | name | email                       |
+      | Aang | aang-the-avatar@example.com |
+    When the Invitation to "aang-the-avatar@example.com" is Ignored
+    Then the Invitation to "aang-the-avatar@example.com" for the "System Test" Space has a status of "ignored"
+    And no further Invitations can be sent to "aang-the-avatar@example.com" for the "System Test" Space

--- a/features/spaces/invitations.feature
+++ b/features/spaces/invitations.feature
@@ -54,9 +54,9 @@ Feature: Spaces: Invitations
     When a Space Owner invites a new Space Member via SMS
     Then an Invitation is sent to that SMS
 
-  @unstarted @andromeda
+  @andromeda
   Scenario: Ignoring invitations
-    Given an Invitation to the "System Test" Space was sent by Space Owner "space-owner@example.com"
+    Given an Invitation to the "System Test" Space is sent by Space Owner "space-owner@example.com"
       | name | email                       |
       | Aang | aang-the-avatar@example.com |
     When the Invitation to "aang-the-avatar@example.com" is Ignored

--- a/features/spaces/invitations.feature
+++ b/features/spaces/invitations.feature
@@ -54,7 +54,7 @@ Feature: Spaces: Invitations
     When a Space Owner invites a new Space Member via SMS
     Then an Invitation is sent to that SMS
 
-  @andromeda
+  @built @andromeda @unimplemented-steps
   Scenario: Ignoring invitations
     Given an Invitation to the "System Test" Space is sent by Space Owner "space-owner@example.com"
       | name | email                       |

--- a/features/steps/invitation_steps.js
+++ b/features/steps/invitation_steps.js
@@ -10,6 +10,11 @@ import {
   refuteDisplayed,
 } from "../support/assertDisplayed.js";
 const assert = assert$0.strict;
+
+When('{a} {invitation} is Ignored', function (a, invitation) {
+  return invitation.ignore(this.driver);
+});
+
 When(
   "an {invitation} to {a} {space} is sent by {actor}",
   { timeout: 90000 },
@@ -50,6 +55,12 @@ When(
     });
   }
 );
+
+Then('no further Invitations can be sent to {string} for {a} {space}', function (string, a, space) {
+  // Write code here that turns the phrase above into concrete actions
+  return 'pending';
+});
+
 Then(
   "an {invitation} for {a} {space} is delivered",
   /**

--- a/features/test_reports/cucumber_test_report.js
+++ b/features/test_reports/cucumber_test_report.js
@@ -1,1 +1,0 @@
-// TODO: Implement me

--- a/spec/factories/invitation.rb
+++ b/spec/factories/invitation.rb
@@ -4,5 +4,9 @@ FactoryBot.define do
     name { FFaker::Name.name }
     email { "#{name.downcase.gsub(' ', '-')}@example.com" }
     invitor factory: :person
+
+    trait :ignored do
+      status { "ignored" }
+    end
   end
 end

--- a/spec/mailers/previews/space_invitation_mailer_preview.rb
+++ b/spec/mailers/previews/space_invitation_mailer_preview.rb
@@ -3,7 +3,7 @@
 class SpaceInvitationMailerPreview < ActionMailer::Preview
   def space_invitation_email
     space = Space.find_by(slug: 'system-test')
-    invitation = space.invitations.last || FactoryBot.create(:invitation, space: space)
+    invitation = space.invitations.pending.last || FactoryBot.create(:invitation, space: space)
     SpaceInvitationMailer.space_invitation_email(invitation)
   end
 end

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Invitation, type: :model do
   it { is_expected.to validate_presence_of(:name) }
   it "defines status as an enum" do
     is_expected.to define_enum_for(:status).with_values(Invitation.statuses)
-      .backed_by_column_of_type(:string)
+      .backed_by_column_of_type(:enum)
   end
 
   describe '#invitor_display_name' do

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -6,8 +6,11 @@ RSpec.describe Invitation, type: :model do
   it { is_expected.to belong_to(:space).inverse_of(:invitations) }
   it { is_expected.to belong_to(:invitor).class_name('Person').inverse_of(:invitations) }
   it { is_expected.to validate_presence_of(:email) }
-  it { is_expected.to validate_inclusion_of(:status).in_array(Invitation::STATUSES) }
   it { is_expected.to validate_presence_of(:name) }
+  it "defines status as an enum" do
+    is_expected.to define_enum_for(:status).with_values(Invitation.statuses)
+      .backed_by_column_of_type(:string)
+  end
 
   describe '#invitor_display_name' do
     it 'is the invitors display name' do

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -24,4 +24,16 @@ RSpec.describe Invitation, type: :model do
       expect(invitation.invitor_display_name).to be_blank
     end
   end
+
+  describe "#save" do
+    let(:invitee) { create(:person) }
+    let!(:ignored_invitation) { create(:invitation, :ignored, email: invitee.email) }
+    let(:ignored_space) { ignored_invitation.space }
+
+    it "won't let you create invitations for a person who has ignored the space" do
+      invitation = build(:invitation, email: invitee.email, space: ignored_space)
+      expect(invitation.save).to eq(false)
+      expect(invitation.errors).to be_added(:email, :invitee_ignored_space)
+    end
+  end
 end

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -35,5 +35,10 @@ RSpec.describe Invitation, type: :model do
       expect(invitation.save).to eq(false)
       expect(invitation.errors).to be_added(:email, :invitee_ignored_space)
     end
+
+    it "allows an invitation to be un-ignored" do
+      expect(ignored_invitation.update(status: :sent)).to eq(true)
+      expect(ignored_invitation.errors).not_to be_added(:email, :invitee_ignored_space)
+    end
   end
 end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Person, type: :model do
-  it { is_expected.to have_many(:invitations).inverse_of(:invitor) }
+  it { is_expected.to have_many(:invitations).inverse_of(:invitor).with_foreign_key(:invitor_id) }
   it { is_expected.to have_many(:authentication_methods).inverse_of(:person).dependent(:destroy_async) }
   it { is_expected.to have_many(:space_memberships).inverse_of(:member).dependent(:destroy_async) }
 

--- a/spec/requests/spaces/invitations/rsvp_spec.rb
+++ b/spec/requests/spaces/invitations/rsvp_spec.rb
@@ -100,6 +100,7 @@ RSpec.describe '/spaces/:space_id/invitations/:invitation_id/rsvp', type: :reque
 
       it 'doesnt complete the invitation' do
         expect { subject }.to change { invitation.reload.status }.to('ignored')
+        expect(response).to render_template(:show)
       end
     end
 

--- a/spec/requests/spaces/invitations/rsvp_spec.rb
+++ b/spec/requests/spaces/invitations/rsvp_spec.rb
@@ -92,5 +92,15 @@ RSpec.describe '/spaces/:space_id/invitations/:invitation_id/rsvp', type: :reque
           .find_by(space: space)).not_to be_present
       end
     end
+
+    context 'when ignoring an invitation' do
+      subject do
+        put space_invitation_rsvp_path(space, invitation), params: { rsvp: { status: 'ignored' } }
+      end
+
+      it 'doesnt complete the invitation' do
+        expect { subject }.to change { invitation.reload.status }.to('ignored')
+      end
+    end
   end
 end

--- a/spec/requests/spaces/invitations/rsvp_spec.rb
+++ b/spec/requests/spaces/invitations/rsvp_spec.rb
@@ -102,5 +102,18 @@ RSpec.describe '/spaces/:space_id/invitations/:invitation_id/rsvp', type: :reque
         expect { subject }.to change { invitation.reload.status }.to('ignored')
       end
     end
+
+    context 'when un-ignoring an invitation' do
+      let(:invitation) { create(:invitation, status: "ignored") }
+
+      subject do
+        put space_invitation_rsvp_path(space, invitation), params: { rsvp: { status: 'sent' } }
+      end
+
+      it 'doesnt complete the invitation' do
+        expect { subject }.to change { invitation.reload.status }.to('sent')
+        expect(response).to render_template(:show)
+      end
+    end
   end
 end


### PR DESCRIPTION
Implement ignoring Invitations, the next step in https://github.com/zinc-collective/convene/issues/117

- [x] Convert `Invitation#status` to an Enum?
- [x] Delegate some rsvp stuff to invitation so we don't have to reach down every time?
- [x] Ignore by clicking link in email
- [x] Ignoring can be undone without accepting the invitation
- [x] Prevent creation of Invitations if there is an ignored invitation with the given contact method. 
- [x] Style it!
- [x] TESTS!