### PR TITLE
Add a sequential number to Factory's Space name to avoid failures due to duplicated names

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,7 +88,7 @@ gem 'sentry-ruby'
 
 # Demo data
 gem 'factory_bot_rails'
-gem 'ffaker'
+gem 'faker'
 
 # Code coverage
 gem 'simplecov', require: false, group: :test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,6 +142,8 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
+    faker (2.22.0)
+      i18n (>= 1.8.11, < 2)
     faraday (1.10.0)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
@@ -165,7 +167,6 @@ GEM
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
     faraday-retry (1.0.3)
-    ffaker (2.21.0)
     ffi (1.15.5)
     friendly_id (5.4.2)
       activerecord (>= 4.0.0)
@@ -364,7 +365,7 @@ DEPENDENCIES
   cssbundling-rails
   dotenv-rails
   factory_bot_rails
-  ffaker
+  faker
   friendly_id (~> 5.4.2)
   gretel (~> 4.4)
   jbuilder (~> 2.11)

--- a/spec/factories/client.rb
+++ b/spec/factories/client.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :client do
-    name { FFaker::Company.name }
+    name { Faker::Company.name }
   end
 end

--- a/spec/factories/invitation.rb
+++ b/spec/factories/invitation.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :invitation do
     space
-    name { FFaker::Name.name }
+    name { Faker::Name.name }
     email { "#{name.downcase.gsub(' ', '-')}@example.com" }
     invitor factory: :person
 

--- a/spec/factories/person.rb
+++ b/spec/factories/person.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :person do
-    name { FFaker::Name.name }
+    name { Faker::Name.name }
     email { "#{name.downcase.gsub(' ', '-')}@example.com" }
   end
 end

--- a/spec/factories/room.rb
+++ b/spec/factories/room.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :room do
     space
-    name { FFaker::Book.genre }
+    name { Faker::Book.genre }
     publicity_level { 'listed' }
 
     trait :internal do

--- a/spec/factories/space.rb
+++ b/spec/factories/space.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :space do
     client
-    sequence(:name) do |n| { "#{FFaker::CheesyLingo.title} #{n}" }
+    sequence(:name) { |n| "#{Faker::Book.title} #{n}" }
     slug { name.gsub(' ', '_').downcase.dasherize }
 
     trait :default do

--- a/spec/factories/space.rb
+++ b/spec/factories/space.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :space do
     client
-    name { FFaker::CheesyLingo.title }
+    sequence(:name) do |n| { "#{FFaker::CheesyLingo.title} #{n}" }
     slug { name.gsub(' ', '_').downcase.dasherize }
 
     trait :default do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-require 'ffaker'
+require 'faker'
 require 'pundit/rspec'
 require 'simplecov'
 require 'vcr'


### PR DESCRIPTION
Test run https://github.com/zinc-collective/convene/runs/7779315597?check_suite_focus=true failed due to the factory trying to make a Space with a duplicated name. This PR adds a sequential number to the Space Name to avoid such collisions.

Bonus: replaced FFaker with Faker, which is identical and better maintained.