### PR TITLE
Prevent furniture icons and heading overlapping

### DIFF
--- a/app/views/furniture_placements/_form.html.erb
+++ b/app/views/furniture_placements/_form.html.erb
@@ -1,10 +1,4 @@
 <%= turbo_frame_tag furniture_placement do %>
-  <header>
-    <h4>
-      <%= furniture_placement.furniture.model_name.human.titleize %>
-    </h4>
-  </header>
-
   <%- if policy(furniture_placement).edit? %>
     <%= form_with(model: [furniture_placement.room.space, furniture_placement.room, furniture_placement], local: true) do |form| %>
       <div>

--- a/app/views/furniture_placements/_furniture_placement.html.erb
+++ b/app/views/furniture_placements/_furniture_placement.html.erb
@@ -5,14 +5,14 @@
                   [:edit, furniture_placement.room.space, furniture_placement.room, furniture_placement],
                   method: :get,
                   title: t('.edit_title', { name: furniture_placement.furniture.model_name.human.titleize }),
-                  class: 'no-underline absolute -top-8'  %>
+                  class: 'no-underline' %>
       <%= button_to t('icons.remove'),
                   [furniture_placement.room.space, furniture_placement.room, furniture_placement],
                   title: t('.remove_title', { name: furniture_placement.furniture.model_name.human.titleize }),
                   method: :delete,
 
                   data: { turbo_method: :delete, turbo_confirm: t('.confirm_removal') },
-                  class: 'no-underline absolute -top-8 left-14'  %>
+                  class: 'no-underline' %>
     <%- end %>
     <%= render partial: furniture_placement.furniture.in_room_template,
               locals: { furniture: furniture_placement.furniture, room: furniture_placement.room,

--- a/app/views/furniture_placements/_furniture_placement.html.erb
+++ b/app/views/furniture_placements/_furniture_placement.html.erb
@@ -1,18 +1,23 @@
 <%= turbo_frame_tag furniture_placement do %>
   <section class="mt-4 relative">
     <%- if editing? %>
-      <%= button_to t('icons.edit'),
-                  [:edit, furniture_placement.room.space, furniture_placement.room, furniture_placement],
-                  method: :get,
-                  title: t('.edit_title', { name: furniture_placement.furniture.model_name.human.titleize }),
-                  class: 'no-underline' %>
-      <%= button_to t('icons.remove'),
-                  [furniture_placement.room.space, furniture_placement.room, furniture_placement],
-                  title: t('.remove_title', { name: furniture_placement.furniture.model_name.human.titleize }),
-                  method: :delete,
+      <header class="flex border-b border-dashed border-primary-900">
+        <h4 class="grow">
+          <%= furniture_placement.furniture.model_name.human.titleize %>
+        </h4>
+        <%= button_to t('icons.edit'),
+                    [:edit, furniture_placement.room.space, furniture_placement.room, furniture_placement],
+                    method: :get,
+                    title: t('.edit_title', { name: furniture_placement.furniture.model_name.human.titleize }),
+                    class: 'no-underline' %>
+        <%= button_to t('icons.remove'),
+                    [furniture_placement.room.space, furniture_placement.room, furniture_placement],
+                    title: t('.remove_title', { name: furniture_placement.furniture.model_name.human.titleize }),
+                    method: :delete,
 
-                  data: { turbo_method: :delete, turbo_confirm: t('.confirm_removal') },
-                  class: 'no-underline' %>
+                    data: { turbo_method: :delete, turbo_confirm: t('.confirm_removal') },
+                    class: 'no-underline' %>
+      </header>
     <%- end %>
     <%= render partial: furniture_placement.furniture.in_room_template,
               locals: { furniture: furniture_placement.furniture, room: furniture_placement.room,

--- a/app/views/rooms/_room.html.erb
+++ b/app/views/rooms/_room.html.erb
@@ -1,9 +1,5 @@
 <div class="flex flex-col content-between justify-end" data-turbo="true">
   <div class="grow">
-    <section id="furniture_placements">
-      <%= render room.furniture_placements.rank(:slot) %>
-    </section>
-
     <%- if editing? %>
       <%- new_furniture_placement = room.furniture_placements.new %>
 
@@ -12,6 +8,10 @@
 
       <%- end %>
     <%- end %>
+
+    <section id="furniture_placements">
+      <%= render room.furniture_placements.rank(:slot) %>
+    </section>
   </div>
 
   <div class="px-6 pt-3">

--- a/app/views/rooms/_room.html.erb
+++ b/app/views/rooms/_room.html.erb
@@ -1,5 +1,5 @@
 <div class="flex flex-col content-between justify-end" data-turbo="true">
-  <div class="grow">
+  <div class="grow <%=editing? ? 'max-w-3xl' : '' %> mx-auto w-full">
     <%- if editing? %>
       <%- new_furniture_placement = room.furniture_placements.new %>
 

--- a/app/views/rooms/_room.html.erb
+++ b/app/views/rooms/_room.html.erb
@@ -1,5 +1,5 @@
 <div class="flex flex-col content-between justify-end" data-turbo="true">
-  <div class="grow <%=editing? ? 'max-w-3xl' : '' %> mx-auto w-full">
+  <div class="grow <%= editing? ? 'max-w-3xl' : '' %> mx-auto w-full">
     <%- if editing? %>
       <%- new_furniture_placement = room.furniture_placements.new %>
 


### PR DESCRIPTION
Hello,

We have improved some nice styling to the furniture placement :) 

https://github.com/zinc-collective/convene/issues/782

<img width="1616" alt="Furniture placement style" src="https://user-images.githubusercontent.com/1160546/185806818-22c133db-b125-43b4-959b-b4c983b1ba54.png">

Co-authored-by: Zee Spencer <zspencer@users.noreply.github.com>
Co-authored-by: Kelly Hong <k_ahong@yahoo.com>
Co-authored-by: Naomi Quinones <naomiquinones@users.noreply.github.com>