### PR TITLE
Add invitation reference to space_memberships table

### DIFF
--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -5,6 +5,8 @@ class Invitation < ApplicationRecord
 
   belongs_to :invitor, class_name: :Person, inverse_of: :invitations
 
+  has_one :space_membership
+
   default_scope -> { order(updated_at: :desc) }
 
   attribute :name, :string

--- a/app/models/rsvp.rb
+++ b/app/models/rsvp.rb
@@ -23,7 +23,7 @@ class Rsvp
     if authentication_method.confirmed?
       invitation.update(status: attributes[:status])
 
-      person.space_memberships.create(space: space)
+      person.space_memberships.create(space: space, invitation: invitation)
     else
       authentication_method.send_one_time_password!(space)
       false

--- a/app/models/space_membership.rb
+++ b/app/models/space_membership.rb
@@ -7,5 +7,8 @@ class SpaceMembership < ApplicationRecord
   # Which person is in the space
   belongs_to :member, class_name: :Person
 
+  # Which invitation was accepted for this membership to be created
+  belongs_to :invitation, optional: true
+
   validates :member, uniqueness: { scope: :space_id }
 end

--- a/app/views/space_memberships/_space_membership.html.erb
+++ b/app/views/space_memberships/_space_membership.html.erb
@@ -1,28 +1,26 @@
-<div class="px-4 py-4 sm:px-6">
-  <div class="flex items-center justify-between">
-    <p class="text-sm font-medium text-primary-600 truncate">
-      <%= space_membership.member.name || "Unknown" %>
-    </p>
-    <div class="ml-2 flex-shrink-0 flex text-sm text-gray-500 sm:mt-0">
-      <p>
-        Joined on
-        <time datetime="2020-01-07">
-          <%= space_membership.created_at %>
-        </time>
-      </p>
-    </div>
-  </div>
-  <div class="mt-2 sm:flex sm:justify-between">
-    <div class="sm:flex">
-      <p class="flex items-center text-sm text-gray-500">
-        <%= space_membership.member.email %>
-      </p>
-      <%= button_to t('icons.remove'),
-          [space, space_membership],
-          title: t('space_memberships.delete'),
-          method: :delete,
-          class: 'no-underline'
-      %>
-    </div>
-  </div>
+<div class="flex justify-between px-4 py-4 sm:px-6 text-sm">
+  <p class="grow font-medium text-primary-600 truncate">
+    <%= space_membership.member.name || "Unknown" %>
+  </p>
+  <p class="text-gray-500 px-2">
+    <%= space_membership.member.email %>
+  </p>
+  <p class="text-gray-500 px-2">
+    Joined on
+    <time datetime="2020-01-07">
+      <%= space_membership.created_at %>
+    </time>
+    <br>
+  <% if space_membership.invitation.present? %>
+      Invited by: <%= space_membership.invitation.invitor.name %>
+  <% end %>
+  </p>
+  <p class="shrink">
+    <%= button_to t('icons.remove'),
+      [space, space_membership],
+      title: t('space_memberships.delete'),
+      method: :delete,
+      class: 'no-underline'
+    %>
+  </p>
 </div>

--- a/app/views/space_memberships/_space_membership.html.erb
+++ b/app/views/space_memberships/_space_membership.html.erb
@@ -8,7 +8,7 @@
   <p class="text-gray-500 px-2">
     Joined on
     <time datetime="2020-01-07">
-      <%= space_membership.created_at %>
+      <%= l(space_membership.created_at, format: :short) %>
     </time>
     <br>
   <% if space_membership.invitation.present? %>

--- a/db/migrate/20220901010259_add_invitation_reference_to_membership.rb
+++ b/db/migrate/20220901010259_add_invitation_reference_to_membership.rb
@@ -1,0 +1,5 @@
+class AddInvitationReferenceToMembership < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :space_memberships, :invitation, type: :uuid, index: true, foreign_key: true, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_11_013601) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_01_010259) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -144,6 +144,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_11_013601) do
     t.uuid "space_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "invitation_id"
+    t.index ["invitation_id"], name: "index_space_memberships_on_invitation_id"
     t.index ["member_id"], name: "index_space_memberships_on_member_id"
     t.index ["space_id"], name: "index_space_memberships_on_space_id"
   end
@@ -175,5 +177,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_11_013601) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "space_memberships", "invitations"
   add_foreign_key "spaces", "rooms", column: "entrance_id"
 end

--- a/spec/requests/spaces/invitations/rsvp_spec.rb
+++ b/spec/requests/spaces/invitations/rsvp_spec.rb
@@ -64,8 +64,11 @@ RSpec.describe '/spaces/:space_id/invitations/:invitation_id/rsvp', type: :reque
           person = Person.find_by!(email: invitation.email)
 
           expect(invitation.reload).to be_accepted
-          expect(person.space_memberships
-              .find_by(space: space)).to be_present
+
+          membership = person.space_memberships.find_by(space: space)
+          expect(membership).to be_present
+          expect(membership.invitation).to eq(invitation)
+          expect(invitation.space_membership).to eq(membership)
 
           authentication_method = person
                                   .authentication_methods


### PR DESCRIPTION
This PR adds some of the functionality outlined in https://github.com/zinc-collective/convene/issues/117:
* adds an `invitation_id` reference to the `space_memberships` table
* displays the invitor name on a membership, if it has an associated invitation