### PR TITLE
Switch back to the mainline rails-spec gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -98,7 +98,7 @@ group :development, :test do
 
   # Our preferred testing library for Ruby and Rails projects
   gem 'rails-controller-testing'
-  gem 'rspec-rails', github: 'zinc-collective/rspec-rails', branch: 'combo-have_enqueued_mail-fixes'
+  gem 'rspec-rails', '~> 6.0.0.rc1'
   gem 'rswag-specs'
   gem 'shoulda-matchers', '~> 5.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,20 +6,6 @@ GIT
       listen (>= 2.7, < 4.0)
       spring (>= 4)
 
-GIT
-  remote: https://github.com/zinc-collective/rspec-rails.git
-  revision: 6660c8eebbbacfd3200172085254e22ca6475174
-  branch: combo-have_enqueued_mail-fixes
-  specs:
-    rspec-rails (5.1.1)
-      actionpack (>= 5.2)
-      activesupport (>= 5.2)
-      railties (>= 5.2)
-      rspec-core (~> 3.10)
-      rspec-expectations (~> 3.10)
-      rspec-mocks (~> 3.10)
-      rspec-support (~> 3.10)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -282,13 +268,21 @@ GEM
     rotp (6.2.0)
     rspec-core (3.11.0)
       rspec-support (~> 3.11.0)
-    rspec-expectations (3.11.0)
+    rspec-expectations (3.11.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
     rspec-mocks (3.11.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
-    rspec-support (3.11.0)
+    rspec-rails (6.0.0.rc1)
+      actionpack (>= 6.1)
+      activesupport (>= 6.1)
+      railties (>= 6.1)
+      rspec-core (~> 3.11)
+      rspec-expectations (~> 3.11)
+      rspec-mocks (~> 3.11)
+      rspec-support (~> 3.11)
+    rspec-support (3.11.1)
     rswag-api (2.6.0)
       railties (>= 3.1, < 7.1)
     rswag-specs (2.6.0)
@@ -380,7 +374,7 @@ DEPENDENCIES
   ranked-model (~> 0.4.8)
   redcarpet (~> 3.5)
   rotp (~> 6.2)
-  rspec-rails!
+  rspec-rails (~> 6.0.0.rc1)
   rswag-api
   rswag-specs
   rswag-ui


### PR DESCRIPTION
I set us to use the release candidate for the `rspec-rails` version that support Rails 7.x. (Looks like `rspec-rails` are in the process of changing their versioning scheme, so there isn't a non-RC version that fits us for now.)