### PR TITLE
Spotlight: Use `"attr"` rather than `:attr` when setting Alt Text

### DIFF
--- a/app/furniture/spotlight/image.rb
+++ b/app/furniture/spotlight/image.rb
@@ -4,10 +4,11 @@ class Spotlight
   class Image < Item
     has_one_attached :file
     def alt_text=text
-      data[:alt_text]=text
+      data["alt_text"]=text
     end
+
     def alt_text
-      data[:alt_text]
+      data["alt_text"]
     end
   end
 end


### PR DESCRIPTION
So, it turns out there's a pretty nasty wart in the `furniture` implementation where setting the data requires you to know the type of the key being set in the dictionary.

That's pretty gross, and probably something we should fix at the architectural level, since it's cost us a ton of brain-space already and we're only just writing our first few bits of Furniture.

That said, in the meantime as you add additional attributes to the Image item, we should be able to follow the pattern of using string keys.
