### PR TITLE
Marketplace: Products Controller persists Products!

### DIFF
--- a/app/furniture/breakout_tables_by_jitsi.rb
+++ b/app/furniture/breakout_tables_by_jitsi.rb
@@ -16,6 +16,12 @@ class BreakoutTablesByJitsi
     end
   end
 
+
+  # @deprecated
+  def in_room_template
+    "#{self.class.furniture_kind}/in_room"
+  end
+
   class Table
     include ActiveModel::Model
     include ActiveModel::Attributes

--- a/app/furniture/breakout_tables_by_jitsi.rb
+++ b/app/furniture/breakout_tables_by_jitsi.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class BreakoutTablesByJitsi
-  def self.append_routes(router)
+  def self.deprecated_append_routes(router)
     router.resources :breakout_tables_by_jitsi, only: [:show], controller: 'breakout_tables_by_jitsi_by_jitsi/'
   end
   include Placeable

--- a/app/furniture/embedded_form.rb
+++ b/app/furniture/embedded_form.rb
@@ -20,6 +20,11 @@ class EmbeddedForm
     "https://airtable.com/embed/#{form_id}"
   end
 
+  # @deprecated
+  def in_room_template
+    "#{self.class.furniture_kind}/in_room"
+  end
+
   def attribute_names
     super + ['form_url']
   end

--- a/app/furniture/furniture.rb
+++ b/app/furniture/furniture.rb
@@ -14,7 +14,15 @@ module Furniture
     spotlight: Spotlight,
   }.freeze
 
-  # Appends each {Furniture}'s CRUD actions
+  # Appends each {Furniture}'s CRUD actions under a FurniturePlacement
+  # @deprecated
+  def self.deprecated_append_routes(routing_context)
+    REGISTRY.each_value do |furniture|
+      furniture.deprecated_append_routes(routing_context) if furniture.respond_to?(:deprecated_append_routes)
+    end
+  end
+
+  # Appends each Furnitures CRUD actions within the {Room}
   def self.append_routes(routing_context)
     REGISTRY.each_value do |furniture|
       furniture.append_routes(routing_context) if furniture.respond_to?(:append_routes)

--- a/app/furniture/furniture.rb
+++ b/app/furniture/furniture.rb
@@ -16,16 +16,16 @@ module Furniture
 
   # Appends each {Furniture}'s CRUD actions under a FurniturePlacement
   # @deprecated
-  def self.deprecated_append_routes(routing_context)
+  def self.deprecated_append_routes(router)
     REGISTRY.each_value do |furniture|
-      furniture.deprecated_append_routes(routing_context) if furniture.respond_to?(:deprecated_append_routes)
+      furniture.deprecated_append_routes(router) if furniture.respond_to?(:deprecated_append_routes)
     end
   end
 
   # Appends each Furnitures CRUD actions within the {Room}
-  def self.append_routes(routing_context)
+  def self.append_routes(router)
     REGISTRY.each_value do |furniture|
-      furniture.append_routes(routing_context) if furniture.respond_to?(:append_routes)
+      furniture.append_routes(router) if furniture.respond_to?(:append_routes)
     end
   end
 

--- a/app/furniture/livestream.rb
+++ b/app/furniture/livestream.rb
@@ -27,6 +27,11 @@ class Livestream
     settings.fetch('layout', '')
   end
 
+  # @deprecated
+  def in_room_template
+    "#{self.class.furniture_kind}/in_room"
+  end
+
   # @todo can we make it so we don't need to define this?
   # and the `settings.fetch` bits?
   def attribute_names

--- a/app/furniture/markdown_text_block.rb
+++ b/app/furniture/markdown_text_block.rb
@@ -22,6 +22,11 @@ class MarkdownTextBlock
     super + ['content']
   end
 
+  # @deprecated
+  def in_room_template
+    "#{self.class.furniture_kind}/in_room"
+  end
+
   def self.renderer
     @_renderer ||= Redcarpet::Markdown.new(Redcarpet::Render::HTML.new(with_toc_data: true))
   end

--- a/app/furniture/marketplace.rb
+++ b/app/furniture/marketplace.rb
@@ -1,3 +1,4 @@
+# @see features/furniture/marketplace.feature.md
 class Marketplace
   include Placeable
 
@@ -9,9 +10,5 @@ class Marketplace
 
   def products
     Marketplace::Product.where(space: space)
-  end
-
-  def to_partial_path
-    'marketplace/marketplace'
   end
 end

--- a/app/furniture/marketplace.rb
+++ b/app/furniture/marketplace.rb
@@ -3,11 +3,15 @@ class Marketplace
 
   def self.append_routes(router)
     router.resource :marketplace, only: [] do
-      router.resources :products, only: %i[create index], module: "marketplace"
+      router.resources :products, only: %i[create index], module: 'marketplace'
     end
   end
 
   def products
     Marketplace::Product.where(space: space)
+  end
+
+  def to_partial_path
+    'marketplace/marketplace'
   end
 end

--- a/app/furniture/marketplace.rb
+++ b/app/furniture/marketplace.rb
@@ -6,4 +6,8 @@ class Marketplace
       router.resources :products, only: %i[create index], module: "marketplace"
     end
   end
+
+  def products
+    Marketplace::Product.where(space: space)
+  end
 end

--- a/app/furniture/marketplace/_in_room.html.erb
+++ b/app/furniture/marketplace/_in_room.html.erb
@@ -1,8 +1,0 @@
-<h2>Marketplace</h2>
-
-<%= form_with model: [space, room, :furniture, Marketplace::Product.new] do |f| %>
-  <%= render "text_field", { attribute: :name, form: f} %>
-  <%= render "text_area", { attribute: :description, form: f} %>
-  <%= render "number_field", { attribute: :price, form: f} %>
-  <%= f.submit %>
-<% end %>

--- a/app/furniture/marketplace/_marketplace.html.erb
+++ b/app/furniture/marketplace/_marketplace.html.erb
@@ -2,7 +2,6 @@
 
 <div>
   <h3>Products</h3>
-  <%- byebug %>
   <%= render marketplace.products %>
 </div>
 <%= form_with model: [marketplace.space, marketplace.room, marketplace.products.new] do |f| %>

--- a/app/furniture/marketplace/_marketplace.html.erb
+++ b/app/furniture/marketplace/_marketplace.html.erb
@@ -1,0 +1,13 @@
+<h2>Marketplace</h2>
+
+<div>
+  <h3>Products</h3>
+  <%- byebug %>
+  <%= render marketplace.products %>
+</div>
+<%= form_with model: [marketplace.space, marketplace.room, marketplace.products.new] do |f| %>
+  <%= render "text_field", { attribute: :name, form: f} %>
+  <%= render "text_area", { attribute: :description, form: f} %>
+  <%= render "number_field", { attribute: :price_cents, form: f} %>
+  <%= f.submit %>
+<% end %>

--- a/app/furniture/marketplace/product.rb
+++ b/app/furniture/marketplace/product.rb
@@ -1,5 +1,6 @@
 class Marketplace
   class Product < ApplicationRecord
     self.table_name = 'marketplace_products'
+    belongs_to :space
   end
 end

--- a/app/furniture/marketplace/product_policy.rb
+++ b/app/furniture/marketplace/product_policy.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+class Marketplace
+  class ProductPolicy < ApplicationPolicy
+    def permitted_attributes(_params)
+      %i[name description price_cents price_currency]
+    end
+  end
+end

--- a/app/furniture/marketplace/products/_product.html.erb
+++ b/app/furniture/marketplace/products/_product.html.erb
@@ -1,0 +1,5 @@
+<h4><%= product.name %></h4>
+
+<%= product.description %>
+
+<hr>

--- a/app/furniture/marketplace/products_controller.rb
+++ b/app/furniture/marketplace/products_controller.rb
@@ -1,6 +1,16 @@
 class Marketplace
-  class ProductsController < ApplicationController
+  class ProductsController < FurnitureController
+    def create
+      product = marketplace.products.new(product_params)
+      product.save!
+    end
 
-    def create ; end
+    def marketplace
+      Marketplace.find_by(room: room)
+    end
+
+    def product_params
+      policy(Marketplace::Product).permit(params.require(:product))
+    end
   end
 end

--- a/app/furniture/marketplace/products_controller.rb
+++ b/app/furniture/marketplace/products_controller.rb
@@ -3,6 +3,8 @@ class Marketplace
     def create
       product = marketplace.products.new(product_params)
       product.save!
+
+      render product
     end
 
     def marketplace
@@ -10,7 +12,7 @@ class Marketplace
     end
 
     def product_params
-      policy(Marketplace::Product).permit(params.require(:product))
+      policy(Marketplace::Product).permit(params.require(:marketplace_product))
     end
   end
 end

--- a/app/furniture/payment_form.rb
+++ b/app/furniture/payment_form.rb
@@ -5,7 +5,7 @@
 class PaymentForm
   include Placeable
 
-  def self.append_routes(router)
+  def self.deprecated_append_routes(router)
     router.scope module: 'payment_form' do
       router.resource :payment_form, only: [:show] do
         router.resources :payments, only: %i[create index]

--- a/app/furniture/payment_form.rb
+++ b/app/furniture/payment_form.rb
@@ -18,6 +18,11 @@ class PaymentForm
     Payment.where(location: placement)
   end
 
+  # @deprecated
+  def in_room_template
+    "#{self.class.furniture_kind}/in_room"
+  end
+
   def link_token_for(person)
     utilities.plaid.create_link_token(person: person, space: placement.space)
   end

--- a/app/furniture/placeable.rb
+++ b/app/furniture/placeable.rb
@@ -6,12 +6,23 @@ module Placeable
   # @return {FurniturePlacement}
   attr_accessor :placement
 
-  delegate :id, :room, :utilities, :persisted?, :save!, to: :placement
+  delegate :id, :room, :space, :utilities, :persisted?, :save!, to: :placement
 
   def self.included(placeable)
     placeable.include ActiveModel::Model
     placeable.include ActiveModel::Attributes
     placeable.include ActiveModel::AttributeAssignment
+    placeable.extend ClassMethods
+  end
+
+  module ClassMethods
+    def find_by(room:)
+      room.furniture_placements.find_by(furniture_kind: furniture_kind).furniture
+    end
+
+    def furniture_kind
+      name.demodulize.underscore
+    end
   end
 
   def settings
@@ -19,10 +30,10 @@ module Placeable
   end
 
   def in_room_template
-    "#{self.class.name.demodulize.underscore}/in_room"
+    "#{self.class.furniture_kind}/in_room"
   end
 
   def form_template
-    "#{self.class.name.demodulize.underscore}/form"
+    "#{self.class.furniture_kind}/form"
   end
 end

--- a/app/furniture/placeable.rb
+++ b/app/furniture/placeable.rb
@@ -29,10 +29,6 @@ module Placeable
     placement.settings
   end
 
-  def in_room_template
-    "#{self.class.furniture_kind}/in_room"
-  end
-
   def form_template
     "#{self.class.furniture_kind}/form"
   end

--- a/app/furniture/placeable.rb
+++ b/app/furniture/placeable.rb
@@ -21,12 +21,20 @@ module Placeable
     end
 
     def furniture_kind
-      name.demodulize.underscore
+      @furniture_kind ||= name.demodulize.underscore
     end
   end
 
   def settings
     placement.settings
+  end
+
+  # Allows us to `render furniture` and use the partial at `furniture/_furniture.html.erb`
+  # @example Assuming `spotlight` is a {Spotlight} that inherits {Placeable}
+  #      render spotlight # renders spotlight/_spotlight.html.erb
+  # @see https://api.rubyonrails.org/classes/ActiveModel/Conversion.html#method-i-to_partial_path
+  def to_partial_path
+    "#{self.class.furniture_kind}/#{self.class.furniture_kind}"
   end
 
   def form_template

--- a/app/furniture/spotlight.rb
+++ b/app/furniture/spotlight.rb
@@ -3,7 +3,7 @@
 class Spotlight
   include Placeable
 
-  def self.append_routes(router)
+  def self.deprecated_append_routes(router)
     router.scope module: 'spotlight' do
       router.resource :spotlight, only: [:show] do
         router.resources :images, only: %i[create edit update]

--- a/app/furniture/spotlight.rb
+++ b/app/furniture/spotlight.rb
@@ -19,6 +19,12 @@ class Spotlight
     image.file.attach(file)
   end
 
+
+  # @deprecated
+  def in_room_template
+    "#{self.class.furniture_kind}/in_room"
+  end
+
   def attribute_names
     %w[file]
   end

--- a/app/furniture/video_bridge.rb
+++ b/app/furniture/video_bridge.rb
@@ -3,4 +3,9 @@
 # Provides an iFramed Jitsi Meet to a {Room}.
 class VideoBridge
   include Placeable
+
+  # @deprecated
+  def in_room_template
+    "#{self.class.furniture_kind}/in_room"
+  end
 end

--- a/app/views/furniture_placements/_furniture_placement.html.erb
+++ b/app/views/furniture_placements/_furniture_placement.html.erb
@@ -14,8 +14,12 @@
                     href: [furniture_placement.room.space, furniture_placement.room, furniture_placement], title: t('.remove_title', { name: furniture_placement.furniture.model_name.human.titleize }), confirm: t('.confirm_destroy')  %>
       </header>
     <%- end %>
-    <%= render partial: furniture_placement.furniture.in_room_template,
-              locals: { furniture: furniture_placement.furniture, room: furniture_placement.room,
-                        person: current_person } %>
+    <%- if furniture_placement.furniture.respond_to?(:in_room_template) %>
+      <%= render partial: furniture_placement.furniture.in_room_template,
+                locals: { furniture: furniture_placement.furniture, space: furniture_placement.space, room: furniture_placement.room,
+                          person: current_person } %>
+    <%- else %>
+      <%= render furniture_placement.furniture %>
+    <%- end %>
   </section>
 <%- end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,10 +16,11 @@ Rails.application.routes.draw do
     end
 
     resources :rooms, only: %i[show edit update new create destroy] do
+      Furniture.append_routes(self)
       resource :waiting_room, only: %i[show update]
       resources :furniture_placements, only: %i[create edit update destroy]
       resource :furniture, only: [] do
-        Furniture.append_routes(self)
+        Furniture.deprecated_append_routes(self)
       end
     end
 

--- a/spec/factories/furniture/marketplace.rb
+++ b/spec/factories/furniture/marketplace.rb
@@ -1,0 +1,18 @@
+FactoryBot.define do
+  factory :marketplace do
+    transient do
+      room { build(:room) }
+    end
+
+    placement do
+      association :furniture_placement, { furniture_kind: 'marketplace', room: room }
+    end
+  end
+
+  factory :marketplace_product, class: 'Marketplace::Product' do
+    name { Faker::TvShows::DrWho.specie }
+    price_cents { Random.rand(1_00..9999_99) }
+
+    association :space
+  end
+end

--- a/spec/furniture/marketplace/products_request_spec.rb
+++ b/spec/furniture/marketplace/products_request_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe Marketplace::ProductsController, type: :request do
+  let(:marketplace) { create(:marketplace)}
+  let(:space) { marketplace.space }
+  let(:room) { marketplace.room }
+  describe "POST /products" do
+
+    it "Creates a Product in the Marketplace" do
+      attributes = attributes_for(:marketplace_product)
+
+      expect do
+        post polymorphic_path([space, room, marketplace, :products]), params: { product: attributes }
+      end.to change(marketplace.products, :count).by(1)
+
+      created_product = marketplace.products.last
+      expect(created_product.name).to eql(attributes[:name])
+      expect(created_product.description).to eql(attributes[:description])
+      expect(created_product.price_cents).to eql(attributes[:price_cents])
+      expect(created_product.price_currency).to eql(Money.default_currency.to_s)
+    end
+  end
+end

--- a/spec/furniture/marketplace/products_request_spec.rb
+++ b/spec/furniture/marketplace/products_request_spec.rb
@@ -1,16 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe Marketplace::ProductsController, type: :request do
-  let(:marketplace) { create(:marketplace)}
+  let(:marketplace) { create(:marketplace) }
   let(:space) { marketplace.space }
   let(:room) { marketplace.room }
-  describe "POST /products" do
-
-    it "Creates a Product in the Marketplace" do
+  describe 'POST /products' do
+    it 'Creates a Product in the Marketplace' do
       attributes = attributes_for(:marketplace_product)
 
       expect do
-        post polymorphic_path([space, room, marketplace, :products]), params: { product: attributes }
+        post polymorphic_path([space, room, marketplace, :products]), params: { marketplace_product: attributes }
       end.to change(marketplace.products, :count).by(1)
 
       created_product = marketplace.products.last


### PR DESCRIPTION
This starts to shift our Furniture and Item system away from an inheritance oriented rails-adjacent structure to a more Rails-forward structure.

Furniture now places it's routes against the *room*, which allows it to support either Singleton-type Resource routes, or more traditional Resources routes.

Further, it brings the `Placeable` interface a bit closer to ActiveRecord; which should reduce pain-points as we unwind the current overly-restrictive and complex Furniture/Item design.