### PR TITLE
doc: remove duplicate TOC in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Convene secure, affordable, always-available digital Spaces where anyone can
 
 ## Overview
 
-Convene is an _Operating System_ for **Community Owned Digital Infrastructure**. 
+Convene is an _Operating System_ for **Community Owned Digital Infrastructure**.
 Once deployed to a server, Convene is accessed by any web browser.
 
 Convene serves as a community-owned, more ethical alternative to investor-owned online tools like
@@ -77,22 +77,6 @@ Paid support is available for \$135 USD per hour<sup>[1][footnote-1]</sup>.
 
 We're always excited for new contributors! Read more in our
 [guide to contributing, located in CONTRIBUTING.md](./CONTRIBUTING.md)
-
-# Convene Web <!-- omit in toc -->
-
-- [Overview](#overview)
-- [Using Convene](#using-convene)
-  - [Purchasing a Convene Operator License.](#purchasing-a-convene-operator-license)
-  - [Help and Support](#help-and-support)
-- [Contributing to Convene](#contributing-to-convene)
-- [System Overview](#system-overview)
-  - [Architecture overview diagram](#architecture-overview-diagram)
-- [Configuring Your Development Machine](#configuring-your-development-machine)
-  - [Debugger](#debugger)
-  - [Developing Mailers](#developing-mailers)
-- [Testing Convene](#testing-convene)
-  - [Overview of the `features` folder](#overview-of-the-features-folder)
-- [About The Zinc Collective](#about-the-zinc-collective)
 
 ## System Overview
 


### PR DESCRIPTION

remove duplicate TOC that displayed in root [README](https://github.com/zinc-collective/convene).


<img width="1064" alt="Screen Shot 2022-10-05 at 5 25 27 PM" src="https://user-images.githubusercontent.com/16140873/194187170-0f4ab5b4-9141-4d8f-9679-df6b524a8755.png">
