### PR TITLE
Memberships: Adds Breadcrumb from Membership: Show page

### DIFF
--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -15,6 +15,10 @@ class Membership < ApplicationRecord
 
   validates :member, uniqueness: { scope: :space_id }
 
+  def member_name
+    member.display_name
+  end
+
   enum status: {
     active: 'active',
     revoked: 'revoked'

--- a/app/views/memberships/show.html.erb
+++ b/app/views/memberships/show.html.erb
@@ -1,3 +1,4 @@
+<%- breadcrumb :show_membership, membership %>
 <h1><%= membership.member.name %></h1>
 <p><%= membership.member.email %></p>
 

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -15,7 +15,16 @@ end
 
 crumb :memberships do |space|
   link 'Members', [space, :memberships]
-  parent :edit_space, space
+  if policy(space).edit?
+    parent :edit_space, Space
+  else
+    parent :root
+  end
+end
+
+crumb :show_membership do |membership|
+  link membership.member_name, [membership.space, membership]
+  parent :memberships, membership.space
 end
 
 crumb :invitations do |space|


### PR DESCRIPTION
I noticed when working on the
[Journal](https://github.com/zinc-collective/convene/issues/898) that when you click on the `Account` link, it kind of drops you into the middle of no where.

This adds a breadcrumb, so we can find our way back! Yay!

## Before
<img width="575" alt="Screen Shot 2022-10-23 at 1 39 29 PM" src="https://user-images.githubusercontent.com/50284/197417169-c66fd46c-f68a-4cab-9f80-5c19a82c2928.png">

## After!
<img width="570" alt="Screen Shot 2022-10-23 at 1 39 20 PM" src="https://user-images.githubusercontent.com/50284/197417174-49833f35-a8ca-43a7-8963-bb16a0a3e1ab.png">

