### PR TITLE
Furniture: Extract seam to ease the elimination of Placeable

### DIFF
--- a/app/furniture/furniture.rb
+++ b/app/furniture/furniture.rb
@@ -31,10 +31,7 @@ module Furniture
 
   # @return [Placeable]
   def self.from_placement(placement)
-    REGISTRY[placement.furniture_kind.to_sym].new(placement: placement)
-  end
-
-  def self.use_relative_model_naming?
-    true
+    furniture_class = REGISTRY[placement.furniture_kind.to_sym]
+    furniture_class.from_placement(placement)
   end
 end

--- a/app/furniture/placeable.rb
+++ b/app/furniture/placeable.rb
@@ -45,5 +45,9 @@ module Placeable
     def furniture_kind
       @furniture_kind ||= name.demodulize.underscore
     end
+
+    def from_placement(placement)
+      new(placement: placement)
+    end
   end
 end


### PR DESCRIPTION
OK, so the trajectory I am going with is we can get rid of the `Furniture`, `FurniturePlacement` and `Placeable` classes and the weird things they do in favor of standard-ass inheritance. I expect that most of the ways those pieces fit within the system will mostly coalesce into the `Furniture` class; but I'm not quite ready to make that leap just yet.

This will let us go through the `MarkdownTextBlock`, `Spotlight`, `VideoBridge`, and `PaymentForm` Furniture and cut their LoC by quite a bit; as well as get us into a much smoother groove when extending those features.

The refactor seemed to serve both the `Marketplace` and the `Journal` feature when we did [the first in an
Ensemble](https://github.com/zinc-collective/convene/pull/862/files#diff-d2a16da4475658ee74f5ff09ab97db7f2ec836b017ae760f4cc13687b150b656R34-R35) and the second [in my own
branch](https://github.com/zinc-collective/convene/pull/901/files)