### PR TITLE
Turn on an explicit locale backend for the Money gem, to get rid of a deprecation message

### DIFF
--- a/config/initializers/money.rb
+++ b/config/initializers/money.rb
@@ -85,7 +85,7 @@ MoneyRails.configure do |config|
 
   # If you would like to use I18n localization (formatting depends on the
   # locale):
-  # config.locale_backend = :i18n
+  config.locale_backend = :i18n
   #
   # Example (using default localization from rails-i18n):
   #


### PR DESCRIPTION
As suggested in the instructions at https://github.com/zinc-collective/convene/pull/new/au/fix-deprecation