### PR TITLE
Prevent false-positives for Pundit's verify_authorized check

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -76,12 +76,10 @@ class ApplicationController < ActionController::Base
       else
         BrandedDomainConstraint.new(space_repository).space_for_request(request) ||
           space_repository.friendly.find(params[:id])
-      end.tap do |space|
-        authorize(space, :show?)
       end
   rescue ActiveRecord::RecordNotFound
     begin
-      @current_space ||= space_repository.default.tap { |space| authorize(space, :show?) }
+      @current_space ||= space_repository.default
     rescue ActiveRecord::RecordNotFound
       Rails.logger.error("No default space exists!")
       @current_space = nil

--- a/app/controllers/me_controller.rb
+++ b/app/controllers/me_controller.rb
@@ -1,5 +1,6 @@
 class MeController < ApplicationController
   def show
+    authorize(current_person)
     respond_to do |format|
       format.json { render json: current_person.as_json(root: :attributes) }
       format.html { render locals: {person: current_person} }

--- a/app/controllers/waiting_rooms_controller.rb
+++ b/app/controllers/waiting_rooms_controller.rb
@@ -13,6 +13,6 @@ class WaitingRoomsController < ApplicationController
   end
 
   helper_method def waiting_room
-    @waiting_room ||= WaitingRoom.new(room: current_room)
+    @waiting_room ||= authorize(WaitingRoom.new(room: current_room))
   end
 end

--- a/app/furniture/marketplace/marketplace_policy.rb
+++ b/app/furniture/marketplace/marketplace_policy.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Marketplace
+  class MarketplacePolicy < ApplicationPolicy
+    class Scope < ApplicationScope
+      def resolve
+        scope.all
+      end
+    end
+  end
+end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -34,6 +34,10 @@ class ApplicationPolicy
     @object = object
   end
 
+  def current_person
+    @person
+  end
+
   def permit(params)
     params.permit(permitted_attributes(params))
   end

--- a/app/policies/guest_policy.rb
+++ b/app/policies/guest_policy.rb
@@ -1,0 +1,9 @@
+class GuestPolicy < ApplicationPolicy
+  def show?
+    true
+  end
+
+  def create?
+    true
+  end
+end

--- a/app/policies/person_policy.rb
+++ b/app/policies/person_policy.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class PersonPolicy < ApplicationPolicy
+  alias_method :person, :object
+
+  def show?
+    current_person == person || current_person.operator?
+  end
+
+  alias_method :new?, :show?
+  alias_method :update?, :show?
+  alias_method :edit?, :show?
+  alias_method :destroy?, :show?
+  alias_method :create?, :show?
+
+  def permitted_attributes(_params)
+    [:name, :slug, :theme, :blueprint, client_attributes: [:name]]
+  end
+
+  class Scope < ApplicationScope
+    def resolve
+      scope.all
+    end
+  end
+end

--- a/app/policies/waiting_room_policy.rb
+++ b/app/policies/waiting_room_policy.rb
@@ -1,0 +1,8 @@
+class WaitingRoomPolicy < ApplicationPolicy
+  def show?
+    true
+  end
+
+  alias_method :update?, :show?
+  alias_method :create?, :show?
+end

--- a/spec/furniture/marketplace/products_controller_request_spec.rb
+++ b/spec/furniture/marketplace/products_controller_request_spec.rb
@@ -4,10 +4,13 @@ RSpec.describe Marketplace::ProductsController, type: :request do
   let(:marketplace) { create(:marketplace) }
   let(:space) { marketplace.space }
   let(:room) { marketplace.room }
+  let(:member) { create(:membership, space: space).member}
 
   describe "POST /products" do
     it "Creates a Product in the Marketplace" do
       attributes = attributes_for(:marketplace_product)
+
+      sign_in(space, member)
 
       expect do
         post polymorphic_path([space, room, marketplace, :products]),


### PR DESCRIPTION
https://github.com/zinc-collective/convene/issues/926

We noticed that, despite our lack-of-authorize calls in some of our Furniture controllers, Pundit was not throwing a shit-fit.

This should make pundit throw more shit-fits about missing Policy objects.

- [x] Remove `authorize` call from `ApplicationController`
- [x] Fix failing unit tests
- [x] Fix failing feature tests by smoke testing the paths they walk and adding in authorize calls.
