### PR TITLE
Add money field with tailwind stylings

### DIFF
--- a/app/furniture/marketplace/product_policy.rb
+++ b/app/furniture/marketplace/product_policy.rb
@@ -3,8 +3,8 @@
 class Marketplace
   class ProductPolicy < ApplicationPolicy
     alias product object
-    def permitted_attributes(_params)
-      %i[name description price_cents price_currency]
+    def permitted_attributes(_params = nil)
+      %i[name description price_cents price_currency price]
     end
 
     def create?

--- a/app/furniture/marketplace/products/_form.html.erb
+++ b/app/furniture/marketplace/products/_form.html.erb
@@ -2,5 +2,6 @@
   <%= render "text_field", { attribute: :name, form: f} %>
   <%= render "text_area", { attribute: :description, form: f} %>
   <%= render "number_field", { attribute: :price_cents, form: f} %>
+  <%= render "money_field", { attribute: :amount, form: f} %>
   <%= f.submit %>
 <% end %>

--- a/app/furniture/marketplace/products/_form.html.erb
+++ b/app/furniture/marketplace/products/_form.html.erb
@@ -1,7 +1,6 @@
 <%= form_with model: product.location do |f| %>
   <%= render "text_field", { attribute: :name, form: f} %>
   <%= render "text_area", { attribute: :description, form: f} %>
-  <%= render "number_field", { attribute: :price_cents, form: f} %>
-  <%= render "money_field", { attribute: :amount, form: f} %>
+  <%= render "money_field", { attribute: :price, form: f, min: 0, step: 0.01} %>
   <%= f.submit %>
 <% end %>

--- a/app/views/application/_money_field.html.erb
+++ b/app/views/application/_money_field.html.erb
@@ -1,0 +1,14 @@
+<% required ||= required | false %>
+  <div>
+  <%= form.label attribute, class: "block text-sm font-medium text-gray-700"%>
+  <div class="relative mt-1 rounded-md shadow-sm">
+    <div class="pointer-events-none absolute bottom-0.5 left-0 flex items-center pl-3">
+      <span class="text-gray-500 sm:text-sm">$</span>
+    </div>
+    <%= form.number_field attribute, class: "block w-full rounded-md border-gray-300 !pl-7 !pr-12 focus:border-indigo-500 focus:ring-indigo-500 text-gray-500 sm:text-sm", required: required %>
+    <div class="pointer-events-none absolute  bottom-0.5 right-0 flex items-center pr-3">
+      <span class="text-gray-500 sm:text-sm" id="price-currency">USD</span>
+    </div>
+  </div>
+  <%= render partial: "error", locals: { model: form.object, attribute: attribute } %>
+</div>

--- a/app/views/application/_money_field.html.erb
+++ b/app/views/application/_money_field.html.erb
@@ -1,11 +1,13 @@
 <% required ||= required | false %>
-  <div>
+<% min = local_assigns[:min] %>
+<% step = local_assigns[:step] %>
+<div>
   <%= form.label attribute, class: "block text-sm font-medium text-gray-700"%>
   <div class="relative mt-1 rounded-md shadow-sm">
     <div class="pointer-events-none absolute bottom-0.5 left-0 flex items-center pl-3">
       <span class="text-gray-500 sm:text-sm">$</span>
     </div>
-    <%= form.number_field attribute, class: "block w-full rounded-md border-gray-300 !pl-7 !pr-12 focus:border-indigo-500 focus:ring-indigo-500 text-gray-500 sm:text-sm", required: required %>
+    <%= form.number_field attribute, class: "block w-full rounded-md border-gray-300 !pl-7 !pr-12 focus:border-indigo-500 focus:ring-indigo-500 text-gray-500 sm:text-sm", step: step, min: min, required: required %>
     <div class="pointer-events-none absolute  bottom-0.5 right-0 flex items-center pr-3">
       <span class="text-gray-500 sm:text-sm" id="price-currency">USD</span>
     </div>

--- a/spec/furniture/marketplace/product_policy_spec.rb
+++ b/spec/furniture/marketplace/product_policy_spec.rb
@@ -1,0 +1,8 @@
+require "rails_helper"
+
+RSpec.describe Marketplace::ProductPolicy do
+  describe '#permitted_attributes' do
+    subject(':permitted_attributes') { Marketplace::ProductPolicy.new(nil, nil).permitted_attributes }
+    it {is_expected.to include :price}
+  end
+end

--- a/spec/furniture/marketplace/product_spec.rb
+++ b/spec/furniture/marketplace/product_spec.rb
@@ -6,4 +6,13 @@ RSpec.describe Marketplace::Product, type: :model do
   describe '#name' do
     it { is_expected.to validate_presence_of(:name) }
   end
+
+  describe '#price=' do
+    it('sets the price_cents') do
+      product = Marketplace::Product.new
+      product.price = 20
+      expect(product.price_cents).to eql(2000)
+    end
+  end
+
 end


### PR DESCRIPTION
Added money input field with dollar sign in front of the money and the end of the number with @zspencer to see with the tailwind component. For now it is always dollar sign as a hard coded string. 

![input-filed](https://user-images.githubusercontent.com/1160546/201472473-0db37473-2168-4758-873a-164dc073a5fc.jpg)
