### PR TITLE
Marketplace: Destroy Products when Destroying Marketplaces

### DIFF
--- a/app/furniture/marketplace/marketplace.rb
+++ b/app/furniture/marketplace/marketplace.rb
@@ -2,7 +2,7 @@
 
 class Marketplace
   class Marketplace < FurniturePlacement
-    has_many :products, inverse_of: :marketplace
+    has_many :products, inverse_of: :marketplace, dependent: :destroy
     has_many :carts, inverse_of: :marketplace, dependent: :destroy
 
     def self.model_name

--- a/spec/furniture/marketplace/marketplace_spec.rb
+++ b/spec/furniture/marketplace/marketplace_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
 RSpec.describe Marketplace::Marketplace, type: :model do
-  it { is_expected.to have_many(:products).inverse_of(:marketplace) }
+  it { is_expected.to have_many(:products).inverse_of(:marketplace).dependent(:destroy) }
   it { is_expected.to have_many(:carts).inverse_of(:marketplace).dependent(:destroy) }
 end


### PR DESCRIPTION
See: https://github.com/zinc-collective/convene/issues/831

I keep forgetting that foreign keys need to be taken care of explicitly
in relations. I'm pretty sure there's a gem that notices mismatches
between dependent settings and database schemas but I don't remember
what it is :X.