### PR TITLE
Explicitly skip_authorization in Memberships index action

### DIFF
--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -2,6 +2,7 @@
 
 class MembershipsController < ApplicationController
   def index
+    skip_authorization
   end
 
   def show


### PR DESCRIPTION
Another small fix after we changed our system to require us to explicitly authorize or scope data in Actions.