### PR TITLE
Marketplace: Cart attach to Shopper

### DIFF
--- a/app/furniture/marketplace/cart.rb
+++ b/app/furniture/marketplace/cart.rb
@@ -5,6 +5,7 @@ class Marketplace
     self.table_name = 'marketplace_carts'
 
     belongs_to :marketplace, inverse_of: :carts
+    belongs_to :shopper, class_name: "Person"
     delegate :space, :room, to: :marketplace
     has_many :cart_products, dependent: :destroy, inverse_of: :cart
     has_many :products, through: :cart_products, inverse_of: :carts

--- a/app/furniture/marketplace/cart.rb
+++ b/app/furniture/marketplace/cart.rb
@@ -5,7 +5,7 @@ class Marketplace
     self.table_name = 'marketplace_carts'
 
     belongs_to :marketplace, inverse_of: :carts
-    belongs_to :shopper, class_name: "Person"
+    belongs_to :shopper, inverse_of: :carts
     delegate :space, :room, to: :marketplace
     has_many :cart_products, dependent: :destroy, inverse_of: :cart
     has_many :products, through: :cart_products, inverse_of: :carts

--- a/app/furniture/marketplace/marketplaces/_marketplace.html.erb
+++ b/app/furniture/marketplace/marketplaces/_marketplace.html.erb
@@ -1,5 +1,5 @@
 
-<%- cart = marketplace.carts.find_or_create_by(id: session[:current_cart] ||= SecureRandom.uuid) %>
+<%- cart = marketplace.carts.find_or_create_by(shopper: current_person) %>
 
 <%= render cart %>
 

--- a/app/furniture/marketplace/marketplaces/_marketplace.html.erb
+++ b/app/furniture/marketplace/marketplaces/_marketplace.html.erb
@@ -1,5 +1,13 @@
 
-<%- cart = marketplace.carts.find_or_create_by(shopper: current_person) %>
+
+
+<%- shopper = if current_person.is_a?(Guest) 
+     Marketplace::Shopper.find_or_create_by(id: session[:current_cart] ||= SecureRandom.uuid)
+  else
+    Marketplace::Shopper.find_or_create_by(person: current_person)
+end %>
+
+<%- cart = marketplace.carts.find_or_create_by(shopper: shopper) %>
 
 <%= render cart %>
 

--- a/app/furniture/marketplace/shopper.rb
+++ b/app/furniture/marketplace/shopper.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Marketplace
+  class Shopper < ApplicationRecord
+    self.table_name = 'marketplace_shoppers'
+
+    belongs_to :person, optional: true
+    has_many :carts, inverse_of: :shopper
+  end
+end

--- a/db/migrate/20221208013832_add_shopper_to_marketplace_carts.rb
+++ b/db/migrate/20221208013832_add_shopper_to_marketplace_carts.rb
@@ -1,0 +1,7 @@
+class AddShopperToMarketplaceCarts < ActiveRecord::Migration[7.0]
+  def change
+    change_table :marketplace_carts do |t|
+      t.references :shopper, type: :uuid, foreign_key: {to_table: :people}
+    end
+  end
+end

--- a/db/migrate/20221208013832_add_shopper_to_marketplace_carts.rb
+++ b/db/migrate/20221208013832_add_shopper_to_marketplace_carts.rb
@@ -1,7 +1,12 @@
 class AddShopperToMarketplaceCarts < ActiveRecord::Migration[7.0]
   def change
+    create_table :marketplace_shoppers, id: :uuid  do |t|
+      t.references(:person, type: :uuid, foreign_key: {to_table: :people}, index: {unique: true})
+      t.timestamps
+    end
+
     change_table :marketplace_carts do |t|
-      t.references :shopper, type: :uuid, foreign_key: {to_table: :people}
+      t.references :shopper, type: :uuid, foreign_key: {to_table: :marketplace_shoppers}
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_13_010533) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_08_013832) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -148,7 +148,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_13_010533) do
     t.uuid "marketplace_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "shopper_id"
     t.index ["marketplace_id"], name: "index_marketplace_carts_on_marketplace_id"
+    t.index ["shopper_id"], name: "index_marketplace_carts_on_shopper_id"
   end
 
   create_table "marketplace_products", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -226,6 +228,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_13_010533) do
   add_foreign_key "marketplace_cart_products", "marketplace_carts", column: "cart_id"
   add_foreign_key "marketplace_cart_products", "marketplace_products", column: "product_id"
   add_foreign_key "marketplace_carts", "furniture_placements", column: "marketplace_id"
+  add_foreign_key "marketplace_carts", "people", column: "shopper_id"
   add_foreign_key "marketplace_products", "furniture_placements", column: "marketplace_id"
   add_foreign_key "memberships", "invitations"
   add_foreign_key "spaces", "rooms", column: "entrance_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -164,6 +164,13 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_08_013832) do
     t.index ["marketplace_id"], name: "index_marketplace_products_on_marketplace_id"
   end
 
+  create_table "marketplace_shoppers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "person_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["person_id"], name: "index_marketplace_shoppers_on_person_id", unique: true
+  end
+
   create_table "memberships", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "member_id"
     t.uuid "space_id"
@@ -228,8 +235,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_08_013832) do
   add_foreign_key "marketplace_cart_products", "marketplace_carts", column: "cart_id"
   add_foreign_key "marketplace_cart_products", "marketplace_products", column: "product_id"
   add_foreign_key "marketplace_carts", "furniture_placements", column: "marketplace_id"
-  add_foreign_key "marketplace_carts", "people", column: "shopper_id"
+  add_foreign_key "marketplace_carts", "marketplace_shoppers", column: "shopper_id"
   add_foreign_key "marketplace_products", "furniture_placements", column: "marketplace_id"
+  add_foreign_key "marketplace_shoppers", "people"
   add_foreign_key "memberships", "invitations"
   add_foreign_key "spaces", "rooms", column: "entrance_id"
 end

--- a/spec/factories/furniture/marketplace.rb
+++ b/spec/factories/furniture/marketplace.rb
@@ -17,5 +17,6 @@ FactoryBot.define do
 
   factory :marketplace_cart, class: "Marketplace::Cart" do
     marketplace
+    association(:shopper, factory: :person)
   end
 end

--- a/spec/factories/furniture/marketplace.rb
+++ b/spec/factories/furniture/marketplace.rb
@@ -17,6 +17,10 @@ FactoryBot.define do
 
   factory :marketplace_cart, class: "Marketplace::Cart" do
     marketplace
-    association(:shopper, factory: :person)
+    association(:shopper, factory: :marketplace_shopper)
   end
+
+  factory :marketplace_shopper, class: "Marketplace::Shopper" do
+  end
+  
 end

--- a/spec/furniture/marketplace/cart_spec.rb
+++ b/spec/furniture/marketplace/cart_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe Marketplace::Cart, type: :model do
 
   it { is_expected.to belong_to(:marketplace).class_name("Marketplace::Marketplace").inverse_of(:carts) }
 
+  it { is_expected.to belong_to(:shopper).class_name("Person") }
+
   describe "#price_total" do
     subject(:price_total) { cart.price_total }
 

--- a/spec/furniture/marketplace/cart_spec.rb
+++ b/spec/furniture/marketplace/cart_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Marketplace::Cart, type: :model do
 
   it { is_expected.to belong_to(:marketplace).class_name("Marketplace::Marketplace").inverse_of(:carts) }
 
-  it { is_expected.to belong_to(:shopper).class_name("Person") }
+  it { is_expected.to belong_to(:shopper).inverse_of(:carts) }
 
   describe "#price_total" do
     subject(:price_total) { cart.price_total }

--- a/spec/furniture/marketplace/shopper_spec.rb
+++ b/spec/furniture/marketplace/shopper_spec.rb
@@ -1,0 +1,7 @@
+require "rails_helper"
+
+RSpec.describe Marketplace::Shopper, type: :model do
+  it { is_expected.to belong_to(:person).optional }
+
+  it { is_expected.to have_many(:carts).inverse_of(:shopper) }
+end


### PR DESCRIPTION
https://github.com/zinc-collective/convene/issues/831

When there were multi Marketplaces in a neighborhood, the page would crash. Now the Cart is attached to a Shopper which prevents the conflict of trying to find the Cart by the same Id across Marketplaces.