### PR TITLE
Journal: Entries with @handle@example.com link to https://example.com/@handle

### DIFF
--- a/app/furniture/journal/entry.rb
+++ b/app/furniture/journal/entry.rb
@@ -1,49 +1,62 @@
-class Journal::Entry < ApplicationRecord
-  self.table_name = "journal_entries"
-  include RendersMarkdown
-  extend StripsNamespaceFromModelName
+class Journal
+  class Entry < ApplicationRecord
+    self.table_name = "journal_entries"
+    include RendersMarkdown
+    extend StripsNamespaceFromModelName
 
-  scope :recent, -> { order("published_at DESC NULLS FIRST") }
+    scope :recent, -> { order("published_at DESC NULLS FIRST") }
 
-  attribute :headline, :string
-  attribute :body, :string
-  validates :body, presence: true
+    attribute :headline, :string
+    attribute :body, :string
+    validates :body, presence: true
 
-  # URI-friendly description of the entry.
-  attribute :slug, :string
-  validates :slug, uniqueness: {scope: :journal_id}
+    # URI-friendly description of the entry.
+    attribute :slug, :string
+    validates :slug, uniqueness: {scope: :journal_id}
 
-  # FriendlyId does the legwork to make the slug uri-friendly
-  extend FriendlyId
-  friendly_id :headline, use: :scoped, scope: :journal
+    # FriendlyId does the legwork to make the slug uri-friendly
+    extend FriendlyId
+    friendly_id :headline, use: :scoped, scope: :journal
 
-  attribute :published_at, :datetime
+    attribute :published_at, :datetime
 
-  # @!attribute journal
-  #   @return [Journal::Journal]
-  belongs_to :journal, class_name: "Journal::Journal", inverse_of: :entries
-  delegate :room, :space, to: :journal
+    # @!attribute journal
+    #   @return [Journal::Journal]
+    belongs_to :journal, class_name: "Journal::Journal", inverse_of: :entries
+    delegate :room, :space, to: :journal
 
-  def published?
-    published_at.present?
-  end
+    def published?
+      published_at.present?
+    end
 
-  def to_html
-    render_markdown(body)
-  end
+    def to_html
+      render_markdown(body)
+    end
 
-  def to_param
-    slug
-  end
+    def self.renderer
+      @_renderer ||= Redcarpet::Markdown.new(
+        Renderer.new(filter_html: true, with_toc_data: true),
+        autolink: true, strikethrough: true,
+        no_intra_emphasis: true,
+        lax_spacing: true,
+        fenced_code_blocks: true, disable_indented_code_blocks: true,
+        tables: true, footnotes: true, superscript: true, quote: true
+      )
+    end
 
-  def location(action = :show)
-    case action
-    when :new
-      [:new] + journal.location + [:entry]
-    when :edit
-      [:edit] + journal.location + [self]
-    else
-      journal.location + [self]
+    def to_param
+      slug
+    end
+
+    def location(action = :show)
+      case action
+      when :new
+        [:new] + journal.location + [:entry]
+      when :edit
+        [:edit] + journal.location + [self]
+      else
+        journal.location + [self]
+      end
     end
   end
 end

--- a/app/furniture/journal/renderer.rb
+++ b/app/furniture/journal/renderer.rb
@@ -1,0 +1,12 @@
+class Journal
+  class Renderer < Redcarpet::Render::Safe
+    def autolink(link, link_type)
+      return link if link_type == :email
+      "<a href=\"#{link}\">#{link}</a>"
+    end
+
+    def postprocess(doc)
+      doc.gsub(/@([a-zA-Z\d]*)@(.*\.[a-zA-Z]*)/, '<a href="https://\2/@\1">@\1@\2</a>')
+    end
+  end
+end

--- a/app/lib/renders_markdown.rb
+++ b/app/lib/renders_markdown.rb
@@ -1,6 +1,10 @@
 module RendersMarkdown
   def render_markdown(content)
-    self.class.renderer.render(content)
+    if self.class.respond_to?(:renderer)
+      self.class.renderer.render(content)
+    else
+      RendersMarkdown.renderer.render(content)
+    end
   end
 
   def self.renderer

--- a/app/lib/renders_markdown.rb
+++ b/app/lib/renders_markdown.rb
@@ -1,6 +1,6 @@
 module RendersMarkdown
   def render_markdown(content)
-    RendersMarkdown.renderer.render(content)
+    self.class.renderer.render(content)
   end
 
   def self.renderer

--- a/spec/furniture/journal/entry_spec.rb
+++ b/spec/furniture/journal/entry_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe Journal::Entry do
+  subject(:entry) { build(:journal_entry, body: body) }
+
+  let(:body) { Faker::Books::CultureSeries.civ }
+
+  describe "#to_html" do
+    subject(:to_html) { entry.to_html }
+
+    context "when #body is 'https://www.google.com @zee@weirder.earth'" do
+      let(:body) { "https://www.google.com @zee@weirder.earth" }
+
+      it { is_expected.to include('<a href="https://weirder.earth/@zee">@zee@weirder.earth</a>') }
+      it { is_expected.to include('<a href="https://www.google.com">https://www.google.com</a>') }
+    end
+  end
+end

--- a/spec/furniture/journal/entry_spec.rb
+++ b/spec/furniture/journal/entry_spec.rb
@@ -3,8 +3,6 @@ require "rails_helper"
 RSpec.describe Journal::Entry do
   subject(:entry) { build(:journal_entry, body: body) }
 
-  let(:body) { Faker::Books::CultureSeries.civ }
-
   describe "#to_html" do
     subject(:to_html) { entry.to_html }
 


### PR DESCRIPTION
https://github.com/zinc-collective/convene/issues/898

There's probably a better way to do this that takes into account that handles may not use the same format on every fediverse instance; but we'll cross that bridge when we come to it.