### PR TITLE
Journal: Use the Entry Headline in Page Title

### DIFF
--- a/app/furniture/journal/entries_controller.rb
+++ b/app/furniture/journal/entries_controller.rb
@@ -40,6 +40,10 @@ class Journal::EntriesController < FurnitureController
     authorize(@entry)
   end
 
+  helper_method def page_title
+    "#{entry.headline} - #{space.name}"
+  end
+
   def entry_params
     policy(Journal::Entry).permit(params.require(:entry))
   end


### PR DESCRIPTION
https://github.com/zinc-collective/convene/issues/898

It just feels weird not to have the actual title in the page...

### Before
<img width="377" alt="Screen Shot 2022-12-17 at 9 08 54 PM" src="https://user-images.githubusercontent.com/50284/208282479-44724bbb-34bd-48cd-ab10-4ba5419ce61d.png">


### After
<img width="500" alt="Screen Shot 2022-12-17 at 9 07 11 PM" src="https://user-images.githubusercontent.com/50284/208282470-957ac3cf-9c18-4c5c-9d3b-2dd4d843eb27.png">

