### PR TITLE
Space: BYO Domains drop Space from polymorphic_urls

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,18 +27,38 @@ class ApplicationController < ActionController::Base
 
   helper_method :current_person
 
-  helper_method def url_for(options=nil)
-    if options[0].is_a?(Space) && options[0].branded_domain.present?
-      space = options.delete_at(0)
-      if options.last.respond_to?(:merge!)
-        options.last.merge!({ domain: space.branded_domain })
+  helper_method def url_for(options)
+    space = if options[0].is_a?(Space) && options[0].branded_domain.present?
+      options.delete_at(0)
+    elsif [:edit, :new].include?(options[0]) && options[1].is_a?(Space) && options[1].branded_domain.present?
+      options.delete_at(1)
+    elsif options.is_a?(Space) && options.branded_domain.present?
+      options
+    end
+
+    if space
+      if options.respond_to?(:last) && options.last.is_a?(Hash)
+        options.last[:domain] = space.branded_domain
+      elsif options.respond_to?(:<<) && options.length > 0
+        options << {domain: space.branded_domain}
       else
-        options << { domain: space.branded_domain }
+        options = [:root, {domain: space.branded_domain}]
       end
     end
 
     super
   end
+
+  helper_method def polymorphic_path(options, **attributes)
+    if options[0].is_a?(Space) && options[0].branded_domain.present? && options.length > 1
+      options.delete_at(0)
+    elsif [:edit, :new].include?(options[0]) && options[1].is_a?(Space) && options[1].branded_domain.present?
+      options.delete_at(1)
+    end
+
+    super
+  end
+
   private
 
   OPERATOR_TOKEN = ENV["OPERATOR_API_KEY"]

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,6 +27,18 @@ class ApplicationController < ActionController::Base
 
   helper_method :current_person
 
+  helper_method def url_for(options=nil)
+    if options[0].is_a?(Space) && options[0].branded_domain.present?
+      space = options.delete_at(0)
+      if options.last.respond_to?(:merge!)
+        options.last.merge!({ domain: space.branded_domain })
+      else
+        options << { domain: space.branded_domain }
+      end
+    end
+
+    super
+  end
   private
 
   OPERATOR_TOKEN = ENV["OPERATOR_API_KEY"]

--- a/app/controllers/authenticated_sessions_controller.rb
+++ b/app/controllers/authenticated_sessions_controller.rb
@@ -17,6 +17,8 @@ class AuthenticatedSessionsController < ApplicationController
     end
   end
 
+  alias_method :update, :create
+
   def destroy
     authenticated_session.destroy
     redirect_to current_space

--- a/app/controllers/furniture_placements_controller.rb
+++ b/app/controllers/furniture_placements_controller.rb
@@ -4,7 +4,7 @@ class FurniturePlacementsController < ApplicationController
       if furniture_placement.save!
         format.html do
           redirect_to(
-            space_room_path(furniture_placement.room.space, furniture_placement.room),
+            [furniture_placement.room.space, furniture_placement.room],
             notice: t(".success", name: furniture_placement.furniture.model_name.human)
           )
         end
@@ -25,7 +25,7 @@ class FurniturePlacementsController < ApplicationController
       if furniture_placement.update!(furniture_placement_params)
         format.html do
           redirect_to(
-            edit_space_room_path(furniture_placement.room.space, furniture_placement.room),
+            [:edit, furniture_placement.room.space, furniture_placement.room],
             notice: t(".success", name: furniture_placement.furniture.model_name.human)
           )
         end
@@ -38,7 +38,7 @@ class FurniturePlacementsController < ApplicationController
     respond_to do |format|
       format.html do
         redirect_to(
-          space_room_path(furniture_placement.room.space, furniture_placement.room),
+          [furniture_placement.room.space, furniture_placement.room],
           notice: t(".success", name: furniture_placement.furniture.model_name.human.titleize)
         )
       end

--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -25,7 +25,7 @@ class MembershipsController < ApplicationController
 
     respond_to do |format|
       format.html do
-        redirect_to(space_memberships_path(membership.space))
+        redirect_to([membership.space, :memberships])
       end
 
       format.turbo_stream do

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -19,7 +19,7 @@ class RoomsController < ApplicationController
   def create
     if room.save
       flash[:notice] = t(".success", room_name: room.name)
-      redirect_to edit_space_room_path(room.space, room)
+      redirect_to [:edit, room.space, room]
     else
       render :new, status: :unprocessable_entity
     end
@@ -29,7 +29,7 @@ class RoomsController < ApplicationController
     respond_to do |format|
       if room.update(room_params)
         format.html do
-          redirect_to edit_space_path(room.space), notice: t(".success", room_name: room.name)
+          redirect_to [:edit, room.space], notice: t(".success", room_name: room.name)
         end
       else
         format.html { render :edit, status: :unprocessable_entity }
@@ -41,7 +41,7 @@ class RoomsController < ApplicationController
 
   def destroy
     if room.destroy
-      redirect_to edit_space_path(room.space), notice: t(".success", room_name: room.name)
+      redirect_to [:edit, room.space], notice: t(".success", room_name: room.name)
     else
       flash.now[:alert] = t(".failure", room_name: room.name)
       render :edit
@@ -69,16 +69,16 @@ class RoomsController < ApplicationController
     return unless room.persisted?
 
     unless room.enterable?(current_access_code(room))
-      redirect_to space_room_waiting_room_path(current_space, current_room, redirect_url: after_authorization_redirect_url)
+      redirect_to [current_space, current_room, :waiting_room, redirect_url: after_authorization_redirect_url]
     end
   end
 
   # TODO: Unit test authorize and redirect url
   private def after_authorization_redirect_url
     if %i[edit update].include?(action_name.to_sym)
-      return edit_space_room_path(room.space, room)
+      return url_for([:edit, room.space, room])
     end
 
-    space_room_path(room.space, room)
+    url_for([room.space, room])
   end
 end

--- a/app/controllers/spaces_controller.rb
+++ b/app/controllers/spaces_controller.rb
@@ -25,7 +25,7 @@ class SpacesController < ApplicationController
   def update
     if space.update(space_params)
       flash[:notice] = t(".success")
-      redirect_to space_path(space)
+      redirect_to space
     else
       flash.now[:alert] = t(".error")
       render :edit

--- a/app/controllers/utility_hookups_controller.rb
+++ b/app/controllers/utility_hookups_controller.rb
@@ -11,7 +11,7 @@ class UtilityHookupsController < ApplicationController
 
   def create
     if utility_hookup.save
-      redirect_to edit_space_path(space)
+      redirect_to [:edit, space]
     else
       render :new
     end
@@ -19,7 +19,7 @@ class UtilityHookupsController < ApplicationController
 
   def update
     if utility_hookup.update(utility_hookup_params)
-      redirect_to edit_space_path(space)
+      redirect_to [:edit, space]
     else
       render :edit
     end

--- a/app/helpers/rooms_helper.rb
+++ b/app/helpers/rooms_helper.rb
@@ -1,9 +1,5 @@
 module RoomsHelper
   def end_call_path(space)
-    if space.branded_domain.present?
-      "https://#{space.branded_domain}/"
-    else
-      space_path(space)
-    end
+    [space]
   end
 end

--- a/app/models/authenticated_session.rb
+++ b/app/models/authenticated_session.rb
@@ -25,7 +25,7 @@ class AuthenticatedSession
   end
 
   def persisted?
-    false
+    true
   end
 
   def destroy

--- a/app/views/authenticated_sessions/_form.html.erb
+++ b/app/views/authenticated_sessions/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: authenticated_session, url: space_authenticated_session_path(current_space), local: true do |form| %>
+<%= form_with model: [current_space, authenticated_session] do |form| %>
   <fieldset>
     <%- if form.object.contact_location.blank? %>
       <%= form.hidden_field :contact_method, value: :email %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -5,11 +5,11 @@
   <nav aria-label="Menu" class="profile-menu" data-person-email="<%= current_person.email %>">
     <%- if current_person.authenticated? %>
       <%- if current_membership.present? %>
-        <%= link_to "Account", space_membership_path(current_space, current_membership), title: current_membership.member.email %>
+        <%= link_to "Account", [current_space, current_membership], title: current_membership.member.email %>
       <%- end %>
-      <%= link_to "Sign out", space_authenticated_session_path(current_space), data: { turbo: true, turbo_method: :delete }, class: 'sign-out' %>
+      <%= link_to "Sign out", [current_space, :authenticated_session], data: { turbo: true, turbo_method: :delete }, class: 'sign-out' %>
     <%- else %>
-      <%= link_to "Sign in", new_space_authenticated_session_path(current_space), class: "sign-in" %>
+      <%= link_to "Sign in", [:new, current_space, :authenticated_session], class: "sign-in" %>
     <%- end %>
   </nav>
 </header>

--- a/app/views/spaces/_room_card.html.erb
+++ b/app/views/spaces/_room_card.html.erb
@@ -10,7 +10,7 @@
   </header>
   <footer>
     <div class="room-door_enter">
-      <%= link_to space_room_path(room.space, room) do %>
+      <%= link_to [room.space, room] do %>
         <span class="icon --enter" role="img" aria-label="Enter <%= room.name %>">Enter Room</span>
       <% end %>
     </div>

--- a/app/views/spaces/edit.html.erb
+++ b/app/views/spaces/edit.html.erb
@@ -17,7 +17,7 @@
     <%- space.rooms.each do |room| %>
       <%- if policy(room).edit? %>
         <div data-access-level="<%=room.access_level %>" data-slug="<%=room.slug%>" data-model="room" data-id="<%=room.id%>">
-          <%= link_to edit_space_room_path(room.space, room) do %>
+          <%= link_to [:edit, room.space, room] do %>
             <span class="icon --configure" role="img" aria-label="Configure"></span><%= room.name %>
           <% end %>
         </div>
@@ -26,7 +26,7 @@
   </div>
 
   <footer>
-    <%= link_to new_space_room_path(space) do %>
+    <%= link_to [:new, space, :room] do %>
       <span class="icon --add" role="img" aria-label="Add"></span>Add New Room
     <% end %>
   </footer>

--- a/app/views/utility_hookups/_form.html.erb
+++ b/app/views/utility_hookups/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: utility_hookup, url: space_utility_hookup_path(utility_hookup.space, utility_hookup), local: true) do |form| %>
+<%= form_with(model: [space, utility_hookup]) do |form| %>
   <%= form.hidden_field :utility_slug %>
   <header>
     <h4>

--- a/app/views/waiting_rooms/show.html.erb
+++ b/app/views/waiting_rooms/show.html.erb
@@ -2,11 +2,11 @@
 <div class="min-h-screen flex items-center justify-between">
   <div class="m-auto">
     <div class="bg-neutral-500 text-white font-extrabold px-8 py-4 rounded">
-      <%= current_room.name %>
+      <%= waiting_room.room.name %>
     </div>
   </div>
 
-  <%= form_with model: waiting_room, url: space_room_waiting_room_path(waiting_room.space, waiting_room.room), class: "access-code-form", local: true do |form| %>
+  <%= form_with model: [waiting_room.room.space, waiting_room.room, waiting_room], class: "access-code-form", local: true do |form| %>
     <%= render "password_field", form: form, attribute: :access_code%>
 
     <%= form.hidden_field :redirect_url %>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -3,20 +3,20 @@
 # @see https://github.com/kzkn/gretel
 crumb :root do
   if current_space.present?
-    link current_space.name, space_path(current_space)
+    link current_space.name, current_space
   else
     link t("home.title"), root_path
   end
 end
 
 crumb :edit_space do |space|
-  link "Configure Space", edit_space_path(space)
+  link "Configure Space", [:edit, space]
 end
 
 crumb :memberships do |space|
   link "Members", [space, :memberships]
   if policy(space).edit?
-    parent :edit_space, Space
+    parent :edit_space, space
   else
     parent :root
   end
@@ -33,7 +33,7 @@ crumb :invitations do |space|
 end
 
 crumb :utility_hookups do |space|
-  link "Utility Hookups", space_utility_hookups_path(space)
+  link "Utility Hookups", [space, :utility_hookups]
   parent :edit_space, space
 end
 
@@ -51,12 +51,12 @@ crumb :room do |room|
 end
 
 crumb :new_room do |room|
-  link t("helpers.submit.room.create"), new_space_room_path(room.space)
+  link t("helpers.submit.room.create"), [:new, room.space, :room]
   parent :edit_space, room.space
 end
 
 crumb :edit_room do |room|
-  link t("helpers.submit.room.edit", {room_name: room.name}), edit_space_room_path(room.space, room)
+  link t("helpers.submit.room.edit", {room_name: room.name}), [:edit, room.space, room]
   parent :room, room
 end
 
@@ -74,4 +74,3 @@ crumb :edit_furniture_placement do |furniture_placement|
   link "Configure #{furniture_placement.title}"
   parent :edit_room, furniture_placement.room
 end
-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
   # post "/auth/:provider/callback", "sessions#create"
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   resources :spaces, only: %I[show edit update create destroy] do
-    resource :authenticated_session, only: %i[new create destroy show]
+    resource :authenticated_session, only: %i[new create update destroy show]
 
     resources :invitations, only: %i[create destroy index] do
       resource :rsvp, only: %i[show update]
@@ -41,7 +41,19 @@ Rails.application.routes.draw do
   end
 
   constraints BrandedDomainConstraint.new(Space) do
-    resources :authenticated_sessions, only: %i[new create delete show]
+    get :edit, to: "spaces#edit"
+    get "/" => "spaces#show"
+    put "/" => "spaces#update"
+
+    resources :invitations, only: %i[create destroy index] do
+      resource :rsvp, only: %i[show update]
+    end
+
+    resources :memberships, only: %i[index show destroy]
+
+    resources :utility_hookups, only: %I[create edit update destroy index]
+
+    resource :authenticated_session, only: %i[new create update destroy show]
 
     resources :rooms, only: %i[show edit update new create destroy] do
       Furniture.append_routes(self)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,8 @@ Rails.application.routes.draw do
   constraints BrandedDomainConstraint.new(Space) do
     resources :authenticated_sessions, only: %i[new create delete show]
 
-    get "/:id", to: "rooms#show"
+    resources :rooms, only: %i[show edit update new create destroy] do
+      Furniture.append_routes(self)
+    end
   end
 end

--- a/features/harness/RoomEditPage.js
+++ b/features/harness/RoomEditPage.js
@@ -20,12 +20,12 @@ class RoomEditPage extends Page {
    * @param {AccessCode} accessCode
    * @returns {Promise<this>}
    */
-  async unlock(accessCode) {
+  unlock(accessCode) {
     const waitingRoom = new WaitingRoomPage(this.driver);
-    await waitingRoom.submitAccessCode(accessCode);
-    await this.accessLevel().select("unlocked");
-    await this.submitButton().click();
-    return this;
+    return waitingRoom.submitAccessCode(accessCode)
+      .then(() => this.accessLevel().select('unlocked'))
+      .then(() => this.submitButton().click())
+      .finally(() => this)
   }
   /**
    * @param {string} accessLevel

--- a/spec/requests/spaces/rooms_request_spec.rb
+++ b/spec/requests/spaces/rooms_request_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe "/spaces/:space_slug/rooms/", type: :request do
       it "removes the room" do
         delete path
         expect { room.reload }.to raise_error(ActiveRecord::RecordNotFound)
-        expect(response).to redirect_to(edit_space_path(room.space))
+        expect(response).to redirect_to([:edit, room.space])
         expect(flash[:notice]).to eql(I18n.t("rooms.destroy.success", room_name: room.name))
       end
     end

--- a/spec/requests/spaces/utility_hookups_spec.rb
+++ b/spec/requests/spaces/utility_hookups_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe "/spaces/:space_id/utility_hookups" do
     it "Updates the Utility Hookup" do
       expect { perform_request }.to(change { utility_hookup.reload.attributes })
 
-      expect(response).to redirect_to edit_space_path(space)
+      expect(response).to redirect_to [:edit, space]
       expect(utility_hookup.utility_slug).to eq(utility_hookup_attributes[:utility_slug])
       expect(utility_hookup.utility.configuration).to eq(utility_hookup_attributes[:utility_attributes])
     end
@@ -109,7 +109,7 @@ RSpec.describe "/spaces/:space_id/utility_hookups" do
       expect { perform_request }
         .to(change { space.utility_hookups.count }.by(1))
 
-      expect(response).to redirect_to edit_space_path(space)
+      expect(response).to redirect_to [:edit, space]
       expect(space.utility_hookups.last.utility_slug).to eql("jitsi")
       expect(space.utility_hookups.last.utility.configuration).to eq(utility_hookup_attributes[:utility_attributes])
     end

--- a/spec/requests/spaces_request_spec.rb
+++ b/spec/requests/spaces_request_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "/spaces/", type: :request do
         SystemTestSpace.prepare
 
         space = Space.find_by(slug: "system-test")
-        delete space_path(space),
+        delete polymorphic_path(space),
           headers: authorization_headers,
           as: :json
 
@@ -86,14 +86,14 @@ RSpec.describe "/spaces/", type: :request do
       end
 
       it "updates the theme" do
-        put space_path(space), params: {space: {theme: "desert_dunes"}}
+        put polymorphic_path(space), params: {space: {theme: "desert_dunes"}}
 
         expect(space.reload.theme).to eq("desert_dunes")
         expect(flash[:notice]).to include("successfully updated")
       end
 
       it "shows an error message with an invalid theme" do
-        put space_path(space), params: {space: {theme: "bogus_theme"}}
+        put polymorphic_path(space), params: {space: {theme: "bogus_theme"}}
 
         expect(space.reload.theme).to eq("purple_mountains")
         expect(flash[:alert]).to include("went wrong")


### PR DESCRIPTION
https://github.com/zinc-collective/convene/issues/74

This had been bugging me for a bit, where the paths on the page would always include the spaces, even if they were being routed to a custom domain.

Now, we send folks to the domain that the space claims and drop the Space from the path, but only on urls built using Rails Polymorphic url builders.

For example:

`space_room_path(space, room)` will still go to
`current_domain.example.com/spaces/:space_id/rooms/:room_id`, while `url_for([space, room])` or `link_to([space, room])` will go to
`space_domain.example.com/rooms/:room_id`