### PR TITLE
Spaces: Support Sub-domains in BYO Domains

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -42,11 +42,11 @@ class ApplicationController < ActionController::Base
 
     # Appends the domain to the options passed to `url_for`
     if options.respond_to?(:last) && options.last.is_a?(Hash)
-      options.last[:domain] = space.branded_domain
+      options.last[:host] = space.branded_domain
     elsif options.respond_to?(:<<) && options.length > 0
-      options << {domain: space.branded_domain}
+      options << {host: space.branded_domain}
     else
-      options = [:root, {domain: space.branded_domain}]
+      options = [:root, {host: space.branded_domain}]
     end
 
     super

--- a/spec/requests/spaces_controller_request_spec.rb
+++ b/spec/requests/spaces_controller_request_spec.rb
@@ -2,8 +2,20 @@
 
 require "swagger_helper"
 
-RSpec.describe "/spaces/", type: :request do
+RSpec.describe SpacesController, type: :request do
   include ActiveJob::TestHelper
+
+  describe "#show" do
+    context "with a branded domain" do
+      let(:space) { create(:space, branded_domain: "beta.example.com") }
+
+      it "links to the domain" do
+        get polymorphic_path(space)
+
+        expect(response.body).to include "//beta.example.com/"
+      end
+    end
+  end
 
   path "/spaces" do
     include ApiHelpers::Path
@@ -56,7 +68,7 @@ RSpec.describe "/spaces/", type: :request do
       end
     end
   end
-  describe "DELETE /spaces/:space_slug/" do
+  describe "#destroy" do
     context "as an Operator using the API" do
       it "deletes the space and all it's other bits" do
         SystemTestSpace.prepare
@@ -77,8 +89,8 @@ RSpec.describe "/spaces/", type: :request do
     end
   end
 
-  describe "PUT /space/:space_slug" do
-    context "as a Space Member" do
+  describe "#update" do
+    context "when a Space Member" do
       let(:space) { create(:space, :with_members, theme: "purple_mountains") }
 
       before do


### PR DESCRIPTION
https://github.com/zinc-collective/convene/issues/23
https://github.com/zinc-collective/convene/issues/74

When I was testing #74 on https://beta.zeespencer.com/ I discovered that it didn't quite work, and was nesting sub-domains (i.e. `beta.zeespencer.com` became `beta.beta.zeespencer.com`)

This is likely because the [`domain` option for `url_for`](http://api.rubyonrails.org/classes/ActionDispatch/Routing/UrlFor.html#method-i-url_for) doesn't actually do the whole domain; just the TLD!

Womp womp!