### PR TITLE
Update CheckoutPolicy to match spec expectations

### DIFF
--- a/app/furniture/marketplace/checkout_policy.rb
+++ b/app/furniture/marketplace/checkout_policy.rb
@@ -11,7 +11,7 @@ class Marketplace
     end
 
     def show?
-      true
+      create?
     end
   end
 end


### PR DESCRIPTION
(this PR is for merging into WIP https://github.com/zinc-collective/convene/pull/1031)

This PR updates the `CheckoutPolicy` implementation to satisfy the expectations in the spec. I do not know if this is precisely the behavior we want -- e.g. maybe we want a "marketplace admin" (space owner?) to be able to always see a Checkout -- but we can expand the behavior later.

This fixes the test failures in https://github.com/zinc-collective/convene/pull/1031