### PR TITLE
Marketplace: Differentiate between Checkout and Order

### DIFF
--- a/app/furniture/furniture.rb
+++ b/app/furniture/furniture.rb
@@ -15,6 +15,7 @@ module Furniture
   def self.append_routes(router)
     REGISTRY.each_value do |furniture|
       furniture.append_routes(router) if furniture.respond_to?(:append_routes)
+      furniture.const_get(:Routes).append_routes(router) if furniture.const_defined?(:Routes)
     end
   end
 

--- a/app/furniture/marketplace.rb
+++ b/app/furniture/marketplace.rb
@@ -1,15 +1,5 @@
 # @see features/furniture/marketplace.feature.md
 class Marketplace
-  def self.append_routes(router)
-    router.resources :marketplaces, only: [:show, :edit, :update], module: "marketplace" do
-      router.resources :products
-      router.resources :carts do
-        router.resources :cart_products
-      end
-      router.resources :checkouts, only: [:show, :create]
-    end
-  end
-
   def self.from_placement(placement)
     placement.becomes(Marketplace)
   end

--- a/app/furniture/marketplace/breadcrumbs.rb
+++ b/app/furniture/marketplace/breadcrumbs.rb
@@ -22,7 +22,6 @@ crumb :marketplace_order do |order|
   link "Order from #{order.created_at.to_fs(:long_ordinal)}", order.location
 end
 
-
 crumb :marketplace_products do |marketplace|
   parent :edit_marketplace, marketplace
   link t("marketplace.product.index"), marketplace.location(child: :products)

--- a/app/furniture/marketplace/breadcrumbs.rb
+++ b/app/furniture/marketplace/breadcrumbs.rb
@@ -17,6 +17,12 @@ crumb :marketplace_checkout do |checkout|
   link "Checkout", checkout.location
 end
 
+crumb :marketplace_order do |order|
+  parent :marketplace, order.marketplace
+  link "Order from #{order.created_at.to_fs(:long_ordinal)}", order.location
+end
+
+
 crumb :marketplace_products do |marketplace|
   parent :edit_marketplace, marketplace
   link t("marketplace.product.index"), marketplace.location(child: :products)

--- a/app/furniture/marketplace/cart.rb
+++ b/app/furniture/marketplace/cart.rb
@@ -12,7 +12,7 @@ class Marketplace
     has_many :cart_products, dependent: :destroy, inverse_of: :cart
     has_many :products, through: :cart_products, inverse_of: :carts
     has_one :checkout, inverse_of: :cart
-    has_one :order, inverse_of: :cart, class_name: "Order"
+    has_one :order, inverse_of: :cart
 
     enum status: {
       pre_checkout: "pre_checkout",

--- a/app/furniture/marketplace/cart.rb
+++ b/app/furniture/marketplace/cart.rb
@@ -12,6 +12,7 @@ class Marketplace
     has_many :cart_products, dependent: :destroy, inverse_of: :cart
     has_many :products, through: :cart_products, inverse_of: :carts
     has_one :checkout, inverse_of: :cart
+    has_one :order, inverse_of: :cart, class_name: "Order"
 
     enum status: {
       pre_checkout: "pre_checkout",

--- a/app/furniture/marketplace/cart_products_controller.rb
+++ b/app/furniture/marketplace/cart_products_controller.rb
@@ -1,5 +1,5 @@
 class Marketplace
-  class CartProductsController < FurnitureController
+  class CartProductsController < Controller
     def create
       authorize(cart_product)
       cart_product.save
@@ -96,10 +96,6 @@ class Marketplace
 
     def cart
       marketplace.carts.find(params[:cart_id])
-    end
-
-    helper_method def marketplace
-      @marketplace ||= policy_scope(Marketplace).find(params[:marketplace_id])
     end
 
     def cart_product_params

--- a/app/furniture/marketplace/checkout.rb
+++ b/app/furniture/marketplace/checkout.rb
@@ -5,9 +5,10 @@ class Marketplace
     self.location_parent = :marketplace
 
     belongs_to :cart, inverse_of: :checkout
+    delegate :marketplace, to: :cart
 
     has_many :ordered_products, through: :cart, source: :cart_products, class_name: "Marketplace::OrderedProduct"
-    delegate :marketplace, to: :cart
+
     belongs_to :shopper, inverse_of: :checkouts
 
     # It would be nice to validate instead the presence of :ordered_products, but my attempts at this raise:
@@ -36,6 +37,11 @@ class Marketplace
       }, {
         api_key: marketplace.stripe_api_key
       })
+    end
+
+    def complete(stripe_session_id:)
+      update!(status: :paid, stripe_session_id: stripe_session_id)
+      cart.update!(status: :checked_out)
     end
 
     private

--- a/app/furniture/marketplace/checkouts/show.html.erb
+++ b/app/furniture/marketplace/checkouts/show.html.erb
@@ -1,2 +1,0 @@
-<%- breadcrumb :marketplace_checkout, checkout%>
-<%= render checkout %>

--- a/app/furniture/marketplace/checkouts_controller.rb
+++ b/app/furniture/marketplace/checkouts_controller.rb
@@ -4,7 +4,7 @@ class Marketplace
       authorize(checkout)
       if params[:stripe_session_id].present?
         checkout.complete(stripe_session_id: params[:stripe_session_id])
-        flash[:notice] = t('.success')
+        flash[:notice] = t(".success")
       end
       redirect_to checkout.becomes(Order).location
     end

--- a/app/furniture/marketplace/checkouts_controller.rb
+++ b/app/furniture/marketplace/checkouts_controller.rb
@@ -1,12 +1,12 @@
 class Marketplace
-  class CheckoutsController < FurnitureController
+  class CheckoutsController < Controller
     def show
       authorize(checkout)
       if params[:stripe_session_id].present?
-        checkout.update!(status: :paid, stripe_session_id: params[:stripe_session_id])
-        checkout.cart.update!(status: :checked_out)
-        flash[:notice] = t(".success")
+        checkout.complete(stripe_session_id: params[:stripe_session_id])
+        flash[:notice] = t('.success')
       end
+      redirect_to checkout.becomes(Order).location
     end
 
     def create
@@ -35,20 +35,8 @@ class Marketplace
       end
     end
 
-    helper_method def shopper
-      @shopper ||= if current_person.is_a?(Guest)
-        Shopper.find_or_create_by(id: session[:guest_shopper_id] ||= SecureRandom.uuid)
-      else
-        Shopper.find_or_create_by(person: current_person)
-      end
-    end
-
     helper_method def cart
       @cart ||= marketplace.carts.find_or_create_by(shopper: shopper, status: :pre_checkout)
-    end
-
-    helper_method def marketplace
-      @marketplace ||= policy_scope(Marketplace).find(params[:marketplace_id])
     end
   end
 end

--- a/app/furniture/marketplace/controller.rb
+++ b/app/furniture/marketplace/controller.rb
@@ -1,0 +1,15 @@
+class Marketplace
+  class Controller < FurnitureController
+    helper_method def marketplace
+      @marketplace ||= policy_scope(Marketplace).find(params[:marketplace_id])
+    end
+
+    helper_method def shopper
+      @shopper ||= if current_person.is_a?(Guest)
+        Shopper.find_or_create_by(id: session[:guest_shopper_id] ||= SecureRandom.uuid)
+      else
+        Shopper.find_or_create_by(person: current_person)
+      end
+    end
+  end
+end

--- a/app/furniture/marketplace/marketplace.rb
+++ b/app/furniture/marketplace/marketplace.rb
@@ -6,6 +6,7 @@ class Marketplace
 
     has_many :products, inverse_of: :marketplace, dependent: :destroy
     has_many :carts, inverse_of: :marketplace, dependent: :destroy
+    has_many :orders, through: :carts
 
     # The Secret Stripe API key belonging to the owner of the Marketplace
     def stripe_api_key=(key)

--- a/app/furniture/marketplace/order.rb
+++ b/app/furniture/marketplace/order.rb
@@ -1,0 +1,5 @@
+class Marketplace
+  class Order < Checkout
+    self.location_parent = :marketplace
+  end
+end

--- a/app/furniture/marketplace/order_policy.rb
+++ b/app/furniture/marketplace/order_policy.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class Marketplace
+  class OrderPolicy < CheckoutPolicy
+    alias_method :order, :object
+
+    def show?
+      create?
+    end
+
+    class Scope < ApplicationScope
+      def resolve
+        scope.all
+      end
+    end
+  end
+end

--- a/app/furniture/marketplace/orders/_order.html.erb
+++ b/app/furniture/marketplace/orders/_order.html.erb
@@ -1,4 +1,4 @@
-<h1>Ordered on <%= checkout.created_at.to_fs(:long_ordinal) %>
+<h1>Ordered on <%= order.created_at.to_fs(:long_ordinal) %>
 <div class="-mx-4 mt-8 overflow-hidden shadow ring-1 ring-black ring-opacity-5 sm:-mx-6 md:mx-0 md:rounded-lg">
   <table class="min-w-full divide-y divide-gray-300 table-fixed">
     <thead class="bg-gray-50">
@@ -16,14 +16,14 @@
       </tr>
     </thead>
     <tbody class="divide-y divide-gray-200 bg-white">
-      <%= render checkout.ordered_products %>
+      <%= render order.ordered_products %>
     </tbody>
-    <tfoot id="checkout-footer-<%= checkout.id%>" class="bg-gray-50">
+    <tfoot id="checkout-footer-<%= order.id%>" class="bg-gray-50">
       <tr>
         <td></td>
         <th scope="row" class="text-right px-1 py-3.5">Total: </th>
         <td class="text-left px-3 py-3.5 font-bold">
-          <%= render "marketplace/carts/total" %>
+          <%= render "marketplace/carts/total", cart: order.cart %>
         </td>
       </tr>
     </tfoot>

--- a/app/furniture/marketplace/orders/show.html.erb
+++ b/app/furniture/marketplace/orders/show.html.erb
@@ -1,0 +1,2 @@
+<%- breadcrumb :marketplace_order, order%>
+<%= render order %>

--- a/app/furniture/marketplace/orders_controller.rb
+++ b/app/furniture/marketplace/orders_controller.rb
@@ -1,0 +1,11 @@
+class Marketplace
+  class OrdersController < Controller
+    def show
+      authorize(order)
+    end
+
+    helper_method def order
+      policy_scope(marketplace.orders).find(params[:id])
+    end
+  end
+end

--- a/app/furniture/marketplace/products_controller.rb
+++ b/app/furniture/marketplace/products_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Marketplace
-  class ProductsController < FurnitureController
+  class ProductsController < Controller
     def new
       authorize(marketplace.products.new)
     end
@@ -39,10 +39,6 @@ class Marketplace
       else
         render :edit
       end
-    end
-
-    helper_method def marketplace
-      @marketplace ||= policy_scope(Marketplace).find(params[:marketplace_id])
     end
 
     helper_method def product

--- a/app/furniture/marketplace/routes.rb
+++ b/app/furniture/marketplace/routes.rb
@@ -1,0 +1,14 @@
+class Marketplace
+  class Routes
+    def self.append_routes(router)
+      router.resources :marketplaces, only: [:show, :edit, :update], module: "marketplace" do
+        router.resources :orders, only: [:show]
+        router.resources :products
+        router.resources :carts do
+          router.resources :cart_products
+        end
+        router.resources :checkouts, only: [:show, :create]
+      end
+    end
+  end
+end

--- a/spec/furniture/marketplace/checkouts_controller_request_spec.rb
+++ b/spec/furniture/marketplace/checkouts_controller_request_spec.rb
@@ -11,9 +11,10 @@ RSpec.describe Marketplace::Checkout, type: :request do
 
     context "when a stripe_session_id is in the params" do
       it "marks the cart as checked out" do
-        get polymorphic_path([space, room, marketplace, checkout], {stripe_session_id: "12345"})
+        get polymorphic_path(checkout.location, { stripe_session_id: "12345" })
         expect(cart.reload).to be_checked_out
         expect(checkout.reload).to be_paid
+        expect(response).to redirect_to(checkout.becomes(Marketplace::Order).location)
       end
     end
   end

--- a/spec/furniture/marketplace/checkouts_controller_request_spec.rb
+++ b/spec/furniture/marketplace/checkouts_controller_request_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Marketplace::Checkout, type: :request do
 
     context "when a stripe_session_id is in the params" do
       it "marks the cart as checked out" do
-        get polymorphic_path(checkout.location, { stripe_session_id: "12345" })
+        get polymorphic_path(checkout.location, {stripe_session_id: "12345"})
         expect(cart.reload).to be_checked_out
         expect(checkout.reload).to be_paid
         expect(response).to redirect_to(checkout.becomes(Marketplace::Order).location)


### PR DESCRIPTION
https://github.com/zinc-collective/convene/issues/831

Where `Checkout` is useful for handling a Checkout flow for the Payment Processor, it doesn't make a ton of sense from a Buyer perspective once the Cart has been Checked out.

I've sprouted an `Order` model, with corresponding Controllers, and moved the `checkouts/show` and `checkouts/_checkout` views to `orders/show` and `orders/_order`.