### PR TITLE
Lint: Apparently `standard` and `standardrb` are different

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -109,8 +109,8 @@ group :development, :test do
 
   gem "rubocop-rails"
   gem "rubocop-rspec"
-  gem "standardrb", "~> 1.0"
-  gem "solargraph", "~> 0.48.0"
+  gem "standard", "~> 1.0"
+  gem "solargraph", "~> 0.48"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,6 +164,7 @@ GEM
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
+    language_server-protocol (3.17.0.2)
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -176,7 +177,7 @@ GEM
     marcel (1.0.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
-    mini_portile2 (2.8.0)
+    mini_portile2 (2.8.1)
     minitest (5.17.0)
     monetize (1.12.0)
       money (~> 6.12)
@@ -203,7 +204,7 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
-    nokogiri (1.13.10)
+    nokogiri (1.14.0)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     parallel (1.22.1)
@@ -221,7 +222,7 @@ GEM
       nio4r (~> 2.0)
     pundit (2.3.0)
       activesupport (>= 3.0.0)
-    racc (1.6.1)
+    racc (1.6.2)
     rack (2.2.6.2)
     rack-test (2.0.2)
       rack (>= 1.3)
@@ -302,20 +303,23 @@ GEM
     rswag-ui (2.8.0)
       actionpack (>= 3.1, < 7.1)
       railties (>= 3.1, < 7.1)
-    rubocop (1.43.0)
+    rubocop (1.42.0)
       json (~> 2.3)
       parallel (~> 1.10)
-      parser (>= 3.2.0.0)
+      parser (>= 3.1.2.1)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
       rubocop-ast (>= 1.24.1, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 2.4.0, < 3.0)
+      unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.24.1)
       parser (>= 3.1.1.0)
     rubocop-capybara (2.17.0)
       rubocop (~> 1.41)
+    rubocop-performance (1.15.2)
+      rubocop (>= 1.7.0, < 2.0)
+      rubocop-ast (>= 0.4.0)
     rubocop-rails (2.17.4)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
@@ -367,10 +371,10 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    standard (0.0.36)
-      rubocop (>= 0.63)
-    standardrb (1.0.1)
-      standard
+    standard (1.22.1)
+      language_server-protocol (~> 3.17.0.2)
+      rubocop (= 1.42.0)
+      rubocop-performance (= 1.15.2)
     stimulus-rails (1.2.1)
       railties (>= 6.0.0)
     stripe (8.1.0)
@@ -449,11 +453,11 @@ DEPENDENCIES
   shoulda-matchers (~> 5.3)
   sidekiq
   simplecov
-  solargraph (~> 0.48.0)
+  solargraph (~> 0.48)
   spring
   spring-watcher-listen!
   sprockets-rails
-  standardrb (~> 1.0)
+  standard (~> 1.0)
   stimulus-rails
   stripe
   turbo-rails

--- a/app/components/icon_button_component.rb
+++ b/app/components/icon_button_component.rb
@@ -20,8 +20,8 @@ class IconButtonComponent < ViewComponent::Base
   private
 
   def data
-    data = { turbo_method: @method, turbo: true }
-    data.merge!({ turbo_confirm: @confirm, confirm: @confirm }) if @confirm.present?
+    data = {turbo_method: @method, turbo: true}
+    data.merge!({turbo_confirm: @confirm, confirm: @confirm}) if @confirm.present?
     data
   end
 end

--- a/app/controllers/furniture_placements_controller.rb
+++ b/app/controllers/furniture_placements_controller.rb
@@ -1,4 +1,11 @@
 class FurniturePlacementsController < ApplicationController
+  def edit
+    respond_to do |format|
+      format.turbo_stream
+      format.html
+    end
+  end
+
   def create
     respond_to do |format|
       if furniture_placement.save!
@@ -10,13 +17,6 @@ class FurniturePlacementsController < ApplicationController
         end
         format.turbo_stream
       end
-    end
-  end
-
-  def edit
-    respond_to do |format|
-      format.turbo_stream
-      format.html
     end
   end
 

--- a/app/furniture/furniture.rb
+++ b/app/furniture/furniture.rb
@@ -8,7 +8,7 @@ module Furniture
     markdown_text_block: MarkdownTextBlock,
     marketplace: Marketplace,
     livestream: Livestream,
-    embedded_form: EmbeddedForm,
+    embedded_form: EmbeddedForm
   }.freeze
 
   # Appends each Furnitures CRUD actions within the {Room}

--- a/app/furniture/marketplace/breadcrumbs.rb
+++ b/app/furniture/marketplace/breadcrumbs.rb
@@ -9,7 +9,7 @@ end
 
 crumb :edit_marketplace do |marketplace|
   parent :room, marketplace.room
-  link t('marketplace.marketplace.edit'), marketplace.location(:edit)
+  link t("marketplace.marketplace.edit"), marketplace.location(:edit)
 end
 
 crumb :marketplace_checkout do |checkout|
@@ -19,7 +19,7 @@ end
 
 crumb :marketplace_products do |marketplace|
   parent :edit_marketplace, marketplace
-  link  t('marketplace.product.index'), marketplace.location(child: :products)
+  link t("marketplace.product.index"), marketplace.location(child: :products)
 end
 
 crumb :marketplace_product do |product|

--- a/app/furniture/marketplace/cart.rb
+++ b/app/furniture/marketplace/cart.rb
@@ -2,7 +2,7 @@
 
 class Marketplace
   class Cart < ApplicationRecord
-    self.table_name = 'marketplace_carts'
+    self.table_name = "marketplace_carts"
     include WithinLocation
     self.location_parent = :marketplace
 

--- a/app/furniture/marketplace/cart_product_policy.rb
+++ b/app/furniture/marketplace/cart_product_policy.rb
@@ -2,7 +2,7 @@
 
 class Marketplace
   class CartProductPolicy < ApplicationPolicy
-    alias cart_product object
+    alias_method :cart_product, :object
     def permitted_attributes(_params = nil)
       %i[quantity product_id]
     end

--- a/app/furniture/marketplace/cart_products_controller.rb
+++ b/app/furniture/marketplace/cart_products_controller.rb
@@ -24,8 +24,8 @@ class Marketplace
             turbo_stream.replace("cart-product-#{cart_product.product_id}", cart_product),
             turbo_stream.replace("cart-footer-#{cart.id}",
               partial: "marketplace/carts/footer", locals: {cart: cart}),
-              turbo_stream.replace("cart-total-#{cart.id}", partial: "marketplace/carts/total", locals: {cart: cart})
-            ]
+            turbo_stream.replace("cart-total-#{cart.id}", partial: "marketplace/carts/total", locals: {cart: cart})
+          ]
         end
       end
     end

--- a/app/furniture/marketplace/checkout.rb
+++ b/app/furniture/marketplace/checkout.rb
@@ -10,7 +10,6 @@ class Marketplace
     delegate :marketplace, to: :cart
     belongs_to :shopper, inverse_of: :checkouts
 
-
     # It would be nice to validate instead the presence of :ordered_products, but my attempts at this raise:
     #  ActiveRecord::HasManyThroughCantAssociateThroughHasOneOrManyReflection:
     #   Cannot modify association 'Marketplace::Checkout#ordered_products' because the source reflection class 'CartProduct' is associated to 'Cart' via :has_many.
@@ -18,15 +17,14 @@ class Marketplace
 
     enum status: {
       pre_checkout: "pre_checkout",
-      paid: "paid",
+      paid: "paid"
     }
 
     def self.model_name
       @_model_name ||= ActiveModel::Name.new(self, ::Marketplace)
     end
 
-
-    def create_stripe_session(success_url: , cancel_url: )
+    def create_stripe_session(success_url:, cancel_url:)
       Stripe::Checkout::Session.create({
         line_items: stripe_line_items,
         mode: "payment",
@@ -53,7 +51,7 @@ class Marketplace
             product_data: {name: cart_product.product.name}
           },
           quantity: cart_product.quantity,
-          adjustable_quantity: { enabled: true }
+          adjustable_quantity: {enabled: true}
         }
       end
     end

--- a/app/furniture/marketplace/checkouts_controller.rb
+++ b/app/furniture/marketplace/checkouts_controller.rb
@@ -1,12 +1,11 @@
 class Marketplace
   class CheckoutsController < FurnitureController
-
     def show
       authorize(checkout)
       if params[:stripe_session_id].present?
         checkout.update!(status: :paid, stripe_session_id: params[:stripe_session_id])
         checkout.cart.update!(status: :checked_out)
-        flash[:notice] = t('.success')
+        flash[:notice] = t(".success")
       end
     end
 

--- a/app/furniture/marketplace/marketplaces_controller.rb
+++ b/app/furniture/marketplace/marketplaces_controller.rb
@@ -11,9 +11,9 @@ class Marketplace
 
     def update
       if marketplace.update(params[:marketplace].permit([:stripe_api_key]))
-        redirect_to marketplace.location(:edit), notice: t('.success')
+        redirect_to marketplace.location(:edit), notice: t(".success")
       else
-        flash[:alert] = t('.failure')
+        flash[:alert] = t(".failure")
         render :edit, status: :unprocessable_entity
       end
     end

--- a/app/furniture/marketplace/product.rb
+++ b/app/furniture/marketplace/product.rb
@@ -2,7 +2,7 @@
 
 class Marketplace
   class Product < ApplicationRecord
-    self.table_name = 'marketplace_products'
+    self.table_name = "marketplace_products"
     include WithinLocation
     self.location_parent = :marketplace
 

--- a/app/furniture/marketplace/product_policy.rb
+++ b/app/furniture/marketplace/product_policy.rb
@@ -2,7 +2,7 @@
 
 class Marketplace
   class ProductPolicy < ApplicationPolicy
-    alias product object
+    alias_method :product, :object
     def permitted_attributes(_params = nil)
       %i[name description price_cents price_currency price]
     end

--- a/app/furniture/marketplace/shopper.rb
+++ b/app/furniture/marketplace/shopper.rb
@@ -2,7 +2,7 @@
 
 class Marketplace
   class Shopper < ApplicationRecord
-    self.table_name = 'marketplace_shoppers'
+    self.table_name = "marketplace_shoppers"
 
     belongs_to :person, optional: true
     has_many :carts, inverse_of: :shopper

--- a/app/models/blueprint.rb
+++ b/app/models/blueprint.rb
@@ -105,7 +105,7 @@ class Blueprint
   BLUEPRINTS = {
     system_test: {
       entrance: "entrance-hall",
-      utility_hookups: [ ],
+      utility_hookups: [],
       members: [{email: "space-owner@example.com"},
         {email: "space-member@example.com"}],
       rooms: [
@@ -115,7 +115,7 @@ class Blueprint
           access_level: :unlocked,
           access_code: nil,
           furniture_placements: {
-            markdown_text_block: {content: "# Welcome!"},
+            markdown_text_block: {content: "# Welcome!"}
           }
         },
         {
@@ -123,35 +123,34 @@ class Blueprint
           publicity_level: :listed,
           access_level: :unlocked,
           access_code: nil,
-          furniture_placements: {
-          }
+          furniture_placements: {}
         },
         {
           name: "Listed Locked Room 1",
           publicity_level: :listed,
           access_level: :locked,
           access_code: :secret,
-          furniture_placements: { }
+          furniture_placements: {}
         },
         {
           name: "Unlisted Room 1",
           publicity_level: :unlisted,
           access_level: :unlocked,
           access_code: nil,
-          furniture_placements: { }
+          furniture_placements: {}
         },
         {
           name: "Unlisted Room 2",
           publicity_level: :unlisted,
           access_level: :unlocked,
           access_code: nil,
-          furniture_placements: { }
+          furniture_placements: {}
         },
         {
           name: "Entrance Hall",
           publicity_level: :unlisted,
           furniture_placements: {
-            markdown_text_block: {content: "# Wooo!"},
+            markdown_text_block: {content: "# Wooo!"}
           }
         }
       ]

--- a/app/models/utility_hookup.rb
+++ b/app/models/utility_hookup.rb
@@ -9,7 +9,7 @@ class UtilityHookup < ApplicationRecord
   # has multiple {UtilityHookup}s.
   # @return [String]
   attribute :name, :string
-  validates :name, presence: :true, uniqueness: { scope: :space_id }
+  validates :name, presence: :true, uniqueness: {scope: :space_id}
 
   def name
     self[:name] ||= utility_slug.to_s.humanize

--- a/config/initializers/money.rb
+++ b/config/initializers/money.rb
@@ -82,7 +82,7 @@ MoneyRails.configure do |config|
   #   sign_before_symbol: nil
   # }
 
-  config.default_format = { no_cents_if_whole: false }
+  config.default_format = {no_cents_if_whole: false}
   config.no_cents_if_whole = false
 
   # If you would like to use I18n localization (formatting depends on the

--- a/db/migrate/20221208013832_add_shopper_to_marketplace_carts.rb
+++ b/db/migrate/20221208013832_add_shopper_to_marketplace_carts.rb
@@ -1,6 +1,6 @@
 class AddShopperToMarketplaceCarts < ActiveRecord::Migration[7.0]
   def change
-    create_table :marketplace_shoppers, id: :uuid  do |t|
+    create_table :marketplace_shoppers, id: :uuid do |t|
       t.references(:person, type: :uuid, foreign_key: {to_table: :people}, index: {unique: true})
       t.timestamps
     end

--- a/spec/components/icon_button_component_spec.rb
+++ b/spec/components/icon_button_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe IconButtonComponent, type: :component do
     subject { render_inline(component) }
 
     let(:component) { described_class.new(**params) }
-    let(:params) { { label: "Some label", title: "Our Title", href: "somewhere.com" } }
+    let(:params) { {label: "Some label", title: "Our Title", href: "somewhere.com"} }
 
     let(:a_el) { subject.at_css("a") }
 
@@ -19,7 +19,7 @@ RSpec.describe IconButtonComponent, type: :component do
     end
 
     context "when confirm is false" do
-      let(:component) { described_class.new(**params.merge({ confirm: false })) }
+      let(:component) { described_class.new(**params.merge({confirm: false})) }
 
       it "does not include confirm nor turbo-confirm" do
         expect(a_el.attributes).not_to include("data-confirm")
@@ -29,7 +29,7 @@ RSpec.describe IconButtonComponent, type: :component do
 
     context "when confirm is present" do
       let(:confirm_text) { "you sure????" }
-      let(:component) { described_class.new(**params.merge({ confirm: confirm_text })) }
+      let(:component) { described_class.new(**params.merge({confirm: confirm_text})) }
 
       it "includes confirm and turbo-confirm" do
         expect(a_el.attributes["data-confirm"].value).to eq(confirm_text)
@@ -38,7 +38,7 @@ RSpec.describe IconButtonComponent, type: :component do
     end
 
     context "when disabled is true" do
-      let(:component) { described_class.new(**params.merge({ disabled: true })) }
+      let(:component) { described_class.new(**params.merge({disabled: true})) }
 
       it "does not render a link" do
         expect(a_el).not_to be_present

--- a/spec/furniture/marketplace/checkouts_controller_request_spec.rb
+++ b/spec/furniture/marketplace/checkouts_controller_request_spec.rb
@@ -7,10 +7,11 @@ RSpec.describe Marketplace::Checkout, type: :request do
 
   describe "#show" do
     let!(:cart) { create(:marketplace_cart, :with_products, marketplace: marketplace) }
-    let(:checkout) { create(:marketplace_checkout, cart: cart, shopper: cart.shopper)}
+    let(:checkout) { create(:marketplace_checkout, cart: cart, shopper: cart.shopper) }
+
     context "when a stripe_session_id is in the params" do
       it "marks the cart as checked out" do
-        get polymorphic_path([space, room, marketplace, checkout], { stripe_session_id: "12345" })
+        get polymorphic_path([space, room, marketplace, checkout], {stripe_session_id: "12345"})
         expect(cart.reload).to be_checked_out
         expect(checkout.reload).to be_paid
       end
@@ -29,7 +30,7 @@ RSpec.describe Marketplace::Checkout, type: :request do
 
     before do
       allow(Stripe::Checkout::Session).to receive(:create).and_return(stripe_checkout_session)
-      allow_any_instance_of(ApplicationController).to receive(:session).and_return({ guest_shopper_id: cart.shopper.id })
+      allow_any_instance_of(ApplicationController).to receive(:session).and_return({guest_shopper_id: cart.shopper.id})
     end
 
     context "when a Guest checks out their Cart" do

--- a/spec/furniture/marketplace/product_policy_spec.rb
+++ b/spec/furniture/marketplace/product_policy_spec.rb
@@ -1,8 +1,9 @@
 require "rails_helper"
 
 RSpec.describe Marketplace::ProductPolicy do
-  describe '#permitted_attributes' do
-    subject(':permitted_attributes') { Marketplace::ProductPolicy.new(nil, nil).permitted_attributes }
-    it {is_expected.to include :price}
+  describe "#permitted_attributes" do
+    subject(:":permitted_attributes") { Marketplace::ProductPolicy.new(nil, nil).permitted_attributes }
+
+    it { is_expected.to include :price }
   end
 end

--- a/spec/models/furniture_placement_spec.rb
+++ b/spec/models/furniture_placement_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe FurniturePlacement do
 
   describe "#furniture" do
     it "returns the configured piece of furniture" do
-      furniture_placement = build(:furniture_placement, settings: { content: "# A Block"})
+      furniture_placement = build(:furniture_placement, settings: {content: "# A Block"})
 
       expect(furniture_placement.furniture).to be_a(MarkdownTextBlock)
       expect(furniture_placement.furniture.content).to eql("# A Block")

--- a/spec/requests/utility_hookups_controller_request_spec.rb
+++ b/spec/requests/utility_hookups_controller_request_spec.rb
@@ -6,7 +6,7 @@ require "support/shared_examples/a_space_member_only_route"
 RSpec.describe UtilityHookupsController do
   let(:space) { create(:space, :with_members) }
   let(:utility_hookup_attributes) do
-    attributes_for(:utility_hookup, :stripe).merge(utility_attributes: { "api_token" => "fake-token" })
+    attributes_for(:utility_hookup, :stripe).merge(utility_attributes: {"api_token" => "fake-token"})
   end
   let(:utility_hookup) { create(:utility_hookup, space: space) }
 


### PR DESCRIPTION
So, I noticed a giant pile of red errors when rubocop was running; which was like... ok... and then it turned out that we were using the `standardrb` gem, which is not the same as the `standard` gem; so it was out of date...

So I updated *that* and then ran `bin/rubocop -a` which made a bajillion changes...

Computers are bad.