### PR TITLE
Neighborhood: Support Cloudflare SSL w/Heroku

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  config.force_ssl = ENV.fetch('FORCE_SSL', true) != 'false'
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
See:
- https://developers.cloudflare.com/ssl/edge-certificates/encrypt-visitor-traffic/
- https://support.cloudflare.com/hc/en-us/articles/205893698-Configure-Cloudflare-and-Heroku-over-HTTPS

So, apparently if you force ssl when you're using Cloudflare on top it can put the application into a redirect loop.

This allows a Neighborhood who relies on Cloudflare for DNS + Security to disable Rails' built in SSL redirection by setting the `FORCE_SSL` environment variable to false.

Note: I would really prefer not to be using Cloudflare at all, however they continue to provide the best free plan and we can't afford to pay for a CDN at this time.