### PR TITLE
Furniture: Destroying a Furniture respects `dependent:` settings

### DIFF
--- a/app/controllers/furniture_placements_controller.rb
+++ b/app/controllers/furniture_placements_controller.rb
@@ -34,7 +34,7 @@ class FurniturePlacementsController < ApplicationController
   end
 
   def destroy
-    furniture_placement.destroy!
+    furniture_placement.furniture.destroy!
     respond_to do |format|
       format.html do
         redirect_to(


### PR DESCRIPTION
https://github.com/zinc-collective/convene/issues/709

When we were smoke-testing the Marketplace, I realized we had to destroy and re-create the Marketplace, but the way we delete them was... uhhh not respecting the (very prudent) foreign-keys we had added!

So now FurniturePlacements polymorph into their child implementation prior to destruction, so that all `dependent: :destroy`  etc. actions get carried out.

Co-authored-by: Dalton <daltonrpruitt@users.noreply.github.com>