### PR TITLE
Marketplace: Refactor - Pull AccountLink up into Marketplace

### DIFF
--- a/app/furniture/marketplace/marketplace.rb
+++ b/app/furniture/marketplace/marketplace.rb
@@ -43,31 +43,14 @@ class Marketplace
         })
       end
 
-      account_link = if account.details_submitted?
-        Stripe::AccountLink.create(
-          {
-            account: stripe_account,
-            refresh_url: refresh_url,
-            return_url: return_url,
-            type: "account_update"
-          },
-          {
-            api_key: stripe_api_key
-          }
-        )
-      else
-        Stripe::AccountLink.create(
-          {
-            account: stripe_account,
-            refresh_url: refresh_url,
-            return_url: return_url,
-            type: "account_onboarding"
-          },
-          {
-            api_key: stripe_api_key
-          }
-        )
-      end
+      Stripe::AccountLink.create({
+        account: stripe_account,
+        refresh_url: refresh_url,
+        return_url: return_url,
+        type: account.details_submitted? ? "account_update" : "account_onboarding"
+      }, {
+        api_key: stripe_api_key
+      })
     end
 
     def self.model_name

--- a/app/furniture/marketplace/stripe_accounts_controller.rb
+++ b/app/furniture/marketplace/stripe_accounts_controller.rb
@@ -3,44 +3,11 @@ class Marketplace
     def create
       # TODO: Should we be using https://stripe.com/docs/connect/oauth-express-accounts instead?!
       authorize(marketplace, :edit?)
-      account = if marketplace.stripe_account.blank?
-        Stripe::Account.create({type: "standard"}, {
-          api_key: marketplace.stripe_api_key
-        }).tap do |account|
-          marketplace.update(stripe_account: account.id)
-        end
-      else
-        Stripe::Account.retrieve(marketplace.stripe_account, {
-          api_key: marketplace.stripe_api_key
-        })
-      end
-
-      account_link = if account.details_submitted?
-        Stripe::AccountLink.create(
-          {
-            account: marketplace.stripe_account,
-            refresh_url: polymorphic_url(marketplace.location(:edit)),
-            return_url: polymorphic_url(marketplace.location(:edit)),
-            type: "account_update"
-          },
-          {
-            api_key: marketplace.stripe_api_key
-          }
-        )
-      else
-        Stripe::AccountLink.create(
-          {
-            account: marketplace.stripe_account,
-            refresh_url: polymorphic_url(marketplace.location(:edit)),
-            return_url: polymorphic_url(marketplace.location(:edit)),
-            type: "account_onboarding"
-          },
-          {
-            api_key: marketplace.stripe_api_key
-          }
-        )
-      end
-      redirect_to account_link.url, status: :see_other, allow_other_host: true
+      stripe_account_link = marketplace.stripe_account_link(
+        refresh_url: polymorphic_url(marketplace.location(:edit)),
+        return_url: polymorphic_url(marketplace.location(:edit))
+      )
+      redirect_to stripe_account_link.url, status: :see_other, allow_other_host: true
     end
 
     helper_method def marketplace


### PR DESCRIPTION
The account link object was being made in the controller, and while that worked it was a mess.

This adjusts things so it's a little bit more order(ly) and places it in the model where it's "best."

Co-authored-by: Dalton <daltonrpruitt@users.noreply.github.com>