### PR TITLE
Marketplace: Collect delivery information at Checkout

### DIFF
--- a/app/furniture/marketplace/checkout.rb
+++ b/app/furniture/marketplace/checkout.rb
@@ -16,6 +16,9 @@ class Marketplace
         mode: "payment",
         success_url: success_url,
         cancel_url: cancel_url,
+        shipping_address_collection: {
+          allowed_countries: ["US"],
+        },
         payment_intent_data: {
           transfer_group: cart.id
         }


### PR DESCRIPTION
https://github.com/zinc-collective/convene/issues/831

It may be better for us to include the option to select Delivery via Piikup here vs Take-out or Self-pickup; but this seems decent enough for now.