### PR TITLE
Memberships: Invitations work on BYO Domains

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,9 @@
 # Default controller for new resources; ensures requests fulfill authentication
 # and authorization requirements, as well as exposes common helper methods.
 class ApplicationController < ActionController::Base
+  before_action :ensure_on_byo_domain
+
+
   include Pundit::Authorization
   after_action :verify_authorized
   after_action :verify_policy_scoped
@@ -62,6 +65,18 @@ class ApplicationController < ActionController::Base
     end
 
     super
+  end
+
+
+  # @todo this should be tested 🙃 halp me
+  def ensure_on_byo_domain
+    if request.get? && current_space.branded_domain.present? && request.domain != current_space.branded_domain
+
+      redirect_url = URI(request.url)
+      redirect_url.host = current_space.branded_domain
+      redirect_url.path = redirect_url.path.gsub("/spaces/#{current_space.slug}","")
+      redirect_to redirect_url.to_s, allow_other_host: true
+    end
   end
 
   private

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 class Invitation < ApplicationRecord
+  self.location_parent = :space
+
   belongs_to :space, inverse_of: :invitations
+
 
   belongs_to :invitor, class_name: :Person, inverse_of: :invitations
 

--- a/app/models/rsvp.rb
+++ b/app/models/rsvp.rb
@@ -2,6 +2,8 @@
 
 class Rsvp
   include ActiveModel::Model
+  include WithinLocation
+  self.location_parent = :invitation
 
   attr_accessor :invitation
 

--- a/app/views/invitations/index.html.erb
+++ b/app/views/invitations/index.html.erb
@@ -6,7 +6,7 @@
 
 
   <div>
-    <%= form_with(model: [space, invitation], local: true) do |invitation_form| %>
+    <%= form_with(model: invitation.location, local: true) do |invitation_form| %>
       <div>
         <%= invitation_form.label :name %>
         <%= invitation_form.text_field :name %>

--- a/app/views/rsvps/_pending.html.erb
+++ b/app/views/rsvps/_pending.html.erb
@@ -1,7 +1,7 @@
 <h2><%= t('.header', space_name: rsvp.invitation.space.name)%></h2>
 <p><%= t('.summary', space_name: rsvp.invitation.space.name, invitor_name: rsvp.invitation.invitor_display_name, invitation_date: rsvp.invitation.created_at) %></p>
 
-<%= form_with model: [rsvp.space, rsvp.invitation, rsvp], local: true do |rsvp_form|%>
+<%= form_with model: rsvp.location do |rsvp_form|%>
   <%= rsvp_form.hidden_field :status, value: 'accepted' %>
   <%= rsvp_form.submit t('.accept', space_name: rsvp.space.name) %>
 <%- end %>

--- a/app/views/rsvps/update.html.erb
+++ b/app/views/rsvps/update.html.erb
@@ -8,7 +8,7 @@
   <h2><%= t('.header', email: rsvp.invitation.email)%></h2>
   <p><%= t('.summary', invitor_name: rsvp.invitation.invitor_display_name) %></p>
 
-  <%= form_with model: [rsvp.space, rsvp.invitation, rsvp], local: true do |rsvp_form|%>
+  <%= form_with model: rsvp.location do |rsvp_form|%>
     <%= rsvp_form.hidden_field :status, value: "accepted" %>
     <%= render "text_field", form: rsvp_form, attribute: :one_time_password %>
     <%= rsvp_form.submit t('.accept', space_name: rsvp.space.name) %>

--- a/app/views/space_invitation_mailer/space_invitation_email.text.erb
+++ b/app/views/space_invitation_mailer/space_invitation_email.text.erb
@@ -2,7 +2,7 @@ Hi <%= @invitation.name %>,
 
 You've been invited to <%= @invitation.space.name %> by <%= @invitation.invitor_display_name %>.
 
-You may view, accept or ignore this invitation at <%= space_invitation_rsvp_url(@invitation.space, @invitation) %>.
+You may view, accept or ignore this invitation at <%= polymorphic_url(@invitation.location(child: :rsvp)) %>.
 
 We hope to see you there! 🥳🎈🎉
 

--- a/spec/requests/spaces_controller_request_spec.rb
+++ b/spec/requests/spaces_controller_request_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe SpacesController, type: :request do
       it "links to the domain" do
         get polymorphic_path(space)
 
-        expect(response.body).to include "//beta.example.com/"
+        expect(response).to redirect_to "http://beta.example.com"
       end
     end
   end


### PR DESCRIPTION
https://github.com/zinc-collective/convene/issues/1078
https://github.com/zinc-collective/convene/issues/117
https://github.com/zinc-collective/convene/issues/74

There's probably a bunch of other domain objects that want `parent_location` set; but this should be good enough to get the invitations flow unbroken.