### PR TITLE
BYODomains: Prevent redirect loop on subdomains

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -70,8 +70,8 @@ class ApplicationController < ActionController::Base
   # @todo this should be tested 🙃 halp me
   def ensure_on_byo_domain
 
-    if request.get? && current_space.branded_domain.present? && request.domain != current_space.branded_domain
-      Rails.logger.debug("Request Domain: #{request.domain}")
+    if request.get? && current_space.branded_domain.present? && request.host != current_space.branded_domain
+      Rails.logger.debug("Request Host: #{request.host}")
       redirect_url = URI(request.url)
       redirect_url.host = current_space.branded_domain
       redirect_url.path = redirect_url.path.gsub("/spaces/#{current_space.slug}","")

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -67,15 +67,16 @@ class ApplicationController < ActionController::Base
     super
   end
 
-
   # @todo this should be tested 🙃 halp me
   def ensure_on_byo_domain
-    if request.get? && current_space.branded_domain.present? && request.domain != current_space.branded_domain
 
+    if request.get? && current_space.branded_domain.present? && request.domain != current_space.branded_domain
+      Rails.logger.debug("Request Domain: #{request.domain}")
       redirect_url = URI(request.url)
       redirect_url.host = current_space.branded_domain
       redirect_url.path = redirect_url.path.gsub("/spaces/#{current_space.slug}","")
-      redirect_to redirect_url.to_s, allow_other_host: true
+      Rails.logger.debug("Redirecting from #{request.url}")
+      redirect_to redirect_url.to_s, allow_other_host: true if redirect_url != URI(request.url)
     end
   end
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,7 +50,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :info
+  config.log_level = ENV.fetch('LOG_LEVEL', 'info').to_sym
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]


### PR DESCRIPTION
https://github.com/zinc-collective/convene/issues/74

Edit: TURNS OUT `request.host` and `request.domain` are different! `request.host` is the full host (i.e. `foo.example.com`); while `request.domain` is just the tld + domain name (i.e. `example.com`)

---

~~It's unclear why, but my best guess is that the CNAME record and Cloudflare are doing some degree of domain rewriting or something and causing them to go back and forth forever.~~

Logs for redirect loop here:

```
2023-01-31T16:52:47.701120+00:00 heroku[router]: at=info method=GET path="/" host=piikup-sandbox.zinc.coop request_id=b946577a-5ea4-4e2b-9a37-4619b1225911 fwd="2601:643:8980:ebb0:19f1:1a52:9f91:7d5c,172.71.154.35" dyno=web.1 connect=0ms service=12ms status=302 bytes=562 protocol=http
2023-01-31T16:52:47.508025+00:00 heroku[router]: at=info method=GET path="/" host=piikup-sandbox.zinc.coop request_id=ff4c3f0b-4ebd-49ee-86ed-f6183666ed0a fwd="2601:643:8980:ebb0:19f1:1a52:9f91:7d5c,172.71.154.34" dyno=web.1 connect=0ms service=9ms status=302 bytes=562 protocol=http
2023-01-31T16:52:47.883575+00:00 app[web.1]: I, [2023-01-31T16:52:47.883484 #4]  INFO -- : [a6829b90-5e64-456e-81bc-46d33cb82c62] Started GET "/" for 172.71.154.35 at 2023-01-31 16:52:47 +0000
2023-01-31T16:52:47.884565+00:00 app[web.1]: I, [2023-01-31T16:52:47.884511 #4]  INFO -- : [a6829b90-5e64-456e-81bc-46d33cb82c62] Processing by SpacesController#show as HTML
2023-01-31T16:52:47.889728+00:00 app[web.1]: I, [2023-01-31T16:52:47.889668 #4]  INFO -- : [a6829b90-5e64-456e-81bc-46d33cb82c62] Redirected to http://piikup-sandbox.zinc.coop/
2023-01-31T16:52:47.889823+00:00 app[web.1]: I, [2023-01-31T16:52:47.889786 #4]  INFO -- : [a6829b90-5e64-456e-81bc-46d33cb82c62] Filter chain halted as :ensure_on_byo_domain rendered or redirected
2023-01-31T16:52:47.889943+00:00 app[web.1]: I, [2023-01-31T16:52:47.889917 #4]  INFO -- : [a6829b90-5e64-456e-81bc-46d33cb82c62] Completed 302 Found in 5ms (ActiveRecord: 0.8ms | Allocations: 1799)
2023-01-31T16:52:48.081439+00:00 app[web.1]: I, [2023-01-31T16:52:48.081354 #4]  INFO -- : [4f58f081-5db8-4b0d-97bd-45919721aa85] Started GET "/" for 172.71.154.35 at 2023-01-31 16:52:48 +0000
2023-01-31T16:52:48.082541+00:00 app[web.1]: I, [2023-01-31T16:52:48.082479 #4]  INFO -- : [4f58f081-5db8-4b0d-97bd-45919721aa85] Processing by SpacesController#show as HTML
2023-01-31T16:52:48.088904+00:00 app[web.1]: I, [2023-01-31T16:52:48.088816 #4]  INFO -- : [4f58f081-5db8-4b0d-97bd-45919721aa85] Redirected to http://piikup-sandbox.zinc.coop/
2023-01-31T16:52:48.088993+00:00 app[web.1]: I, [2023-01-31T16:52:48.088947 #4]  INFO -- : [4f58f081-5db8-4b0d-97bd-45919721aa85] Filter chain halted as :ensure_on_byo_domain rendered or redirected
2023-01-31T16:52:48.089146+00:00 app[web.1]: I, [2023-01-31T16:52:48.089109 #4]  INFO -- : [4f58f081-5db8-4b0d-97bd-45919721aa85] Completed 302 Found in 6ms (ActiveRecord: 1.4ms | Allocations: 1799)
2023-01-31T16:52:47.890252+00:00 heroku[router]: at=info method=GET path="/" host=piikup-sandbox.zinc.coop request_id=a6829b90-5e64-456e-81bc-46d33cb82c62 fwd="2601:643:8980:ebb0:19f1:1a52:9f91:7d5c,172.71.154.35" dyno=web.1 connect=0ms service=8ms status=302 bytes=562 protocol=http
2023-01-31T16:52:48.102702+00:00 heroku[router]: at=info method=GET path="/" host=piikup-sandbox.zinc.coop request_id=4f58f081-5db8-4b0d-97bd-45919721aa85 fwd="2601:643:8980:ebb0:19f1:1a52:9f91:7d5c,172.71.154.35" dyno=web.1 connect=0ms service=11ms status=302 bytes=562 protocol=http
2023-01-31T16:52:48.268890+00:00 app[web.1]: I, [2023-01-31T16:52:48.267750 #4]  INFO -- : [9cb9c952-9c42-43e0-a6e6-c4d9aeddaf18] Started GET "/" for 172.71.154.35 at 2023-01-31 16:52:48 +0000
2023-01-31T16:52:48.268921+00:00 app[web.1]: I, [2023-01-31T16:52:48.268834 #4]  INFO -- : [9cb9c952-9c42-43e0-a6e6-c4d9aeddaf18] Processing by SpacesController#show as HTML
2023-01-31T16:52:48.273483+00:00 app[web.1]: I, [2023-01-31T16:52:48.273433 #4]  INFO -- : [9cb9c952-9c42-43e0-a6e6-c4d9aeddaf18] Redirected to http://piikup-sandbox.zinc.coop/
2023-01-31T16:52:48.273549+00:00 app[web.1]: I, [2023-01-31T16:52:48.273524 #4]  INFO -- : [9cb9c952-9c42-43e0-a6e6-c4d9aeddaf18] Filter chain halted as :ensure_on_byo_domain rendered or redirected
2023-01-31T16:52:48.273651+00:00 app[web.1]: I, [2023-01-31T16:52:48.273629 #4]  INFO -- : [9cb9c952-9c42-43e0-a6e6-c4d9aeddaf18] Completed 302 Found in 5ms (ActiveRecord: 0.7ms | Allocations: 1799)
```