### PR TITLE
Remove obsolete video_bridge placements from the Demo space

### DIFF
--- a/app/models/demo_space.rb
+++ b/app/models/demo_space.rb
@@ -3,39 +3,24 @@ class DemoSpace
     {
       name: "Zee's Desk",
       publicity_level: :listed,
-      furniture_placements: {
-        video_bridge: {}
-      }
     },
     {
       name: "Vivek's Desk",
       publicity_level: :listed,
-      furniture_placements: {
-        video_bridge: {}
-      }
     },
     {
       name: "Water Cooler",
       publicity_level: :listed,
-      furniture_placements: {
-        video_bridge: {}
-      }
     },
     {
       name: "The Ada Lovelace Room",
       publicity_level: :listed,
-      furniture_placements: {
-        video_bridge: {}
-      }
     },
     {
       name: "Locked Room",
       publicity_level: :listed,
       access_level: :locked,
       access_code: :friends,
-      furniture_placements: {
-        video_bridge: {}
-      }
     }
   ].freeze
 


### PR DESCRIPTION
A left-over from https://github.com/zinc-collective/convene/pull/1051, which is causing non-working video-bridges to magically re-appear in the Demo space.