### PR TITLE
`Marketplace`: `Vendor` receives `Payment` upon `Order` completion

### DIFF
--- a/app/furniture/marketplace/marketplace.rb
+++ b/app/furniture/marketplace/marketplace.rb
@@ -68,7 +68,7 @@ class Marketplace
         api_key: stripe_api_key
       })
     rescue Stripe::InvalidRequestError => e
-      Rails.logger.error({ summary: "Stripe account creation is sad!", detail: e.message})
+      Rails.logger.error({summary: "Stripe account creation is sad!", detail: e.message})
       nil
     end
 

--- a/app/furniture/marketplace/marketplace.rb
+++ b/app/furniture/marketplace/marketplace.rb
@@ -21,7 +21,6 @@ class Marketplace
       settings["stripe_account"] = stripe_account
     end
 
-
     def stripe_webhook_endpoint
       settings["stripe_webhook_endpoint"]
     end
@@ -74,7 +73,7 @@ class Marketplace
       Stripe::WebhookEndpoint.create({
         enabled_events: ["checkout.session.completed"],
         url: webhook_url
-      }, { api_key: stripe_api_key }).tap do |stripe_webhook_endpoint|
+      }, {api_key: stripe_api_key}).tap do |stripe_webhook_endpoint|
         update(stripe_webhook_endpoint: stripe_webhook_endpoint.id, stripe_webhook_endpoint_secret: stripe_webhook_endpoint.secret)
       end
     end

--- a/app/furniture/marketplace/marketplace.rb
+++ b/app/furniture/marketplace/marketplace.rb
@@ -67,9 +67,14 @@ class Marketplace
       }, {
         api_key: stripe_api_key
       })
+    rescue Stripe::InvalidRequestError => e
+      Rails.logger.error({ summary: "Stripe account creation is sad!", detail: e.message})
+      nil
     end
 
     def create_stripe_webhook_endpoint(webhook_url:)
+      return if stripe_webhook_endpoint.present?
+
       Stripe::WebhookEndpoint.create({
         enabled_events: ["checkout.session.completed"],
         url: webhook_url

--- a/app/furniture/marketplace/marketplace.rb
+++ b/app/furniture/marketplace/marketplace.rb
@@ -30,6 +30,14 @@ class Marketplace
       settings["stripe_webhook_endpoint"] = stripe_webhook_endpoint
     end
 
+    def stripe_webhook_endpoint_secret
+      settings["stripe_webhook_endpoint_secret"]
+    end
+
+    def stripe_webhook_endpoint_secret=stripe_webhook_endpoint_secret
+      settings["stripe_webhook_endpoint_secret"] = stripe_webhook_endpoint_secret
+    end
+
     def delivery_fee_cents= delivery_fee_cents
       settings["delivery_fee_cents"] = delivery_fee_cents
     end
@@ -67,7 +75,7 @@ class Marketplace
         enabled_events: ["checkout.session.completed"],
         url: webhook_url
       }, { api_key: stripe_api_key }).tap do |stripe_webhook_endpoint|
-        update(stripe_webhook_endpoint: stripe_webhook_endpoint.id)
+        update(stripe_webhook_endpoint: stripe_webhook_endpoint.id, stripe_webhook_endpoint_secret: stripe_webhook_endpoint.secret)
       end
     end
 

--- a/app/furniture/marketplace/marketplace.rb
+++ b/app/furniture/marketplace/marketplace.rb
@@ -21,6 +21,15 @@ class Marketplace
       settings["stripe_account"] = stripe_account
     end
 
+
+    def stripe_webhook_endpoint
+      settings["stripe_webhook_endpoint"]
+    end
+
+    def stripe_webhook_endpoint=stripe_webhook_endpoint
+      settings["stripe_webhook_endpoint"] = stripe_webhook_endpoint
+    end
+
     def delivery_fee_cents= delivery_fee_cents
       settings["delivery_fee_cents"] = delivery_fee_cents
     end
@@ -51,6 +60,15 @@ class Marketplace
       }, {
         api_key: stripe_api_key
       })
+    end
+
+    def create_stripe_webhook_endpoint(webhook_url:)
+      Stripe::WebhookEndpoint.create({
+        enabled_events: ["checkout.session.completed"],
+        url: webhook_url
+      }, { api_key: stripe_api_key }).tap do |stripe_webhook_endpoint|
+        update(stripe_webhook_endpoint: stripe_webhook_endpoint.id)
+      end
     end
 
     def self.model_name

--- a/app/furniture/marketplace/marketplaces/edit.html.erb
+++ b/app/furniture/marketplace/marketplaces/edit.html.erb
@@ -2,11 +2,10 @@
 
 <%= render "form", marketplace: marketplace %>
 
-<%- if marketplace.stripe_account.blank? %>
-  <%= button_to t('.connect_stripe'), marketplace.location(child: :stripe_account), method: :post, data: { turbo: false } %>
-<%- else %>
+<%- if marketplace.stripe_account.present? %>
   <%= t('.stripe_connected') %>
 <%- end %>
+<%= button_to t('.connect_stripe'), marketplace.location(child: :stripe_account), method: :post, data: { turbo: false } %>
 
 <%- if policy(marketplace.products.new).create? %>
   <%= link_to t('marketplace.product.index'), marketplace.location(child: :products) %>

--- a/app/furniture/marketplace/routes.rb
+++ b/app/furniture/marketplace/routes.rb
@@ -2,6 +2,8 @@ class Marketplace
   class Routes
     def self.append_routes(router)
       router.resources :marketplaces, only: [:show, :edit, :update], module: "marketplace" do
+        router.resources :stripe_events
+
         router.resources :carts do
           router.resources :cart_products
           router.resource :checkout, only: [:show, :create]

--- a/app/furniture/marketplace/stripe_accounts_controller.rb
+++ b/app/furniture/marketplace/stripe_accounts_controller.rb
@@ -5,8 +5,11 @@ class Marketplace
       authorize(marketplace, :edit?)
       stripe_account_link = marketplace.stripe_account_link(
         refresh_url: polymorphic_url(marketplace.location(:edit)),
-        return_url: polymorphic_url(marketplace.location(:edit))
+        return_url: polymorphic_url(marketplace.location(:edit)),
       )
+
+      marketplace.create_stripe_webhook_endpoint(webhook_url: polymorphic_url(marketplace.location(child: :stripe_events)))
+
       redirect_to stripe_account_link.url, status: :see_other, allow_other_host: true
     end
 

--- a/app/furniture/marketplace/stripe_accounts_controller.rb
+++ b/app/furniture/marketplace/stripe_accounts_controller.rb
@@ -10,7 +10,11 @@ class Marketplace
 
       marketplace.create_stripe_webhook_endpoint(webhook_url: polymorphic_url(marketplace.location(child: :stripe_events)))
 
-      redirect_to stripe_account_link.url, status: :see_other, allow_other_host: true
+      if stripe_account_link.present?
+        redirect_to stripe_account_link.url, status: :see_other, allow_other_host: true
+      else
+        redirect_to marketplace.location(:edit), notice: "Stripe Re-Connected!"
+      end
     end
 
     helper_method def marketplace

--- a/app/furniture/marketplace/stripe_accounts_controller.rb
+++ b/app/furniture/marketplace/stripe_accounts_controller.rb
@@ -5,7 +5,7 @@ class Marketplace
       authorize(marketplace, :edit?)
       stripe_account_link = marketplace.stripe_account_link(
         refresh_url: polymorphic_url(marketplace.location(:edit)),
-        return_url: polymorphic_url(marketplace.location(:edit)),
+        return_url: polymorphic_url(marketplace.location(:edit))
       )
 
       marketplace.create_stripe_webhook_endpoint(webhook_url: polymorphic_url(marketplace.location(child: :stripe_events)))

--- a/app/furniture/marketplace/stripe_events_controller.rb
+++ b/app/furniture/marketplace/stripe_events_controller.rb
@@ -7,7 +7,8 @@ class Marketplace
     def create
       skip_authorization
       payload = request.body.read
-      event = Stripe::Event.construct_from(params)
+      signature = request.env['HTTP_STRIPE_SIGNATURE'];
+      event = Stripe::Event.construct_from(params, signature, marketplace.stripe_webhook_endpoint_secret)
 
       case event.type
 

--- a/app/furniture/marketplace/stripe_events_controller.rb
+++ b/app/furniture/marketplace/stripe_events_controller.rb
@@ -7,8 +7,8 @@ class Marketplace
     def create
       skip_authorization
       payload = request.body.read
-      signature = request.env['HTTP_STRIPE_SIGNATURE'];
-      event = Stripe::Event.construct_from(params, signature, marketplace.stripe_webhook_endpoint_secret)
+      signature = request.env["HTTP_STRIPE_SIGNATURE"]
+      event = Stripe::Webhook.construct_event(params, signature, marketplace.stripe_webhook_endpoint_secret)
 
       case event.type
 

--- a/app/furniture/marketplace/stripe_events_controller.rb
+++ b/app/furniture/marketplace/stripe_events_controller.rb
@@ -8,7 +8,8 @@ class Marketplace
       skip_authorization
       payload = request.body.read
       signature = request.env["HTTP_STRIPE_SIGNATURE"]
-      event = Stripe::Webhook.construct_event(params, signature, marketplace.stripe_webhook_endpoint_secret)
+
+      event = Stripe::Webhook.construct_event(payload, signature, marketplace.stripe_webhook_endpoint_secret)
 
       case event.type
 

--- a/app/furniture/marketplace/stripe_events_controller.rb
+++ b/app/furniture/marketplace/stripe_events_controller.rb
@@ -1,0 +1,27 @@
+class Marketplace
+  class StripeEventsController < Controller
+    skip_before_action :verify_authenticity_token
+
+    # @todo add signing check using the stripe webhook signing secret
+    # @see https://stripe.com/docs/webhooks/quickstart
+    def create
+      skip_authorization
+      payload = request.body.read
+      event = Stripe::Event.construct_from(params)
+
+      case event.type
+
+      when "checkout.session.completed"
+        payment_intent = Stripe::PaymentIntent.retrieve(event.data.dig("object", "payment_intent"), {api_key: marketplace.stripe_api_key})
+        order = Order.find(payment_intent.transfer_group)
+
+        transfer = Stripe::Transfer.create({
+          amount: order.price_total.cents,
+          currency: "usd",
+          destination: marketplace.stripe_account,
+          transfer_group: order.id
+        }, {api_key: marketplace.stripe_api_key})
+      end
+    end
+  end
+end

--- a/app/furniture/marketplace/stripe_events_controller.rb
+++ b/app/furniture/marketplace/stripe_events_controller.rb
@@ -2,8 +2,6 @@ class Marketplace
   class StripeEventsController < Controller
     skip_before_action :verify_authenticity_token
 
-    # @todo add signing check using the stripe webhook signing secret
-    # @see https://stripe.com/docs/webhooks/quickstart
     def create
       skip_authorization
       payload = request.body.read
@@ -22,6 +20,8 @@ class Marketplace
           destination: marketplace.stripe_account,
           transfer_group: order.id
         }, {api_key: marketplace.stripe_api_key})
+      else
+        raise UnexpectedStripeEventTypeError, event.type
       end
     end
   end

--- a/app/furniture/marketplace/stripe_events_controller.rb
+++ b/app/furniture/marketplace/stripe_events_controller.rb
@@ -10,14 +10,13 @@ class Marketplace
       signature = request.env["HTTP_STRIPE_SIGNATURE"]
 
       event = Stripe::Webhook.construct_event(payload, signature, marketplace.stripe_webhook_endpoint_secret)
-
       case event.type
 
       when "checkout.session.completed"
-        payment_intent = Stripe::PaymentIntent.retrieve(event.data.dig("object", "payment_intent"), {api_key: marketplace.stripe_api_key})
+        payment_intent = Stripe::PaymentIntent.retrieve(event.data.object.payment_intent, {api_key: marketplace.stripe_api_key})
         order = Order.find(payment_intent.transfer_group)
 
-        transfer = Stripe::Transfer.create({
+        Stripe::Transfer.create({
           amount: order.price_total.cents,
           currency: "usd",
           destination: marketplace.stripe_account,

--- a/app/furniture/marketplace/unexpected_stripe_event_type_error.rb
+++ b/app/furniture/marketplace/unexpected_stripe_event_type_error.rb
@@ -1,0 +1,7 @@
+class Marketplace
+  class UnexpectedStripeEventTypeError < StandardError
+    def initialize(type)
+      super("We aren't sure how to handle Stripe events of #{type}")
+    end
+  end
+end

--- a/spec/factories/furniture/marketplace.rb
+++ b/spec/factories/furniture/marketplace.rb
@@ -26,6 +26,22 @@ FactoryBot.define do
     end
   end
 
+  factory :marketplace_order, class: "Marketplace::Order" do
+    marketplace
+    status { :paid }
+    association(:shopper, factory: :marketplace_shopper)
+
+    trait :with_products
+    after(:build) do |order, _evaluator|
+      build(:marketplace_ordered_product, order: order)
+    end
+  end
+
+  factory :marketplace_ordered_product, class: "Marketplace::OrderedProduct" do
+    association(:product, factory: :marketplace_product)
+    association(:order, factory: :marketplace_order)
+  end
+
   factory :marketplace_shopper, class: "Marketplace::Shopper" do
   end
 end

--- a/spec/factories/furniture/marketplace.rb
+++ b/spec/factories/furniture/marketplace.rb
@@ -1,6 +1,11 @@
 FactoryBot.define do
   factory :marketplace, class: "Marketplace::Marketplace" do
     room
+    trait :with_stripe_utility do
+      after(:create) do |marketplace|
+        create(:stripe_utility, space: marketplace.room.space)
+      end
+    end
   end
 
   factory :marketplace_product, class: "Marketplace::Product" do
@@ -40,6 +45,7 @@ FactoryBot.define do
   factory :marketplace_ordered_product, class: "Marketplace::OrderedProduct" do
     association(:product, factory: :marketplace_product)
     association(:order, factory: :marketplace_order)
+    quantity { 1 }
   end
 
   factory :marketplace_shopper, class: "Marketplace::Shopper" do

--- a/spec/factories/utility_hookup.rb
+++ b/spec/factories/utility_hookup.rb
@@ -7,5 +7,9 @@ FactoryBot.define do
     trait :stripe do
       utility_slug { "stripe" }
     end
+
+    factory :stripe_utility do
+      utility_slug { "stripe" }
+    end
   end
 end

--- a/spec/furniture/marketplace/checkouts_controller_request_spec.rb
+++ b/spec/furniture/marketplace/checkouts_controller_request_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Marketplace::Checkout, type: :request do
   let(:room) { marketplace.room }
   let!(:cart) { create(:marketplace_cart, :with_products, marketplace: marketplace) }
   let(:checkout) { build(:marketplace_checkout, cart: cart) }
-  let!(:stripe) { create(:utility_hookup, :stripe, space: space) }
+
+  before { create(:stripe_utility, space: space) }
 
   describe "#show" do
     context "when a stripe_session_id is in the params" do

--- a/spec/furniture/marketplace/stripe_accounts_controller_request_spec.rb
+++ b/spec/furniture/marketplace/stripe_accounts_controller_request_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Marketplace::StripeAccountsController, type: :request do
   let(:marketplace) { create(:marketplace) }
   let(:space) { marketplace.space }
   let(:member) { create(:membership, space: space).member }
-  let!(:stripe) { create(:utility_hookup, :stripe, space: space, configuration: {"api_token" => "asdf"}) }
+  let!(:stripe) { create(:stripe_utility, space: space, configuration: {"api_token" => "asdf"}) }
   let(:stripe_account_link) { double(Stripe::AccountLink, url: "http://example.com/") }
   let(:stripe_account) { double(Stripe::Account, id: "ac_1234", details_submitted?: false) }
   let(:stripe_webhook_endpoint) { double(Stripe::WebhookEndpoint, id: "whe_1234", secret: "oooooooooooo") }

--- a/spec/furniture/marketplace/stripe_accounts_controller_request_spec.rb
+++ b/spec/furniture/marketplace/stripe_accounts_controller_request_spec.rb
@@ -3,12 +3,11 @@ require "rails_helper"
 RSpec.describe Marketplace::StripeAccountsController, type: :request do
   let(:marketplace) { create(:marketplace) }
   let(:space) { marketplace.space }
-  let(:room) { marketplace.room }
   let(:member) { create(:membership, space: space).member }
-  let!(:stripe) { create(:utility_hookup, :stripe, space: space, configuration: { "api_token" => "asdf" }) }
+  let!(:stripe) { create(:utility_hookup, :stripe, space: space, configuration: {"api_token" => "asdf"}) }
   let(:stripe_account_link) { double(Stripe::AccountLink, url: "http://example.com/") }
-  let(:stripe_account) { double(Stripe::Account, id: "ac_1234", details_submitted?: false)}
-  let(:stripe_webhook_endpoint) { double(Stripe::WebhookEndpoint, id: "whe_1234", secret: "oooooooooooo")}
+  let(:stripe_account) { double(Stripe::Account, id: "ac_1234", details_submitted?: false) }
+  let(:stripe_webhook_endpoint) { double(Stripe::WebhookEndpoint, id: "whe_1234", secret: "oooooooooooo") }
 
   before do
     allow(Stripe::Account).to receive(:create).and_return(stripe_account)
@@ -16,7 +15,8 @@ RSpec.describe Marketplace::StripeAccountsController, type: :request do
     allow(Stripe::WebhookEndpoint).to receive(:create)
       .with({
         enabled_events: ["checkout.session.completed"],
-        url: polymorphic_url(marketplace.location(child: :stripe_events)) }, { api_key: marketplace.stripe_api_key })
+        url: polymorphic_url(marketplace.location(child: :stripe_events))
+      }, {api_key: marketplace.stripe_api_key})
       .and_return(stripe_webhook_endpoint)
   end
 

--- a/spec/furniture/marketplace/stripe_accounts_controller_request_spec.rb
+++ b/spec/furniture/marketplace/stripe_accounts_controller_request_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Marketplace::StripeAccountsController, type: :request do
   let!(:stripe) { create(:utility_hookup, :stripe, space: space, configuration: { "api_token" => "asdf" }) }
   let(:stripe_account_link) { double(Stripe::AccountLink, url: "http://example.com/") }
   let(:stripe_account) { double(Stripe::Account, id: "ac_1234", details_submitted?: false)}
-  let(:stripe_webhook_endpoint) { double(Stripe::WebhookEndpoint, id: "whe_1234")}
+  let(:stripe_webhook_endpoint) { double(Stripe::WebhookEndpoint, id: "whe_1234", secret: "oooooooooooo")}
 
   before do
     allow(Stripe::Account).to receive(:create).and_return(stripe_account)
@@ -28,6 +28,7 @@ RSpec.describe Marketplace::StripeAccountsController, type: :request do
     end
 
     specify { expect { call }.to change { marketplace.reload.stripe_webhook_endpoint }.to(stripe_webhook_endpoint.id) }
+    specify { expect { call }.to change { marketplace.reload.stripe_webhook_endpoint_secret }.to(stripe_webhook_endpoint.secret) }
     it { is_expected.to redirect_to(stripe_account_link.url) }
     # Not sure how to test this: status: :see_other, allow_other_hosts: true
   end

--- a/spec/furniture/marketplace/stripe_events_controller_request_spec.rb
+++ b/spec/furniture/marketplace/stripe_events_controller_request_spec.rb
@@ -26,5 +26,11 @@ RSpec.describe Marketplace::StripeEventsController, type: :request do
     end
 
     specify { call && expect(Stripe::Transfer).to(have_received(:create).with({amount: order.price_total.cents, currency: "usd", destination: marketplace.stripe_account, transfer_group: order.id}, {api_key: marketplace.stripe_api_key})) }
+
+    context "when stripe sends us an event we can't handle" do
+      let(:stripe_event) { double(Stripe::Event, type: "a.weird.event") }
+
+      specify { expect { call }.to raise_error(Marketplace::UnexpectedStripeEventTypeError) }
+    end
   end
 end

--- a/spec/furniture/marketplace/stripe_events_controller_request_spec.rb
+++ b/spec/furniture/marketplace/stripe_events_controller_request_spec.rb
@@ -1,22 +1,30 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Marketplace::StripeEventsController, type: :request do
-  let(:marketplace) { create(:marketplace, stripe_account: "sa_1234") }
+  let(:marketplace) { create(:marketplace, :with_stripe_utility, stripe_account: "sa_1234", stripe_webhook_endpoint_secret: "whsec_1234") }
   let(:space) { marketplace.space }
   let(:member) { create(:membership, space: space).member }
-  let(:order) { create(:marketplace_order, :with_products)}
+  let(:order) { create(:marketplace_order, :with_products) }
 
+  let(:stripe_event) { double(Stripe::Event, type: "checkout.session.completed", data: double(object: double(payment_intent: "pi_1234"))) }
 
-  # @todo ok we should probably generate this or something? I dunno...
-  let(:stripe_event) { {} }
+  let(:payment_intent) { double(Stripe::PaymentIntent, transfer_group: order.id) }
+
+  before do
+    allow(Stripe::Webhook).to receive(:construct_event).with(anything, "sig_1234", marketplace.stripe_webhook_endpoint_secret).and_return(stripe_event)
+
+    allow(Stripe::PaymentIntent).to receive(:retrieve).with("pi_1234", anything).and_return(payment_intent)
+    allow(Stripe::Transfer).to receive(:create)
+  end
 
   describe "#create" do
     subject(:call) do
       sign_in(space, member)
-      post polymorphic_path(marketplace.location(child: :stripe_events), params: stripe_event)
+
+      post polymorphic_path(marketplace.location(child: :stripe_events)), headers: {HTTP_STRIPE_SIGNATURE: "sig_1234"}
       response
     end
 
-    specify { call && expect(Stripe::Transfer).to(have_received(:create).with({ amount: order.price_total.cents, currency: "usd", destination: marketplace.stripe_account, transfer_group: order.id }, { api_key: marketplace.api_key })) }
+    specify { call && expect(Stripe::Transfer).to(have_received(:create).with({amount: order.price_total.cents, currency: "usd", destination: marketplace.stripe_account, transfer_group: order.id}, {api_key: marketplace.stripe_api_key})) }
   end
 end

--- a/spec/furniture/marketplace/stripe_events_controller_request_spec.rb
+++ b/spec/furniture/marketplace/stripe_events_controller_request_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe Marketplace::StripeEventsController, type: :request do
+  let(:marketplace) { create(:marketplace, stripe_account: "sa_1234") }
+  let(:space) { marketplace.space }
+  let(:member) { create(:membership, space: space).member }
+  let(:order) { create(:marketplace_order, :with_products)}
+
+
+  # @todo ok we should probably generate this or something? I dunno...
+  let(:stripe_event) { {} }
+
+  describe "#create" do
+    subject(:call) do
+      sign_in(space, member)
+      post polymorphic_path(marketplace.location(child: :stripe_events), params: stripe_event)
+      response
+    end
+
+    specify { call && expect(Stripe::Transfer).to(have_received(:create).with({ amount: order.price_total.cents, currency: "usd", destination: marketplace.stripe_account, transfer_group: order.id }, { api_key: marketplace.api_key })) }
+  end
+end

--- a/spec/models/utility_hookup_spec.rb
+++ b/spec/models/utility_hookup_spec.rb
@@ -2,39 +2,39 @@
 
 require "rails_helper"
 
-RSpec.describe UtilityHookup, type: :model do
+RSpec.describe UtilityHookup do
   it { is_expected.to validate_presence_of(:utility_slug) }
 
   describe ".new" do
     it "accepts nested attributes for the utility" do
-      uh = UtilityHookup.new(utility_slug: :stripe, utility_attributes: {api_token: "asdf"})
+      uh = described_class.new(utility_slug: :stripe, utility_attributes: {api_token: "asdf"})
       expect(uh.utility.api_token).to eq("asdf")
     end
   end
 
   describe "#name" do
     it "defaults to the humanized version of the hookup slug" do
-      utility_hookup = UtilityHookup.new(utility_slug: :null_hookup)
+      utility_hookup = described_class.new(utility_slug: :null_hookup)
       expect(utility_hookup.name).to eq("Null hookup")
     end
   end
 
   describe "#utility" do
     it "exposes its configuration" do
-      utility_hookup = UtilityHookup.new(utility_slug: :null_hookup, configuration: {a: :b})
-      expect(utility_hookup.utility).to be_a(UtilityHookup)
+      utility_hookup = described_class.new(utility_slug: :null_hookup, configuration: {a: :b})
+      expect(utility_hookup.utility).to be_a(described_class)
       expect(utility_hookup.utility.configuration["a"]).to eq("b")
     end
   end
 
   describe "#configuration" do
     it "starts as an empty hash" do
-      uh = FactoryBot.create(:utility_hookup, :stripe)
+      uh = create(:stripe_utility)
       expect(uh.configuration).to eq({})
     end
 
     it "is encrypted" do
-      utility_hookup = UtilityHookup.new(utility_slug: :null_hookup, configuration: {a: :b})
+      utility_hookup = described_class.new(utility_slug: :null_hookup, configuration: {a: :b})
       expect(utility_hookup.configuration).to eq("a" => "b")
       expect(utility_hookup.configuration_ciphertext).not_to be_empty
     end

--- a/spec/requests/utility_hookups_controller_request_spec.rb
+++ b/spec/requests/utility_hookups_controller_request_spec.rb
@@ -6,7 +6,7 @@ require "support/shared_examples/a_space_member_only_route"
 RSpec.describe UtilityHookupsController do
   let(:space) { create(:space, :with_members) }
   let(:utility_hookup_attributes) do
-    attributes_for(:utility_hookup, :stripe).merge(utility_attributes: {"api_token" => "fake-token"})
+    attributes_for(:stripe_utility).merge(utility_attributes: {"api_token" => "fake-token"})
   end
   let(:utility_hookup) { create(:utility_hookup, space: space) }
 


### PR DESCRIPTION
https://github.com/zinc-collective/convene/issues/831

OK, this is the first shot across the bow for listening to stripe checkout completions and sending the money onwards to Vendors

Co-authored-by: Dalton <daltonrpruitt@users.noreply.github.com>
Co-authored-by: Ana Ulin <anaulin@users.noreply.github.com>

**TODO**

* [x] add programmatic way to register a marketplace's webhook endpoint with Stripe
* [x] add signature verification (look at https://stripe.com/docs/webhooks/quickstart for an example code snippet)
* [x] add automated tests for new webhook controller