### PR TITLE
`Neighborhood`: Default to `postgres:latest` image for new databases

### DIFF
--- a/.github/workflows/test-convene-web.yml
+++ b/.github/workflows/test-convene-web.yml
@@ -45,7 +45,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:12
+        image: postgres:latest
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -98,7 +98,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:12
+        image: postgres:latest
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.1'
 
 services:
   db:
-    image: postgres:12
+    image: postgres:latest
     restart: always
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust


### PR DESCRIPTION
We had hardcoded in 12, but latest is probably more appropriate since postgresql's releases are generally top-notch and getting stuck in old postgres is a recipe for sad :'(

That said, it could also be a point of friction since it will mean we'll need to learn how to bump major versions of local / neighborhood databases... Anyway meh.