### PR TITLE
`Marketplace`: Allow deletion of `Marketplace`

### DIFF
--- a/app/furniture/furniture.rb
+++ b/app/furniture/furniture.rb
@@ -21,7 +21,7 @@ module Furniture
 
   # @return [FurniturePlacement]
   def self.from_placement(placement)
-    furniture_class = REGISTRY[placement.furniture_kind.to_sym]
+    furniture_class = REGISTRY.fetch(placement.furniture_kind.to_sym)
     furniture_class.from_placement(placement)
   end
 end

--- a/app/furniture/marketplace/cart.rb
+++ b/app/furniture/marketplace/cart.rb
@@ -2,7 +2,7 @@
 
 class Marketplace
   class Cart < Record
-    self.table_name = "marketplace_carts"
+    self.table_name = "marketplace_orders"
     self.location_parent = :marketplace
 
     default_scope { where(status: :pre_checkout) }

--- a/app/furniture/marketplace/order.rb
+++ b/app/furniture/marketplace/order.rb
@@ -1,6 +1,6 @@
 class Marketplace
   class Order < Record
-    self.table_name = "marketplace_carts"
+    self.table_name = "marketplace_orders"
     self.location_parent = :marketplace
 
     belongs_to :marketplace, inverse_of: :orders

--- a/db/migrate/20230210204421_rename_marketplace_carts_and_drop_foreign_key_constraint.rb
+++ b/db/migrate/20230210204421_rename_marketplace_carts_and_drop_foreign_key_constraint.rb
@@ -3,6 +3,5 @@ class RenameMarketplaceCartsAndDropForeignKeyConstraint < ActiveRecord::Migratio
     remove_foreign_key "marketplace_carts", "furniture_placements", column: "marketplace_id"
 
     rename_table :marketplace_carts, :marketplace_orders
-
   end
 end

--- a/db/migrate/20230210204421_rename_marketplace_carts_and_drop_foreign_key_constraint.rb
+++ b/db/migrate/20230210204421_rename_marketplace_carts_and_drop_foreign_key_constraint.rb
@@ -1,0 +1,8 @@
+class RenameMarketplaceCartsAndDropForeignKeyConstraint < ActiveRecord::Migration[7.0]
+  def change
+    remove_foreign_key "marketplace_carts", "furniture_placements", column: "marketplace_id"
+
+    rename_table :marketplace_carts, :marketplace_orders
+
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_20_234526) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_10_204421) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -134,15 +134,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_20_234526) do
     t.index ["product_id"], name: "index_marketplace_cart_products_on_product_id"
   end
 
-  create_table "marketplace_carts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "marketplace_orders", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "marketplace_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "shopper_id"
     t.string "status", default: "pre_checkout", null: false
     t.string "stripe_session_id"
-    t.index ["marketplace_id"], name: "index_marketplace_carts_on_marketplace_id"
-    t.index ["shopper_id"], name: "index_marketplace_carts_on_shopper_id"
+    t.index ["marketplace_id"], name: "index_marketplace_orders_on_marketplace_id"
+    t.index ["shopper_id"], name: "index_marketplace_orders_on_shopper_id"
   end
 
   create_table "marketplace_products", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -223,10 +223,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_20_234526) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "journal_entries", "furniture_placements", column: "journal_id"
-  add_foreign_key "marketplace_cart_products", "marketplace_carts", column: "cart_id"
+  add_foreign_key "marketplace_cart_products", "marketplace_orders", column: "cart_id"
   add_foreign_key "marketplace_cart_products", "marketplace_products", column: "product_id"
-  add_foreign_key "marketplace_carts", "furniture_placements", column: "marketplace_id"
-  add_foreign_key "marketplace_carts", "marketplace_shoppers", column: "shopper_id"
+  add_foreign_key "marketplace_orders", "marketplace_shoppers", column: "shopper_id"
   add_foreign_key "marketplace_products", "furniture_placements", column: "marketplace_id"
   add_foreign_key "marketplace_shoppers", "people"
   add_foreign_key "memberships", "invitations"

--- a/spec/factories/furniture/marketplace.rb
+++ b/spec/factories/furniture/marketplace.rb
@@ -6,6 +6,18 @@ FactoryBot.define do
         create(:stripe_utility, space: marketplace.room.space)
       end
     end
+
+    trait :with_orders do
+      transient do
+        order_quantity { 1 }
+      end
+
+      after(:build) do |marketplace, evaluator|
+        evaluator.order_quantity.times do
+          build(:marketplace_order, marketplace: marketplace)
+        end
+      end
+    end
   end
 
   factory :marketplace_product, class: "Marketplace::Product" do

--- a/spec/furniture/marketplace/marketplace_spec.rb
+++ b/spec/furniture/marketplace/marketplace_spec.rb
@@ -4,4 +4,16 @@ RSpec.describe Marketplace::Marketplace, type: :model do
   it { is_expected.to have_many(:products).inverse_of(:marketplace).dependent(:destroy) }
   it { is_expected.to have_many(:orders).inverse_of(:marketplace) }
   it { is_expected.to have_many(:carts).inverse_of(:marketplace).dependent(:destroy) }
+
+  describe "#destroy" do
+    subject(:destroy) { -> { marketplace.destroy } }
+
+    let(:marketplace) { create(:marketplace, :with_orders) }
+    let(:orders) { marketplace.orders }
+
+    context "when there are `Order`s" do
+      it { is_expected.not_to raise_error }
+      it { is_expected.not_to change(orders, :count) }
+    end
+  end
 end

--- a/spec/requests/furniture_placements_controller_request_spec.rb
+++ b/spec/requests/furniture_placements_controller_request_spec.rb
@@ -1,11 +1,11 @@
 require "rails_helper"
 
-RSpec.describe "/spaces/:space_slug/rooms/:room_slug/furniture_placements", type: :request do
+RSpec.describe FurniturePlacementsController do
   let(:placement) { create(:furniture_placement, room: room) }
   let(:room) { create(:room) }
   let(:space) { room.space }
 
-  describe "POST /spaces/:space_slug/rooms/:room_slug/furniture_placements" do
+  describe "#create" do
     let(:membership) { create(:membership, space: space) }
     let!(:person) { membership.member }
 
@@ -13,7 +13,7 @@ RSpec.describe "/spaces/:space_slug/rooms/:room_slug/furniture_placements", type
 
     it "creates a furniture placement of the kind of furniture provided within the room" do
       expect do
-        post space_room_furniture_placements_path(space, room), params: {furniture_placement: {furniture_kind: :markdown_text_block}}
+        post polymorphic_path(room.location(child: :furniture_placements)), params: {furniture_placement: {furniture_kind: :markdown_text_block}}
       end.to change { room.furniture_placements.count }.by(1)
 
       placement = room.furniture_placements.last
@@ -23,8 +23,8 @@ RSpec.describe "/spaces/:space_slug/rooms/:room_slug/furniture_placements", type
     end
   end
 
-  describe "PATCH /spaces/:space_slug/rooms/:room_slug/furniture_placements/:id" do
-    let(:placement_path) { space_room_furniture_placement_path(space, room, placement) }
+  describe "#update" do
+    let(:placement_path) { polymorphic_path(placement.location) }
 
     context "when the person is a guest" do
       it "does not allow updating placements" do
@@ -47,12 +47,12 @@ RSpec.describe "/spaces/:space_slug/rooms/:room_slug/furniture_placements", type
     end
   end
 
-  describe "DELETE /spaces/:space_slug/rooms/:room_slug/furniture_placements/:id" do
-    let(:placement_path) { space_room_furniture_placement_path(space, room, placement) }
+  describe "#destroy" do
+    let(:placement_path) { polymorphic_path(placement.location) }
 
     context "when the person is a guest" do
       it "does not allow destroying placements" do
-        patch placement_path, params: {furniture_placement: {furniture_attributes: {content: "updated content"}}}
+        delete placement_path
         expect(response).not_to have_http_status(:success)
         expect(placement.reload).to be_present
       end


### PR DESCRIPTION
https://github.com/zinc-collective/convene/issues/831

~I'm not 100% sold on this fixing the [Sentry Issue](https://github.com/zinc-collective/convene/issues/1110) that prompted me to do the patch, but hopefully it makes things a little tidier.~

That's because I had the wrong Sentry Issue! This one is the correct one [Sentry Issue](https://github.com/zinc-collective/convene/issues/1112)

In particular:

1. `Marketplace`s can be destroyed while preserving `Shopper`s `Order` history
2. `Furniture#from_placement` will raise a better error when attempting to load `Furniture` that doesn't exist  
3. the `FurniturePlacementController`s Request spec lives in a place that folks working from Rails standards will find more easily