### PR TITLE
Fix settings for marketplace delivery fee field

### DIFF
--- a/app/furniture/marketplace/marketplaces/_form.html.erb
+++ b/app/furniture/marketplace/marketplaces/_form.html.erb
@@ -1,4 +1,4 @@
 <%= form_with model: marketplace.location do |f| %>
-  <%= render "money_field", { attribute: :delivery_fee, form: f, min: 0, step: 0.1} %>
+  <%= render "money_field", { attribute: :delivery_fee, form: f, min: 0, step: 0.01} %>
   <%= f.submit %>
 <% end %>

--- a/app/views/application/_money_field.html.erb
+++ b/app/views/application/_money_field.html.erb
@@ -1,6 +1,6 @@
-<% required ||= required | false %>
-<% min = local_assigns[:min] %>
-<% step = local_assigns[:step] %>
+<% required = local_assigns[:required] || false %>
+<% min = local_assigns[:min] || 0 %>
+<% step = local_assigns[:step] || 0.01 %>
 <div>
   <%= form.label attribute, class: "block text-sm font-medium text-gray-700"%>
   <div class="relative mt-1 rounded-md shadow-sm">


### PR DESCRIPTION
https://github.com/zinc-collective/convene/issues/831

This fix makes it possible to set a delivery fee with two decimals.

### Before
![image](https://user-images.githubusercontent.com/6729309/219244212-cd03a772-da2b-4f64-96d4-c3462091aa20.png)

### After
![image](https://user-images.githubusercontent.com/6729309/219244264-fb3d22c6-5c73-430d-af2e-8fd53741226e.png)
