### PR TITLE
`Utility`: 🐞🔨 `Member` may Set `Utility` Attributes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,5 @@
 {
-  "markdown.extension.toc.levels": "2..3"
+  "markdown.extension.toc.levels": "2..3",
+  "files.trimFinalNewlines": true,
+  "files.trimTrailingWhitespace": true
 }

--- a/app/controllers/utility_hookups_controller.rb
+++ b/app/controllers/utility_hookups_controller.rb
@@ -22,7 +22,7 @@ class UtilityHookupsController < ApplicationController
   end
 
   def update
-    if utility_hookup.update(utility_hookup_params)
+    if utility_hookup.utility.update(utility_hookup_params)
       redirect_to [:edit, space]
     else
       render :edit

--- a/app/controllers/utility_hookups_controller.rb
+++ b/app/controllers/utility_hookups_controller.rb
@@ -36,9 +36,13 @@ class UtilityHookupsController < ApplicationController
   helper_method def utility_hookup
     return @utility_hookup if defined?(@utility_hookup)
 
-    @utility_hookup = policy_scope(space.utility_hookups).find_by(id: params[:id]) if params[:id]
-    @utility_hookup ||= policy_scope(space.utility_hookups).new(utility_hookup_params)
-    authorize(@utility_hookup)
+    @utility_hookup = if params[:id]
+      policy_scope(space.utility_hookups).find(params[:id])
+    else
+      space.utility_hookups.new(utility_hookup_params)
+    end
+
+    authorize(@utility_hookup) if @utility_hookup
   end
 
   def utility_hookup_params

--- a/app/policies/utility_hookup_policy.rb
+++ b/app/policies/utility_hookup_policy.rb
@@ -42,8 +42,8 @@ class UtilityHookupPolicy < ApplicationPolicy
   def permitted_attributes(params)
     utility_permitted_attributes =
       policy!(Utilities.fetch(params[:utility_slug]))
-        &.permitted_attributes(params[:utility_attributes])
+        &.permitted_attributes(params)
 
-    [:name, :utility_slug, utility_attributes: utility_permitted_attributes]
+    [:name, :utility_slug] + utility_permitted_attributes
   end
 end

--- a/app/policies/utility_hookup_policy.rb
+++ b/app/policies/utility_hookup_policy.rb
@@ -40,9 +40,12 @@ class UtilityHookupPolicy < ApplicationPolicy
   end
 
   def permitted_attributes(params)
-    utility_permitted_attributes =
-      policy!(Utilities.fetch(params[:utility_slug]))
-        &.permitted_attributes(params)
+    utility_model = Utilities.fetch(params[:utility_slug])
+    utility_permitted_attributes = if utility_model != UtilityHookup
+      policy!(utility_model)&.permitted_attributes(params)
+    else
+      []
+    end
 
     [:name, :utility_slug] + utility_permitted_attributes
   end

--- a/spec/factories/utility_hookup.rb
+++ b/spec/factories/utility_hookup.rb
@@ -4,12 +4,10 @@ FactoryBot.define do
     association(:space)
 
     utility_slug { "null" }
-    trait :stripe do
-      utility_slug { "stripe" }
-    end
+  end
 
-    factory :stripe_utility do
-      utility_slug { "stripe" }
-    end
+  factory :stripe_utility do
+    utility_slug { "stripe" }
+    api_token { "not_real" }
   end
 end

--- a/spec/models/utility_hookup_spec.rb
+++ b/spec/models/utility_hookup_spec.rb
@@ -29,8 +29,7 @@ RSpec.describe UtilityHookup do
 
   describe "#configuration" do
     it "starts as an empty hash" do
-      uh = create(:stripe_utility)
-      expect(uh.configuration).to eq({})
+      expect(build(:utility_hookup).configuration).to eq({})
     end
 
     it "is encrypted" do


### PR DESCRIPTION
https://github.com/zinc-collective/convene/pull/1072/

I had introduced a bug when [I tried to clean up the UtilityHookup design](https://github.com/zinc-collective/convene/pull/1072/)