### PR TITLE
Show a link to add a Stripe API key if one isn't set

### DIFF
--- a/app/furniture/marketplace/locales/en.yml
+++ b/app/furniture/marketplace/locales/en.yml
@@ -8,6 +8,7 @@ en:
       edit: "Configure Marketplace"
     marketplaces:
       edit:
+        add_stripe_hookup_key: "Add a Stripe API key to %{space_name}"
         connect_stripe: "Connect to Stripe"
         stripe_connected: "Stripe Connected!"
       update:

--- a/app/furniture/marketplace/marketplace.rb
+++ b/app/furniture/marketplace/marketplace.rb
@@ -13,6 +13,12 @@ class Marketplace
       space.utility_hookups.find_by!(utility_slug: :stripe).utility.api_token
     end
 
+    def stripe_api_key?
+      stripe_api_key.present?
+    rescue ActiveRecord::RecordNotFound
+      false
+    end
+
     def stripe_account
       settings["stripe_account"]
     end

--- a/app/furniture/marketplace/marketplaces/edit.html.erb
+++ b/app/furniture/marketplace/marketplaces/edit.html.erb
@@ -2,11 +2,18 @@
 
 <%= render "form", marketplace: marketplace %>
 
-<%- if marketplace.stripe_account.present? %>
-  <%= t('.stripe_connected') %>
-<%- end %>
-<%= button_to t('.connect_stripe'), marketplace.location(child: :stripe_account), method: :post, data: { turbo: false } %>
+<%- if marketplace.stripe_api_key? %>
+  <%- if marketplace.stripe_account.present? %>
+    <%= t('.stripe_connected') %>
+  <%- end %>
+  <%= button_to t('.connect_stripe'),
+      marketplace.location(child: :stripe_account), method: :post, data: { turbo: false } %>
+<% else %>
+  <%= button_to t('.add_stripe_hookup_key', space_name: space.name),
+      space.location(:edit), method: :get, data: { turbo: false } %>
+<% end %>
 
 <%- if policy(marketplace.products.new).create? %>
-  <%= link_to t('marketplace.product.index'), marketplace.location(child: :products) %>
+  <%= button_to t('marketplace.product.index'),
+      marketplace.location(child: :products), method: :get, data: { turbo: false } %>
 <%- end %>


### PR DESCRIPTION
https://github.com/zinc-collective/convene/issues/831

Instead of prompting to "connect stripe account", which fails if there is no Stripe API key, now we prompt to add a Space-level Stripe API key.

Initially I was linking directly to `utility_hookups/new`, but the problem with that is that it is possible to have already a utility hookup for stripe, but no API key, so going to `space/edit` seems better for now.

At some point we'll want to surround these buttons with policy checks, because maybe the vendor setting up the marketplace doesn't have permissions to set up the Stripe hookup for the space.

### Before
https://user-images.githubusercontent.com/6729309/219253804-57217199-06f2-49a0-9e37-034f3fd11158.mp4

### After
https://user-images.githubusercontent.com/6729309/219254250-5764d484-8d53-4e32-931f-fbaa1ad2ee59.mp4


