### PR TITLE
`Stripe`: Add a bit of help to the UI about finding the Stripe API keys

### DIFF
--- a/app/utilities/stripe_utilities/_form.html.erb
+++ b/app/utilities/stripe_utilities/_form.html.erb
@@ -1,1 +1,5 @@
 <%= render "password_field", form: form, attribute: :api_token %>
+<small>
+  <%= t('.api_key_help') %>
+  <%= link_to "https://dashboard.stripe.com/apikeys", "https://dashboard.stripe.com/apikeys" %>
+</small>

--- a/app/views/spaces/edit.html.erb
+++ b/app/views/spaces/edit.html.erb
@@ -45,7 +45,7 @@
 
 
 <fieldset>
-  <h3>Utility Hookups</h3>
+  <h3>Utilities</h3>
   <%- space.utility_hookups.each do |utility_hookup| %>
     <%- if policy(utility_hookup).edit? %>
       <%= render partial: "utility_hookups/form", locals: { utility_hookup: utility_hookup } %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -68,7 +68,7 @@ Rails.application.configure do
   config.assets.quiet = true
 
   # Raises error for missing translations.
-  # config.i18n.raise_on_missing_translations = true
+  config.i18n.raise_on_missing_translations = true
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -68,7 +68,7 @@ Rails.application.configure do
   config.assets.quiet = true
 
   # Raises error for missing translations.
-  config.i18n.raise_on_missing_translations = true
+  # config.i18n.raise_on_missing_translations = true
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.

--- a/config/locales/utilities/stripe_utilities/en.yml
+++ b/config/locales/utilities/stripe_utilities/en.yml
@@ -1,0 +1,4 @@
+en:
+  stripe_utilities:
+    form:
+      api_key_help: You can find your Stripe API key in the Stripe Developer Dashboard


### PR DESCRIPTION
https://github.com/zinc-collective/convene/issues/1002

Because I need it every single time 😅

Also renamed "Utility Hookups" to "Utilities" in the UI.

### Before
![image](https://user-images.githubusercontent.com/6729309/219258510-3717f51b-f986-43ce-97fc-d2dff967b6e6.png)


### After
![image](https://user-images.githubusercontent.com/6729309/219258419-4b1df2cd-16f8-4b4a-b281-f0be621cdefc.png)
