### PR TITLE
`Marketplace`: Prevent race-condition in `Checkout`

### DIFF
--- a/app/furniture/marketplace/checkout.rb
+++ b/app/furniture/marketplace/checkout.rb
@@ -3,7 +3,7 @@ class Marketplace
     self.location_parent = :cart
     include ActiveModel::Validations
     attr_accessor :cart
-    delegate :shopper, :marketplace, to: :cart
+    delegate :shopper, :marketplace, :persisted?, to: :cart
 
     # It would be nice to validate instead the presence of :ordered_products, but my attempts at this raise:
     #  ActiveRecord::HasManyThroughCantAssociateThroughHasOneOrManyReflection:
@@ -25,14 +25,6 @@ class Marketplace
       }, {
         api_key: marketplace.stripe_api_key
       })
-    end
-
-    def complete(stripe_session_id:)
-      cart.update!(status: :paid, stripe_session_id: stripe_session_id)
-    end
-
-    def persisted?
-      true
     end
 
     private

--- a/app/furniture/marketplace/checkouts_controller.rb
+++ b/app/furniture/marketplace/checkouts_controller.rb
@@ -1,20 +1,11 @@
 class Marketplace
   class CheckoutsController < Controller
-    def show
-      authorize(checkout)
-      if params[:stripe_session_id].present?
-        checkout.complete(stripe_session_id: params[:stripe_session_id])
-        flash[:notice] = t(".success")
-      end
-      redirect_to order.location
-    end
-
     def create
       authorize(checkout)
 
       if checkout.valid?
         stripe_session = checkout.create_stripe_session(
-          success_url: "#{polymorphic_url(checkout.location)}?stripe_session_id={CHECKOUT_SESSION_ID}",
+          success_url: "#{polymorphic_url(order.location)}?stripe_session_id={CHECKOUT_SESSION_ID}",
           cancel_url: polymorphic_url(marketplace.location)
         )
         redirect_to stripe_session.url, status: :see_other, allow_other_host: true

--- a/app/furniture/marketplace/locales/en.yml
+++ b/app/furniture/marketplace/locales/en.yml
@@ -1,9 +1,6 @@
 
 en:
   marketplace:
-    checkouts:
-      show:
-        success: "You successfully checked out!"
     marketplace:
       edit: "Configure Marketplace"
     marketplaces:

--- a/spec/furniture/marketplace/checkout_spec.rb
+++ b/spec/furniture/marketplace/checkout_spec.rb
@@ -2,11 +2,4 @@ require "rails_helper"
 
 RSpec.describe Marketplace::Checkout, type: :model do
   subject(:checkout) { described_class.new(cart: create(:marketplace_cart)) }
-
-  describe "#complete" do
-    before { checkout.complete(stripe_session_id: "asdf") }
-
-    specify { expect(checkout.cart.stripe_session_id).to eql("asdf") }
-    specify { expect(checkout.cart).to be_paid }
-  end
 end

--- a/spec/furniture/marketplace/checkouts_controller_request_spec.rb
+++ b/spec/furniture/marketplace/checkouts_controller_request_spec.rb
@@ -9,17 +9,6 @@ RSpec.describe Marketplace::Checkout, type: :request do
 
   before { create(:stripe_utility, space: space) }
 
-  describe "#show" do
-    context "when a stripe_session_id is in the params" do
-      it "marks the cart as checked out" do
-        get polymorphic_path(checkout.location, {stripe_session_id: "12345"})
-
-        expect(cart.reload).to be_paid
-        expect(response).to redirect_to(cart.becomes(Marketplace::Order).location)
-      end
-    end
-  end
-
   describe "#create" do
     subject(:completed_request) {
       post polymorphic_path(checkout.location)


### PR DESCRIPTION
https://github.com/zinc-collective/convene/issues/831

So, it turns out *sometimes* Stripe will fire off that checkout session completed event faster than we can handle it!

Now that we listen for webhook events, it makes sense that we don't need to send people back to show their checkout; and can send them right on to their order.

Note: We may be able to get rid of the stripe checkout session id bits completely, since we use the transfer group as our key for looking up which order to apply the charge to.