### PR TITLE
`Neighborhood`: Use the appropriate Heroku plans

### DIFF
--- a/app.json
+++ b/app.json
@@ -49,13 +49,10 @@
       },
       "addons": [
         {
-          "plan": "heroku-postgresql:hobby-dev",
-          "options": {
-            "verison": "12"
-          }
+          "plan": "heroku-postgresql:mini"
         },
         {
-          "plan": "heroku-redis:hobby-dev"
+          "plan": "heroku-redis:mini"
         }
       ]
     }


### PR DESCRIPTION
https://github.com/zinc-collective/convene/issues/890

Well, now that Heroku got rid of their free tier I updated the app.json to:

1. Get rid of the explicit version, which was... spelled wrong anyway and doing nothing
2. Use the new Heroku plans, so that folks who are trying to launch a new deployment don't have that headscratcher.