### PR TITLE
`Neighborhood`: Delete dead `Client`-based `Blueprint`.

### DIFF
--- a/app/models/blueprint.rb
+++ b/app/models/blueprint.rb
@@ -4,12 +4,6 @@
 class Blueprint
   attr_accessor :attributes
 
-  def self.prepare_clients!
-    CLIENTS.each do |client_attributes|
-      Blueprint.new(client_attributes).find_or_create!
-    end
-  end
-
   def initialize(attributes)
     @attributes = attributes
   end
@@ -156,24 +150,4 @@ class Blueprint
       ]
     }
   }.with_indifferent_access
-
-  # @todo migrate this to a private configuration file!
-  CLIENTS = [{
-    client: {
-      name: "Zinc",
-      space: {
-        name: "Convene",
-        entrance: "landing-page",
-        members: [{email: "zee@zinc.coop"}],
-        rooms: [{
-          name: "Landing Page",
-          access_level: :unlocked,
-          publicity_level: :unlisted,
-          furniture_placements: {
-            markdown_text_block: {}
-          }
-        }]
-      }
-    }
-  }].freeze
 end

--- a/lib/tasks/release.rake
+++ b/lib/tasks/release.rake
@@ -4,6 +4,5 @@ namespace :release do
   desc "Ensures any post-release / pre-deploy behavior has occurred"
   task after_build: [:environment, "db:prepare"] do
     SystemTestSpace.prepare
-    Blueprint.prepare_clients!
   end
 end


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/476
- https://github.com/zinc-collective/convene/issues/890

This was put in place to reduce cost-of-setup, but is no longer necessary.