### PR TITLE
`Space`: `Entrance` may be set via UI

### DIFF
--- a/app/policies/space_policy.rb
+++ b/app/policies/space_policy.rb
@@ -23,7 +23,7 @@ class SpacePolicy < ApplicationPolicy
   alias_method :create?, :destroy?
 
   def permitted_attributes(_params)
-    [:name, :slug, :theme, :blueprint, client_attributes: [:name]]
+    [:name, :slug, :theme, :entrance_id, :blueprint, client_attributes: [:name]]
   end
 
   class Scope < ApplicationScope

--- a/app/views/spaces/edit.html.erb
+++ b/app/views/spaces/edit.html.erb
@@ -39,6 +39,7 @@
                include_blank: false,
                options: Space::THEME_OPTIONS.map { |t| [t.titleize, t] },
                form: space_form %>
+    <%= render "select", attribute: :entrance_id, include_blank: true, options: space.rooms.map { |r| [r.name, r.id] }, form: space_form %>
     <%= space_form.submit %>
   <%- end %>
 </fieldset>

--- a/app/views/spaces/edit.html.erb
+++ b/app/views/spaces/edit.html.erb
@@ -39,7 +39,7 @@
                include_blank: false,
                options: Space::THEME_OPTIONS.map { |t| [t.titleize, t] },
                form: space_form %>
-    <%= render "select", attribute: :entrance_id, include_blank: true, options: space.rooms.map { |r| [r.name, r.id] }, form: space_form %>
+    <%= render "select", attribute: :entrance_id, include_blank: true, options: space.rooms.map { |room| [room.name, room.id] }, form: space_form %>
     <%= space_form.submit %>
   <%- end %>
 </fieldset>


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1154

Turns out, we had never exposed an affordance for setting the `Space` entrance! Whoopsie-doodle!