### PR TITLE
`Operator`: a `Person` may be a `Neighborhood` `Operator`

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -21,10 +21,6 @@ class Person < ApplicationRecord
     spaces.include?(space)
   end
 
-  def operator?
-    false
-  end
-
   def display_name
     return name if name.present?
 

--- a/app/policies/furniture_placement_policy.rb
+++ b/app/policies/furniture_placement_policy.rb
@@ -16,7 +16,7 @@ class FurniturePlacementPolicy < ApplicationPolicy
   end
 
   def update?
-    person&.member_of?(furniture_placement.space)
+    person&.operator? || person&.member_of?(furniture_placement.space)
   end
 
   alias_method :edit?, :update?

--- a/app/policies/room_policy.rb
+++ b/app/policies/room_policy.rb
@@ -6,11 +6,11 @@ class RoomPolicy < ApplicationPolicy
 
   def show?
     return true if room.unlocked? || room.locked?
-    return true if room.internal? && person&.member_of?(space)
+    return true if room.internal? && (person&.member_of?(space) || person&.operator?)
   end
 
   def create?
-    person&.member_of?(space)
+    person&.member_of?(space) || person&.operator?
   end
 
   alias_method :edit?, :create?

--- a/app/policies/space_policy.rb
+++ b/app/policies/space_policy.rb
@@ -10,7 +10,7 @@ class SpacePolicy < ApplicationPolicy
   def update?
     return false unless person
 
-    person.member_of?(space)
+    person.member_of?(space) || person.operator?
   end
 
   alias_method :new?, :update?

--- a/app/policies/utility_hookup_policy.rb
+++ b/app/policies/utility_hookup_policy.rb
@@ -16,7 +16,7 @@ class UtilityHookupPolicy < ApplicationPolicy
   def create?
     return false unless person
 
-    person.member_of?(utility_hookup.space)
+    person.member_of?(utility_hookup.space) || person.operator?
   end
 
   def index?

--- a/db/migrate/20230227232512_add_operator_to_person.rb
+++ b/db/migrate/20230227232512_add_operator_to_person.rb
@@ -1,0 +1,5 @@
+class AddOperatorToPerson < ActiveRecord::Migration[7.0]
+  def change
+    add_column :people, :operator, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_23_015357) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_27_232512) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -182,6 +182,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_23_015357) do
     t.string "email", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "operator", default: false
     t.index ["email"], name: "index_people_on_email", unique: true
   end
 

--- a/spec/policies/room_policy_spec.rb
+++ b/spec/policies/room_policy_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe RoomPolicy do
   let(:membership) { create(:membership, space: room.space) }
   let(:member) { membership.member }
   let(:non_member) { create(:person) }
+  let(:operator) { create(:person, operator: true) }
 
   describe "Internal Rooms" do
     let(:room) { create(:room, :internal) }
@@ -14,6 +15,7 @@ RSpec.describe RoomPolicy do
     permissions :show? do
       it { is_expected.not_to permit(nil, room) }
       it { is_expected.to permit(member, room) }
+      it { is_expected.to permit(operator, room) }
       it { is_expected.not_to permit(non_member, room) }
     end
   end
@@ -24,6 +26,7 @@ RSpec.describe RoomPolicy do
     permissions :show? do
       it { is_expected.to permit(nil, room) }
       it { is_expected.to permit(member, room) }
+      it { is_expected.to permit(operator, room) }
       it { is_expected.to permit(non_member, room) }
     end
   end
@@ -36,6 +39,7 @@ RSpec.describe RoomPolicy do
     permissions :show? do
       it { is_expected.to permit(nil, room) }
       it { is_expected.to permit(member, room) }
+      it { is_expected.to permit(operator, room) }
       it { is_expected.to permit(non_member, room) }
     end
   end
@@ -43,6 +47,7 @@ RSpec.describe RoomPolicy do
   permissions :new?, :create?, :update?, :edit?, :destroy? do
     it { is_expected.not_to permit(nil, room) }
     it { is_expected.to permit(member, room) }
+    it { is_expected.to permit(operator, room) }
     it { is_expected.not_to permit(non_member, room) }
   end
 

--- a/spec/policies/space_policy_spec.rb
+++ b/spec/policies/space_policy_spec.rb
@@ -6,10 +6,13 @@ RSpec.describe SpacePolicy do
   let(:membership) { create(:membership) }
   let(:space) { membership.space }
   let(:member) { membership.member }
-  let(:non_member) { create((:person)) }
+  let(:non_member) { create(:person) }
+  let(:operator) { create(:person, operator: true)}
 
   permissions :update?, :edit? do
     it { is_expected.to permit(member, space) }
+    it { is_expected.to permit(operator, space) }
+
     it { is_expected.not_to permit(non_member, space) }
     it { is_expected.not_to permit(nil, space) }
   end

--- a/spec/policies/utility_hookup_policy_spec.rb
+++ b/spec/policies/utility_hookup_policy_spec.rb
@@ -6,16 +6,19 @@ RSpec.describe UtilityHookupPolicy do
   let(:space) { create(:space, :with_members) }
   let(:utility_hookup) { create(:utility_hookup, space: space) }
   let(:member) { space.members.first }
+  let(:operator) { create(:person, operator: true)}
   let(:non_member) { create(:person) }
 
   permissions :show? do
     it { is_expected.to permit(nil, utility_hookup) }
     it { is_expected.to permit(member, utility_hookup) }
+    it { is_expected.to permit(operator, utility_hookup) }
     it { is_expected.to permit(non_member, utility_hookup) }
   end
 
   permissions :new?, :create?, :edit?, :update? do
     it { is_expected.to permit(member, utility_hookup) }
+    it { is_expected.to permit(operator, utility_hookup) }
     it { is_expected.not_to permit(non_member, utility_hookup) }
     it { is_expected.not_to permit(nil, utility_hookup) }
   end


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/892
- https://github.com/zinc-collective/convene/issues/103

`Operator`s run the whole show, and have broad permissions, including being able to create/update/destroy `Neighborhood`, `Room`, `Space`, `Utility`, `Furniture`, etc.

It may make sense for them to by default do anything on any object; but I didn't want to do that yet.