### PR TITLE
🧹 `Neighborhood`: Respect `pundit`s syntax, `rubocop-rspec`!

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ require:
 
 inherit_gem:
   standard: config/base.yml
+  pundit: config/rubocop-rspec.yml
 
 AllCops:
   Exclude:


### PR DESCRIPTION
- See: https://github.com/varvet/pundit/tree/v2.3.0#linting-with-rubocop-rspec

Before: `273 files inspected, 235 offenses detected, 94 offenses autocorrectable`
After:  `273 files inspected, 213 offenses detected, 98 offenses autocorrectable`