### PR TITLE
🏎️ `Membership`: Find `current_membership` through `Person`, not `Space` 

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -120,7 +120,7 @@ class ApplicationController < ActionController::Base
 
   helper_method def current_membership
     @current_membership ||= if current_space.present? && current_person.present?
-      current_space.memberships.find_by(member: current_person)
+      current_person.memberships.find_by(space: current_space)
     end
   end
 


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/117

This is likely a premature optimization, but my inclination is that a `Person` will likely have fewer `Membership`s than a `Space` does; which means the index on `Membership#space_id` will likely require more compute to locate the particular `Membership` than the `Membership#person_id` index.