### PR TITLE
🧹 `Neighborhood`: Update `bundler` gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -469,4 +469,4 @@ RUBY VERSION
    ruby 3.1.3p185
 
 BUNDLED WITH
-   2.2.33
+   2.4.7


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/892

This gets rid of the following deprecation warning:

```
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call
`DidYouMean.correct_error(error_name, spell_checker)' instead.
```