### PR TITLE
🔐 `Marketplace`: Encrypt `Order#delivery_address`!

### DIFF
--- a/app/furniture/marketplace/cart.rb
+++ b/app/furniture/marketplace/cart.rb
@@ -15,6 +15,8 @@ class Marketplace
     has_many :cart_products, dependent: :destroy, inverse_of: :cart
     has_many :products, through: :cart_products, inverse_of: :carts
 
+    has_encrypted :delivery_address, migrating: true
+
     enum status: {
       pre_checkout: "pre_checkout",
       paid: "paid"

--- a/app/furniture/marketplace/order.rb
+++ b/app/furniture/marketplace/order.rb
@@ -11,7 +11,7 @@ class Marketplace
     has_many :ordered_products, inverse_of: :order, foreign_key: :cart_id
     has_many :products, through: :ordered_products, inverse_of: :orders
 
-    has_encrypted :delivery_address
+    has_encrypted :delivery_address, migrating: true
 
     enum status: {
       pre_checkout: "pre_checkout",

--- a/app/furniture/marketplace/order.rb
+++ b/app/furniture/marketplace/order.rb
@@ -11,7 +11,7 @@ class Marketplace
     has_many :ordered_products, inverse_of: :order, foreign_key: :cart_id
     has_many :products, through: :ordered_products, inverse_of: :orders
 
-    attribute :delivery_address, :string
+    has_encrypted :delivery_address
 
     enum status: {
       pre_checkout: "pre_checkout",

--- a/db/migrate/20230302202459_marketplace_encrypt_order_delivery_address.rb
+++ b/db/migrate/20230302202459_marketplace_encrypt_order_delivery_address.rb
@@ -1,6 +1,5 @@
 class MarketplaceEncryptOrderDeliveryAddress < ActiveRecord::Migration[7.0]
   def change
-    rename_column :marketplace_orders, :delivery_address, :deprecated_delivery_address
     add_column :marketplace_orders, :delivery_address_ciphertext, :text
   end
 end

--- a/db/migrate/20230302202459_marketplace_encrypt_order_delivery_address.rb
+++ b/db/migrate/20230302202459_marketplace_encrypt_order_delivery_address.rb
@@ -1,0 +1,6 @@
+class MarketplaceEncryptOrderDeliveryAddress < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :marketplace_orders, :delivery_address, :deprecated_delivery_address
+    add_column :marketplace_orders, :delivery_address_ciphertext, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -134,7 +134,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_02_202459) do
     t.uuid "shopper_id"
     t.string "status", default: "pre_checkout", null: false
     t.string "stripe_session_id"
-    t.string "deprecated_delivery_address"
+    t.string "delivery_address"
     t.string "contact_email"
     t.text "delivery_address_ciphertext"
     t.index ["marketplace_id"], name: "index_marketplace_orders_on_marketplace_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_02_024315) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_02_202459) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -134,8 +134,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_02_024315) do
     t.uuid "shopper_id"
     t.string "status", default: "pre_checkout", null: false
     t.string "stripe_session_id"
-    t.string "delivery_address"
+    t.string "deprecated_delivery_address"
     t.string "contact_email"
+    t.text "delivery_address_ciphertext"
     t.index ["marketplace_id"], name: "index_marketplace_orders_on_marketplace_id"
     t.index ["shopper_id"], name: "index_marketplace_orders_on_shopper_id"
   end

--- a/lib/tasks/release.rake
+++ b/lib/tasks/release.rake
@@ -3,6 +3,12 @@
 namespace :release do
   desc "Ensures any post-release / pre-deploy behavior has occurred"
   task after_build: [:environment, "db:prepare"] do
+    # @todo Delete after running in prod
+    Marketplace::Order.all.find_each do |order|
+      next unless order.deprecated_delivery_address.present?
+
+      order.update(delivery_address: order.deprecated_delivery_address, deprecated_delivery_address: nil)
+    end
     SystemTestSpace.prepare
   end
 end

--- a/lib/tasks/release.rake
+++ b/lib/tasks/release.rake
@@ -3,12 +3,7 @@
 namespace :release do
   desc "Ensures any post-release / pre-deploy behavior has occurred"
   task after_build: [:environment, "db:prepare"] do
-    # @todo Delete after running in prod
-    Marketplace::Order.all.find_each do |order|
-      next unless order.deprecated_delivery_address.present?
-
-      order.update(delivery_address: order.deprecated_delivery_address, deprecated_delivery_address: nil)
-    end
+    Lockbox.migrate(Marketplace::Order)
     SystemTestSpace.prepare
   end
 end


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1136
- https://github.com/zinc-collective/convene/issues/831

So, I totally didn't think about how delivery addresses are PII and probably should not be stored in plaintext! Womp. Womp. Womp.

Now they ain't!

We'll want to delete the `release:after_build` bits after a prod deploy.