### PR TITLE
🐞 `Space`: Fix broken `SpacesController#new` action

### DIFF
--- a/app/views/spaces/new.html.erb
+++ b/app/views/spaces/new.html.erb
@@ -1,9 +1,5 @@
 <%= form_with(model: space) do |form| %>
   <%= render "text_field", attribute: :name, form: form %>
 
-  <%= form.fields_for(:client, space.client || space.build_client) do |client_form|%>
-    <%= render "text_field", attribute: :name, form: client_form %>
-  <%- end %>
-
   <%= form.submit %>
 <%- end %>

--- a/spec/requests/spaces_controller_request_spec.rb
+++ b/spec/requests/spaces_controller_request_spec.rb
@@ -5,39 +5,6 @@ require "swagger_helper"
 RSpec.describe SpacesController do
   include ActiveJob::TestHelper
 
-  describe "#show" do
-    subject(:perform_request) do
-      get url
-      test_response
-    end
-
-    let(:space) { create(:space) }
-    let(:url) { polymorphic_url(space) }
-
-    it { is_expected.to be_ok }
-    specify { perform_request && assert_select("##{dom_id(space)}") }
-
-    context "with a branded domain" do
-      let(:space) { create(:space, branded_domain: "beta.example.com") }
-
-      context "when accessing via the neighborhood url" do
-        it { is_expected.to redirect_to "http://beta.example.com" }
-      end
-
-      context "when accessing via domain" do
-        before do
-          space
-          host! "beta.example.com"
-        end
-
-        let(:url) { "http://beta.example.com" }
-
-        it { is_expected.to be_ok }
-        specify { perform_request && assert_select("##{dom_id(space)}") }
-      end
-    end
-  end
-
   path "/spaces" do
     include ApiHelpers::Path
 
@@ -88,8 +55,42 @@ RSpec.describe SpacesController do
       end
     end
   end
+
+  describe "#show" do
+    subject(:perform_request) do
+      get url
+      test_response
+    end
+
+    let(:space) { create(:space) }
+    let(:url) { polymorphic_url(space) }
+
+    it { is_expected.to be_ok }
+    specify { perform_request && assert_select("##{dom_id(space)}") }
+
+    context "with a branded domain" do
+      let(:space) { create(:space, branded_domain: "beta.example.com") }
+
+      context "when accessing via the neighborhood url" do
+        it { is_expected.to redirect_to "http://beta.example.com" }
+      end
+
+      context "when accessing via domain" do
+        before do
+          space
+          host! "beta.example.com"
+        end
+
+        let(:url) { "http://beta.example.com" }
+
+        it { is_expected.to be_ok }
+        specify { perform_request && assert_select("##{dom_id(space)}") }
+      end
+    end
+  end
+
   describe "#destroy" do
-    context "as an Operator using the API" do
+    context "when an an Operator using the AP" do
       it "deletes the space and all it's other bits" do
         SystemTestSpace.prepare
 
@@ -129,6 +130,26 @@ RSpec.describe SpacesController do
         expect(space.reload.theme).to eq("purple_mountains")
         expect(flash[:alert]).to include("went wrong")
       end
+    end
+  end
+
+  describe "#new" do
+    subject(:result) do
+      sign_in(nil, user)
+      get polymorphic_path([:new, :space])
+      response
+    end
+
+    context "when not logged in" do
+      let(:user) { nil }
+
+      it { is_expected.to be_not_found }
+    end
+
+    context "when an Operator" do
+      let(:user) { create(:person, operator: true) }
+
+      it { is_expected.to be_ok }
     end
   end
 end

--- a/spec/support/auth_helpers.rb
+++ b/spec/support/auth_helpers.rb
@@ -8,7 +8,7 @@ module AuthHelpers
 
     authentication_method.bump_one_time_password!
 
-    post(space_authenticated_session_path(space),
+    post(polymorphic_path([space, :authenticated_session].compact),
       params: {authenticated_session: {
         authentication_method_id: authentication_method.id,
         one_time_password: authentication_method.one_time_password


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1154
- https://github.com/zinc-collective/convene/pull/1161
- https://github.com/zinc-collective/convene/pull/1141

Deleting the `Client` was great! But when we merged the `Neighborhood` first-run PR, we still had the `Client#name` field; which no longer exists.

So now there's two tests for the `SpacesController#new` action:
- 1 to catch any errors in the happy-path request/response cycle
- 1 to make sure `Guest`s cant create a Space