### PR TITLE
✨ `Marketplace`: Collect `Shopper`s Delivery Address before `Checkout`

### DIFF
--- a/app/furniture/marketplace/cart.rb
+++ b/app/furniture/marketplace/cart.rb
@@ -28,7 +28,11 @@ class Marketplace
       end
     end
 
-    delegate :delivery_fee, to: :marketplace
+    def delivery_fee
+      return marketplace.delivery_fee if delivery_address.present?
+
+      0
+    end
 
     def price_total
       product_total + delivery_fee

--- a/app/furniture/marketplace/cart_policy.rb
+++ b/app/furniture/marketplace/cart_policy.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class Marketplace
+  class CartPolicy < ApplicationPolicy
+    alias_method :cart, :object
+    def permitted_attributes(_params = nil)
+      %i[delivery_address]
+    end
+
+    def create?
+      true
+    end
+
+    def update?
+      cart.shopper.person == current_person
+    end
+
+    class Scope < ApplicationScope
+      def resolve
+        scope.all
+      end
+    end
+  end
+end

--- a/app/furniture/marketplace/cart_policy.rb
+++ b/app/furniture/marketplace/cart_policy.rb
@@ -12,7 +12,7 @@ class Marketplace
     end
 
     def update?
-      cart.shopper.person == current_person
+      cart.shopper.person.nil? || cart.shopper.person == current_person
     end
 
     class Scope < ApplicationScope

--- a/app/furniture/marketplace/carts/_cart.html.erb
+++ b/app/furniture/marketplace/carts/_cart.html.erb
@@ -12,7 +12,7 @@
         Delivering to <%= cart.delivery_address %>
 
       </p>
-      <%= button_to "Change Address", cart.location, params: { cart: { delivery_address: nil } }%>
+      <%= button_to "Update Address", cart.location, params: { cart: { delivery_address: nil } }%>
     </div>
 
   <%- end %>

--- a/app/furniture/marketplace/carts/_cart.html.erb
+++ b/app/furniture/marketplace/carts/_cart.html.erb
@@ -15,30 +15,29 @@
       <%= button_to "Update Address", cart.location, params: { cart: { delivery_address: nil } }%>
     </div>
 
+    <div class="-mx-4 mt-8 overflow-hidden shadow ring-1 ring-black ring-opacity-5 sm:-mx-6 md:mx-0 md:rounded-lg">
+      <table class="min-w-full divide-y divide-gray-300 table-fixed">
+        <thead class="bg-gray-50">
+          <tr>
+            <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">
+              <%= Marketplace::Product.human_attribute_name(:name) %>
+            </th>
+            <th scope="col" class="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 lg:table-cell">
+              <%= Marketplace::Product.human_attribute_name(:description) %>
+            </th>
+            <th scope="col" class="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 sm:table-cell">
+              <%= Marketplace::Product.human_attribute_name(:price) %>
+            </th>
+            <th  scope="col" class="w-48">&nbsp;</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-200 bg-white">
+          <%- cart.marketplace.products.each do |product| %>
+            <%= render cart.cart_products.find_or_initialize_by(product: product) %>
+          <%- end %>
+        </tbody>
+        <%= render "marketplace/carts/footer", cart: cart %>
+      </table>
+    </div>
   <%- end %>
-
-  <div class="-mx-4 mt-8 overflow-hidden shadow ring-1 ring-black ring-opacity-5 sm:-mx-6 md:mx-0 md:rounded-lg">
-    <table class="min-w-full divide-y divide-gray-300 table-fixed">
-      <thead class="bg-gray-50">
-        <tr>
-          <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">
-            <%= Marketplace::Product.human_attribute_name(:name) %>
-          </th>
-          <th scope="col" class="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 lg:table-cell">
-            <%= Marketplace::Product.human_attribute_name(:description) %>
-          </th>
-          <th scope="col" class="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 sm:table-cell">
-            <%= Marketplace::Product.human_attribute_name(:price) %>
-          </th>
-          <th  scope="col" class="w-48">&nbsp;</th>
-        </tr>
-      </thead>
-      <tbody class="divide-y divide-gray-200 bg-white">
-        <%- cart.marketplace.products.each do |product| %>
-          <%= render cart.cart_products.find_or_initialize_by(product: product) %>
-        <%- end %>
-      </tbody>
-      <%= render "marketplace/carts/footer", cart: cart %>
-    </table>
-  </div>
 </div>

--- a/app/furniture/marketplace/carts/_cart.html.erb
+++ b/app/furniture/marketplace/carts/_cart.html.erb
@@ -1,24 +1,44 @@
-<div class="-mx-4 mt-8 overflow-hidden shadow ring-1 ring-black ring-opacity-5 sm:-mx-6 md:mx-0 md:rounded-lg">
-  <table class="min-w-full divide-y divide-gray-300 table-fixed">
-    <thead class="bg-gray-50">
-      <tr>
-        <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">
-          <%= Marketplace::Product.human_attribute_name(:name) %>
-        </th>
-        <th scope="col" class="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 lg:table-cell">
-          <%= Marketplace::Product.human_attribute_name(:description) %>
-        </th>
-        <th scope="col" class="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 sm:table-cell">
-          <%= Marketplace::Product.human_attribute_name(:price) %>
-        </th>
-        <th  scope="col" class="w-48">&nbsp;</th>
-      </tr>
-    </thead>
-    <tbody class="divide-y divide-gray-200 bg-white">
-      <%- cart.marketplace.products.each do |product| %>
-        <%= render cart.cart_products.find_or_initialize_by(product: product) %>
-      <%- end %>
-    </tbody>
-    <%= render "marketplace/carts/footer", cart: cart %>
-  </table>
+<div id="<%= dom_id(cart) %>">
+
+  <%- if cart.delivery_address.blank? %>
+    <%= form_with model: cart.location do |cart_form| %>
+      <%= render "text_field", attribute: :delivery_address, form: cart_form %>
+
+      <%= cart_form.submit %>
+    <%- end %>
+  <%- else %>
+    <div class="flex flex-wrap">
+      <p class="p-3">
+        Delivering to <%= cart.delivery_address %>
+
+      </p>
+      <%= button_to "Change Address", cart.location, params: { cart: { delivery_address: nil } }%>
+    </div>
+
+  <%- end %>
+
+  <div class="-mx-4 mt-8 overflow-hidden shadow ring-1 ring-black ring-opacity-5 sm:-mx-6 md:mx-0 md:rounded-lg">
+    <table class="min-w-full divide-y divide-gray-300 table-fixed">
+      <thead class="bg-gray-50">
+        <tr>
+          <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">
+            <%= Marketplace::Product.human_attribute_name(:name) %>
+          </th>
+          <th scope="col" class="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 lg:table-cell">
+            <%= Marketplace::Product.human_attribute_name(:description) %>
+          </th>
+          <th scope="col" class="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 sm:table-cell">
+            <%= Marketplace::Product.human_attribute_name(:price) %>
+          </th>
+          <th  scope="col" class="w-48">&nbsp;</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-gray-200 bg-white">
+        <%- cart.marketplace.products.each do |product| %>
+          <%= render cart.cart_products.find_or_initialize_by(product: product) %>
+        <%- end %>
+      </tbody>
+      <%= render "marketplace/carts/footer", cart: cart %>
+    </table>
+  </div>
 </div>

--- a/app/furniture/marketplace/carts/_footer.html.erb
+++ b/app/furniture/marketplace/carts/_footer.html.erb
@@ -8,8 +8,9 @@
   <tr>
     <td class="text-left px-3 py-3.5 text-right" colspan="8">
       <%= render "marketplace/carts/total", cart: cart %>
-      <%= button_to("Checkout", cart.location(child: :checkout), data: { turbo: false }) %>
+      <%- if cart.delivery_address.present? %>
+        <%= button_to("Checkout", cart.location(child: :checkout), data: { turbo: false }) %>
+      <%- end %>
     </td>
-
   </tr>
 </tfoot>

--- a/app/furniture/marketplace/carts/_total.html.erb
+++ b/app/furniture/marketplace/carts/_total.html.erb
@@ -3,7 +3,7 @@
     Products:
     <%= humanized_money_with_symbol(cart.product_total) %></span>
   <%- if cart.delivery_address.present? %>
-    <span>Delivery:
+    <span>Delivery Fee:
       <%= humanized_money_with_symbol(cart.delivery_fee) %></span>
   <%- end %>
   <span class="font-bold">

--- a/app/furniture/marketplace/carts/_total.html.erb
+++ b/app/furniture/marketplace/carts/_total.html.erb
@@ -1,10 +1,12 @@
-<span id="cart-total-<%= cart.id%>" class="w-full flex flex-col">
-  <span class="text-right">
+<span id="cart-total-<%= cart.id%>" class="w-full flex flex-col sm:text-right">
+  <span>
     Products:
     <%= humanized_money_with_symbol(cart.product_total) %></span>
-  <span class="text-right">Delivery:
-    <%= humanized_money_with_symbol(cart.delivery_fee) %></span>
-  <span class="text-right font-bold">
+  <%- if cart.delivery_address.present? %>
+    <span>Delivery:
+      <%= humanized_money_with_symbol(cart.delivery_fee) %></span>
+  <%- end %>
+  <span class="font-bold">
     Total: <%= humanized_money_with_symbol(cart.price_total) %>
     </span>
 </span>

--- a/app/furniture/marketplace/carts_controller.rb
+++ b/app/furniture/marketplace/carts_controller.rb
@@ -1,0 +1,24 @@
+class Marketplace
+  class CartsController < Controller
+    def update
+      authorize(cart)
+      cart.update(cart_params)
+      respond_to do |format|
+        format.html do
+          redirect_to cart.room.location
+        end
+        format.turbo_stream do
+          render turbo_stream: [turbo_stream.replace(dom_id(cart), cart)]
+        end
+      end
+    end
+
+    def cart
+      @cart ||= policy_scope(marketplace.carts).find(params[:id])
+    end
+
+    def cart_params
+      policy(Cart).permit(params.require(:cart))
+    end
+  end
+end

--- a/app/furniture/marketplace/checkout.rb
+++ b/app/furniture/marketplace/checkout.rb
@@ -16,9 +16,6 @@ class Marketplace
         mode: "payment",
         success_url: success_url,
         cancel_url: cancel_url,
-        shipping_address_collection: {
-          allowed_countries: ["US"],
-        },
         payment_intent_data: {
           transfer_group: cart.id
         }

--- a/spec/furniture/marketplace/cart_spec.rb
+++ b/spec/furniture/marketplace/cart_spec.rb
@@ -22,7 +22,13 @@ RSpec.describe Marketplace::Cart, type: :model do
       cart.cart_products.create!(product: product_b, quantity: 2)
     end
 
-    it { is_expected.to eql(product_a.price + product_b.price + product_b.price + marketplace.delivery_fee) }
+    it { is_expected.to eql(product_a.price + product_b.price * 2) }
+
+    context "when the #delivery_address is present" do
+      let(:cart) { create(:marketplace_cart, delivery_address: "123", marketplace: marketplace) }
+
+      it { is_expected.to eql(product_a.price + product_b.price + product_b.price + marketplace.delivery_fee) }
+    end
   end
 
   describe "#product_total" do

--- a/spec/furniture/marketplace/cart_spec.rb
+++ b/spec/furniture/marketplace/cart_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Marketplace::Cart, type: :model do
     context "when the #delivery_address is present" do
       let(:cart) { create(:marketplace_cart, delivery_address: "123", marketplace: marketplace) }
 
-      it { is_expected.to eql(product_a.price + product_b.price + product_b.price + marketplace.delivery_fee) }
+      it { is_expected.to eql(product_a.price + product_b.price * 2 + marketplace.delivery_fee) }
     end
   end
 

--- a/spec/furniture/marketplace/carts_controller_request_spec.rb
+++ b/spec/furniture/marketplace/carts_controller_request_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe Marketplace::CartsController, type: :request do
+  let(:marketplace) { create(:marketplace) }
+  let(:space) { marketplace.space }
+  let(:room) { marketplace.room }
+  let(:person) { create(:person) }
+
+  let(:shopper) { create(:marketplace_shopper, person: person) }
+
+  describe "#update" do
+    it "changes the delivery address" do
+      cart = create(:marketplace_cart, marketplace: marketplace, shopper: shopper)
+      sign_in(space, person)
+
+      put polymorphic_path(cart.location), params: {cart: {delivery_address: "123 N West St"}}
+
+      expect(response).to redirect_to(room.location)
+    end
+  end
+end


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1136

While collecting the address via Stripe was reasonable at the time, if we want to support dynamic pricing, we'll need the address ahead of time.

This will also (theoretically) allow us to let people know when they are outside of the `Distributor` delivery area.

## After!


https://user-images.githubusercontent.com/50284/222832192-12b8f715-b0d5-4d1e-bd09-9dfdcf8f9d9a.mp4



## Before

https://user-images.githubusercontent.com/50284/222587195-9b7b01e9-5fd1-4732-824f-663516c5c83e.mp4

