### PR TITLE
🧹 `Utility`: Use `UtilityHookup#location` in forms

### DIFF
--- a/app/models/utility_hookup.rb
+++ b/app/models/utility_hookup.rb
@@ -4,6 +4,7 @@
 class UtilityHookup < ApplicationRecord
   # @return [Space]
   belongs_to :space
+  self.location_parent = :space
 
   # Human-friendly name for disambiguating when a particular kind of {Hookup}
   # has multiple {UtilityHookup}s.

--- a/app/views/utility_hookups/_form.html.erb
+++ b/app/views/utility_hookups/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: [space, utility_hookup]) do |form| %>
+<%= form_with(model: utility_hookup.location) do |form| %>
   <%- form.object = form.object.utility %>
   <%= form.hidden_field :utility_slug %>
   <header>

--- a/app/views/utility_hookups/new.html.erb
+++ b/app/views/utility_hookups/new.html.erb
@@ -1,5 +1,6 @@
 <%- breadcrumb :new_utility_hookup, utility_hookup %>
-<%= form_with(model: [utility_hookup.space, utility_hookup], local: true) do |form| %>
+
+<%= form_with(model: utility_hookup.location) do |form| %>
   <%= render "select", attribute: :utility_slug, options: Utilities::REGISTRY.keys, form: form %>
   <%= render "text_field", attribute: :name, form: form %>
   <%= form.submit %>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -33,12 +33,12 @@ crumb :invitations do |space|
 end
 
 crumb :utility_hookups do |space|
-  link "Utility Hookups", [space, :utility_hookups]
+  link "Utility Hookups", space.location(child: :utility_hookups)
   parent :edit_space, space
 end
 
 crumb :new_utility_hookup do |utility_hookup|
-  link "New Utility Hookup", [:new, utility_hookup.space, :utility_hookup]
+  link "New Utility Hookup", utility_hookup.location
   parent :utility_hookups, utility_hookup.space
 end
 


### PR DESCRIPTION
- Extracted from htps://github.com/zinc-collective/convene/pull/1083

This is mostly for consistency and to start to close out a piece of work I started a while back but never finished.