### PR TITLE
🧹 `Furniture`: use `FurniturePlacement#location` in forms

### DIFF
--- a/app/views/furniture_placements/_new.html.erb
+++ b/app/views/furniture_placements/_new.html.erb
@@ -1,6 +1,6 @@
 <fieldset id="new_furniture_placement">
   <h3><%= t('rooms.place_furniture_heading') %></h3>
-  <%= form_with model: [furniture_placement.room.space, furniture_placement.room, furniture_placement] do | placement_form | %>
+  <%= form_with model: furniture_placement.location do | placement_form | %>
     <%= placement_form.hidden_field :slot, value: furniture_placement.room.furniture_placements.count %>
     <%= placement_form.select :furniture_kind, Furniture::REGISTRY.keys.map { |k| [k.to_s.titleize, k] } %>
     <footer>


### PR DESCRIPTION
- Extracted from: https://github.com/zinc-collective/convene/pull/1083
- https://github.com/zinc-collective/convene/issues/74
- https://github.com/zinc-collective/convene/issues/709