### PR TITLE
🛠️ `Component`: Set up `view_component` `Preview`s

### DIFF
--- a/app/views/layouts/component_preview.html.erb
+++ b/app/views/layouts/component_preview.html.erb
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title></title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+    <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
+    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+  </head>
+
+  <body>
+    <%= yield %>
+  </body>
+</html>

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,5 +37,8 @@ module ConveneWeb
 
     config.i18n.load_path += Dir[Rails.root.join("config", "locales", "**", "*.{rb,yml}")]
     config.i18n.load_path += Dir[Rails.root.join("app", "furniture", "**", "locales", "**", "*.{rb,yml}")]
+
+    config.view_component.preview_paths << "#{Rails.root}/spec/components/previews"
+    config.view_component.default_preview_layout = "component_preview"
   end
 end


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1187

This is an intermediary step before we look into `LookBook` or similar which:

1. Makes it possible to define component previews in `spec/components/previews`
2. Creates a basic layout for showing Components
