### PR TITLE
🧹🔐🛠️ `Marketplace`: Fully exercise `Policy` objects

### DIFF
--- a/app/furniture/marketplace/cart_policy.rb
+++ b/app/furniture/marketplace/cart_policy.rb
@@ -1,18 +1,10 @@
 # frozen_string_literal: true
 
 class Marketplace
-  class CartPolicy < ApplicationPolicy
+  class CartPolicy < Policy
     alias_method :cart, :object
     def permitted_attributes(_params = nil)
       %i[delivery_address]
-    end
-
-    def create?
-      true
-    end
-
-    def update?
-      cart.shopper.person.nil? || cart.shopper.person == current_person
     end
 
     class Scope < ApplicationScope

--- a/app/furniture/marketplace/cart_product.rb
+++ b/app/furniture/marketplace/cart_product.rb
@@ -5,9 +5,10 @@ class Marketplace
     self.table_name = "marketplace_cart_products"
 
     belongs_to :cart, inverse_of: :cart_products
+    delegate :shopper, to: :cart
 
     belongs_to :product, inverse_of: :cart_products
-    delegate :name, :description, :price, :price_cents, to: :product
+    delegate :name, :description, :marketplace, :price, :price_cents, to: :product
 
     validates_uniqueness_of :product, scope: :cart_id
     validate :editable_cart

--- a/app/furniture/marketplace/cart_product_policy.rb
+++ b/app/furniture/marketplace/cart_product_policy.rb
@@ -1,18 +1,9 @@
 # frozen_string_literal: true
 
 class Marketplace
-  class CartProductPolicy < ApplicationPolicy
-    alias_method :cart_product, :object
+  class CartProductPolicy < Policy
     def permitted_attributes(_params = nil)
       %i[quantity product_id]
-    end
-
-    def create?
-      true
-    end
-
-    def update?
-      true
     end
 
     class Scope < ApplicationScope

--- a/app/furniture/marketplace/checkout_policy.rb
+++ b/app/furniture/marketplace/checkout_policy.rb
@@ -1,17 +1,6 @@
 # frozen_string_literal: true
 
 class Marketplace
-  class CheckoutPolicy < ApplicationPolicy
-    alias_method :checkout, :object
-
-    def create?
-      return true if checkout.shopper.person.blank? && !current_person.authenticated?
-
-      checkout.shopper.person == current_person
-    end
-
-    def show?
-      create?
-    end
+  class CheckoutPolicy < Policy
   end
 end

--- a/app/furniture/marketplace/marketplace_policy.rb
+++ b/app/furniture/marketplace/marketplace_policy.rb
@@ -1,15 +1,17 @@
 # frozen_string_literal: true
 
 class Marketplace
-  class MarketplacePolicy < ApplicationPolicy
+  class MarketplacePolicy < Policy
     alias_method :marketplace, :object
     def show?
       true
     end
 
-    def update?
-      person&.member_of?(marketplace.space)
+    def create?
+      current_person.operator? || current_person.member_of?(marketplace.space)
     end
+
+    alias_method :update?, :create?
 
     class Scope < ApplicationScope
       def resolve

--- a/app/furniture/marketplace/order_policy.rb
+++ b/app/furniture/marketplace/order_policy.rb
@@ -1,13 +1,7 @@
 # frozen_string_literal: true
 
 class Marketplace
-  class OrderPolicy < CheckoutPolicy
-    alias_method :order, :object
-
-    def show?
-      create?
-    end
-
+  class OrderPolicy < Policy
     class Scope < ApplicationScope
       def resolve
         scope.all

--- a/app/furniture/marketplace/policy.rb
+++ b/app/furniture/marketplace/policy.rb
@@ -1,0 +1,38 @@
+class Marketplace
+  class Policy < ApplicationPolicy
+    def create?
+      return true if current_person.operator?
+      return true if current_person.member_of?(marketplace.space)
+
+      return true if shopper&.person.blank? && !current_person.authenticated?
+
+      return true if shopper&.person == current_person
+
+      false
+    end
+    alias_method :update?, :create?
+
+    def shopper
+      return object if object.is_a?(Shopper)
+
+      return object.shopper if object.respond_to?(:shopper)
+    end
+
+    def marketplace
+      return object if object.is_a?(Marketplace)
+
+      object.marketplace if object.respond_to?(:marketplace)
+    end
+
+    module SpecFactories
+      def self.included(spec)
+        spec.let(:marketplace) { create(:marketplace) }
+        spec.let(:membership) { create(:membership, space: marketplace.room.space) }
+        spec.let(:member) { membership.member }
+        spec.let(:neighbor) { create(:person) }
+        spec.let(:operator) { create(:person, operator: true) }
+        spec.let(:guest) { Guest.new }
+      end
+    end
+  end
+end

--- a/app/furniture/marketplace/product_policy.rb
+++ b/app/furniture/marketplace/product_policy.rb
@@ -1,18 +1,21 @@
 # frozen_string_literal: true
 
 class Marketplace
-  class ProductPolicy < ApplicationPolicy
+  class ProductPolicy < Policy
     alias_method :product, :object
     def permitted_attributes(_params = nil)
       %i[name description price_cents price_currency price]
     end
 
-    def create?
-      person.member_of?(product.space)
-    end
-
     def update?
-      create?
+      return false unless current_person.authenticated?
+
+      super
+    end
+    alias_method :create?, :update?
+
+    def show?
+      true
     end
 
     class Scope < ApplicationScope

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -3,7 +3,8 @@
 # Parent class for Policies.
 # @see https://github.com/varvet/pundit#policies
 class ApplicationPolicy
-  attr_reader :person, :object
+  attr_reader :current_person, :object
+  alias_method :person, :current_person
 
   def create?
     raise NotImplementedError
@@ -29,13 +30,13 @@ class ApplicationPolicy
     true
   end
 
-  def initialize(person, object)
-    @person = person
-    @object = object
+  def show?
+    update?
   end
 
-  def current_person
-    @person
+  def initialize(current_person, object)
+    @current_person = current_person
+    @object = object
   end
 
   def permit(params)
@@ -47,10 +48,10 @@ class ApplicationPolicy
   end
 
   def policy(object)
-    Pundit.policy(person, object)
+    Pundit.policy(current_person, object)
   end
 
   def policy!(object)
-    Pundit.policy!(person, object)
+    Pundit.policy!(current_person, object)
   end
 end

--- a/spec/factories/furniture/marketplace.rb
+++ b/spec/factories/furniture/marketplace.rb
@@ -28,8 +28,12 @@ FactoryBot.define do
   end
 
   factory :marketplace_cart_product, class: "Marketplace::CartProduct" do
-    association(:product, factory: :marketplace_product)
-    association(:cart, factory: :marketplace_cart)
+    transient do
+      marketplace { nil }
+    end
+
+    product { association(:marketplace_product, marketplace: marketplace) }
+    cart { association(:marketplace_cart, marketplace: marketplace) }
   end
 
   factory :marketplace_cart, class: "Marketplace::Cart" do
@@ -37,8 +41,8 @@ FactoryBot.define do
     association(:shopper, factory: :marketplace_shopper)
 
     trait :with_products do
-      after(:build) do |cart, _evaluator|
-        build(:marketplace_cart_product, cart: cart)
+      after(:build) do |cart, evaluator|
+        build(:marketplace_cart_product, cart: cart, marketplace: evaluator.instance.marketplace)
       end
     end
   end

--- a/spec/factories/marketplace/checkouts.rb
+++ b/spec/factories/marketplace/checkouts.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
         person { nil }
       end
       after(:build) do |checkout, evaluator|
-        shopper = build(:marketplace_shopper, person: evaluator.person)
+        shopper = build(:marketplace_shopper, person: evaluator.person.is_a?(Guest) ? nil : evaluator.person)
         checkout.cart = build(:marketplace_cart, marketplace: evaluator.marketplace, shopper: shopper)
       end
     end

--- a/spec/furniture/marketplace/cart_policy_spec.rb
+++ b/spec/furniture/marketplace/cart_policy_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe Marketplace::CartPolicy, type: :policy do
+  subject { described_class }
+
+  include Marketplace::Policy::SpecFactories
+
+  let(:cart) { create(:marketplace_cart, shopper: shopper, marketplace: marketplace) }
+  let(:shopper) { build(:marketplace_shopper) }
+
+  permissions :create?, :destroy?, :edit?, :show?, :update? do
+    it { is_expected.to permit(member, cart) }
+    it { is_expected.to permit(operator, cart) }
+
+    context "when the neighbor is the shopper" do
+      let(:shopper) { create(:marketplace_shopper, person: neighbor) }
+
+      it { is_expected.to permit(neighbor, cart) }
+      it { is_expected.not_to permit(guest, cart) }
+    end
+
+    context "when the shopper is a guest" do
+      it { is_expected.not_to permit(neighbor, cart) }
+      it { is_expected.to permit(guest, cart) }
+    end
+  end
+
+  permissions :index? do
+    it { is_expected.to permit(guest, Marketplace::Cart) }
+    it { is_expected.to permit(neighbor, Marketplace::Cart) }
+    it { is_expected.to permit(member, Marketplace::Cart) }
+    it { is_expected.to permit(operator, Marketplace::Cart) }
+  end
+end

--- a/spec/furniture/marketplace/cart_product_policy_spec.rb
+++ b/spec/furniture/marketplace/cart_product_policy_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe Marketplace::CartProductPolicy, type: :policy do
+  subject { described_class }
+
+  include Marketplace::Policy::SpecFactories
+
+  let(:cart) { create(:marketplace_cart, shopper: shopper, marketplace: marketplace) }
+  let(:shopper) { build(:marketplace_shopper) }
+  let(:cart_product) { create(:marketplace_cart_product, cart: cart, marketplace: marketplace) }
+
+  permissions :create?, :destroy?, :edit?, :show?, :update? do
+    it { is_expected.to permit(member, cart_product) }
+    it { is_expected.to permit(operator, cart_product) }
+
+    context "when the neighbor is the shopper" do
+      let(:shopper) { create(:marketplace_shopper, person: neighbor) }
+
+      it { is_expected.to permit(neighbor, cart_product) }
+      it { is_expected.not_to permit(guest, cart_product) }
+    end
+
+    context "when the shopper is a guest" do
+      it { is_expected.not_to permit(neighbor, cart_product) }
+      it { is_expected.to permit(guest, cart_product) }
+    end
+  end
+
+  permissions :index? do
+    it { is_expected.to permit(guest, Marketplace::CartProduct) }
+    it { is_expected.to permit(neighbor, Marketplace::CartProduct) }
+    it { is_expected.to permit(member, Marketplace::CartProduct) }
+    it { is_expected.to permit(operator, Marketplace::CartProduct) }
+  end
+end

--- a/spec/furniture/marketplace/marketplace_policy_spec.rb
+++ b/spec/furniture/marketplace/marketplace_policy_spec.rb
@@ -3,21 +3,19 @@ require "rails_helper"
 RSpec.describe Marketplace::MarketplacePolicy, type: :policy do
   subject { described_class }
 
-  let(:marketplace) { create(:marketplace) }
-  let(:membership) { create(:membership, space: marketplace.room.space) }
-  let(:member) { membership.member }
-  let(:non_member) { create(:person) }
-  let(:guest) { nil }
+  include Marketplace::Policy::SpecFactories
 
-  permissions :show? do
+  permissions :index?, :show? do
     it { is_expected.to permit(member, marketplace) }
-    it { is_expected.to permit(non_member, marketplace) }
+    it { is_expected.to permit(neighbor, marketplace) }
+    it { is_expected.to permit(operator, marketplace) }
     it { is_expected.to permit(guest, marketplace) }
   end
 
-  permissions :update? do
+  permissions :new?, :create?, :destroy?, :edit?, :update? do
+    it { is_expected.to permit(operator, marketplace) }
     it { is_expected.to permit(member, marketplace) }
-    it { is_expected.not_to permit(non_member, marketplace) }
+    it { is_expected.not_to permit(neighbor, marketplace) }
     it { is_expected.not_to permit(guest, marketplace) }
   end
 end

--- a/spec/furniture/marketplace/order_policy_spec.rb
+++ b/spec/furniture/marketplace/order_policy_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe Marketplace::OrderPolicy, type: :policy do
+  subject { described_class }
+
+  include Marketplace::Policy::SpecFactories
+
+  let(:order) { create(:marketplace_order, shopper: shopper, marketplace: marketplace) }
+  let(:shopper) { build(:marketplace_shopper) }
+
+  permissions :create?, :destroy?, :edit?, :show?, :update? do
+    it { is_expected.to permit(member, order) }
+    it { is_expected.to permit(operator, order) }
+
+    context "when the neighbor is the shopper" do
+      let(:shopper) { create(:marketplace_shopper, person: neighbor) }
+
+      it { is_expected.to permit(neighbor, order) }
+      it { is_expected.not_to permit(guest, order) }
+    end
+
+    context "when the shopper is a guest" do
+      it { is_expected.not_to permit(neighbor, order) }
+      it { is_expected.to permit(guest, order) }
+    end
+  end
+
+  permissions :index? do
+    it { is_expected.to permit(guest, Marketplace::Order) }
+    it { is_expected.to permit(neighbor, Marketplace::Order) }
+    it { is_expected.to permit(member, Marketplace::Order) }
+    it { is_expected.to permit(operator, Marketplace::Order) }
+  end
+end

--- a/spec/furniture/marketplace/product_policy_spec.rb
+++ b/spec/furniture/marketplace/product_policy_spec.rb
@@ -1,9 +1,30 @@
 require "rails_helper"
 
-RSpec.describe Marketplace::ProductPolicy do
+RSpec.describe Marketplace::ProductPolicy, type: :policy do
+  subject { described_class }
+
+  let(:product) { create(:marketplace_product, marketplace: marketplace) }
+
   describe "#permitted_attributes" do
     subject(:permitted_attributes) { described_class.new(nil, nil).permitted_attributes }
 
     it { is_expected.to include :price }
+  end
+
+  include Marketplace::Policy::SpecFactories
+
+  permissions :create?, :destroy?, :edit?, :update? do
+    it { is_expected.to permit(member, product) }
+    it { is_expected.to permit(operator, product) }
+
+    it { is_expected.not_to permit(neighbor, product) }
+    it { is_expected.not_to permit(guest, product) }
+  end
+
+  permissions :index?, :show? do
+    it { is_expected.to permit(guest, product) }
+    it { is_expected.to permit(neighbor, product) }
+    it { is_expected.to permit(member, product) }
+    it { is_expected.to permit(operator, product) }
   end
 end


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/831

Since we're getting close to running orders through, I figured it would make sense to flesh out the tests for the `Policy` objects in the `Marketplace` domain.

This:

- Sprouts a `Marketplace::Policy` class with the default permissions for objects.
- Gets rid of `ApplicationPolicy#person` for `ApplicationPolicy#current_person`.