### PR TITLE
✨ `Marketplace`: Collect `Order#contact_phone_number` prior to `Checkout`

### DIFF
--- a/app/furniture/marketplace/cart.rb
+++ b/app/furniture/marketplace/cart.rb
@@ -40,7 +40,7 @@ class Marketplace
     end
 
     def ready_for_delivery?
-      self.delivery_address.present? && self.contact_phone_number.present? ? true: false
+      (delivery_address.present? && contact_phone_number.present?)
     end
   end
 end

--- a/app/furniture/marketplace/cart.rb
+++ b/app/furniture/marketplace/cart.rb
@@ -38,5 +38,9 @@ class Marketplace
     def price_total
       product_total + delivery_fee
     end
+
+    def ready_for_delivery?
+      self.delivery_address.present? && self.contact_phone_number.present? ? true: false
+    end
   end
 end

--- a/app/furniture/marketplace/cart.rb
+++ b/app/furniture/marketplace/cart.rb
@@ -16,6 +16,7 @@ class Marketplace
     has_many :products, through: :cart_products, inverse_of: :carts
 
     has_encrypted :delivery_address
+    has_encrypted :contact_phone_number
 
     enum status: {
       pre_checkout: "pre_checkout",

--- a/app/furniture/marketplace/cart_policy.rb
+++ b/app/furniture/marketplace/cart_policy.rb
@@ -4,7 +4,7 @@ class Marketplace
   class CartPolicy < Policy
     alias_method :cart, :object
     def permitted_attributes(_params = nil)
-      %i[delivery_address]
+      %i[delivery_address contact_phone_number]
     end
 
     class Scope < ApplicationScope

--- a/app/furniture/marketplace/carts/_cart.html.erb
+++ b/app/furniture/marketplace/carts/_cart.html.erb
@@ -5,7 +5,7 @@
       <%= render "text_field", attribute: :delivery_address, form: cart_form %>
       <%= render "text_field", attribute: :contact_phone_number, form: cart_form %>
 
-      <%= cart_form.submit t('marketplace.edit_delivery_info.edit') %>
+      <%= cart_form.submit t('marketplace.delivery_info.edit') %>
     <%- end %>
   <%- else %>
     <div class="flex justify-between flex-wrap">

--- a/app/furniture/marketplace/carts/_cart.html.erb
+++ b/app/furniture/marketplace/carts/_cart.html.erb
@@ -9,11 +9,13 @@
     <%- end %>
   <%- else %>
     <div class="flex justify-between flex-wrap">
-      <div class="w-full flex items-center justify-between text-sm">
+      <div class="sm:w-1/2 w-full flex items-center justify-between text-sm">
         <span>Delivering to:</span>
         <%= cart.delivery_address %>
         <%= render ButtonComponent.new(href: cart.location.concat([params: { cart: { delivery_address: nil } }]), label: t('marketplace.delivery_address.edit'), title: nil, classes: "shrink font-light text-xs m-0 bg-primary-200 underline") %>
+      </div>
 
+      <div class="sm:w-1/2 w-full flex items-center justify-between text-sm">
         <span>Contact Phone Number:</span>
         <%= cart.contact_phone_number %>
         <%= render ButtonComponent.new(href: cart.location.concat([params: { cart: { contact_phone_number: nil } }]), label: t('marketplace.contact_phone_number.edit'), title: nil, classes: "shrink font-light text-xs m-0 bg-primary-200 underline") %>

--- a/app/furniture/marketplace/carts/_cart.html.erb
+++ b/app/furniture/marketplace/carts/_cart.html.erb
@@ -1,20 +1,23 @@
 <div id="<%= dom_id(cart) %>">
 
-  <%- if cart.delivery_address.blank? %>
+  <%- if cart.delivery_address.blank? || cart.contact_phone_number.blank? %>
     <%= form_with model: cart.location do |cart_form| %>
       <%= render "text_field", attribute: :delivery_address, form: cart_form %>
+      <%= render "text_field", attribute: :contact_phone_number, form: cart_form %>
 
-      <%= cart_form.submit t('marketplace.delivery_address.edit') %>
+      <%= cart_form.submit t('marketplace.edit_delivery_info.edit') %>
     <%- end %>
   <%- else %>
     <div class="flex justify-between flex-wrap">
       <div class="w-full flex items-center justify-between text-sm">
         <span>Delivering to:</span>
+        <%= cart.delivery_address %>
         <%= render ButtonComponent.new(href: cart.location.concat([params: { cart: { delivery_address: nil } }]), label: t('marketplace.delivery_address.edit'), title: nil, classes: "shrink font-light text-xs m-0 bg-primary-200 underline") %>
+
+        <span>Contact Phone Number:</span>
+        <%= cart.contact_phone_number %>
+        <%= render ButtonComponent.new(href: cart.location.concat([params: { cart: { contact_phone_number: nil } }]), label: t('marketplace.contact_phone_number.edit'), title: nil, classes: "shrink font-light text-xs m-0 bg-primary-200 underline") %>
       </div>
-
-
-      <p class="grow"><%= cart.delivery_address %></p>
     </div>
 
     <div class="-mx-4 mt-4 overflow-hidden shadow ring-1 ring-black ring-opacity-5 sm:-mx-6 md:mx-0 md:rounded-lg">

--- a/app/furniture/marketplace/carts/_footer.html.erb
+++ b/app/furniture/marketplace/carts/_footer.html.erb
@@ -8,7 +8,7 @@
   <tr>
     <td class="text-left px-3 py-3.5 text-right" colspan="8">
       <%= render "marketplace/carts/total", cart: cart %>
-      <%- if cart.delivery_address.present? %>
+      <%- if cart.delivery_address.present? && cart.contact_phone_number.present?%>
         <%= button_to("Checkout", cart.location(child: :checkout), data: { turbo: false }) %>
       <%- end %>
     </td>

--- a/app/furniture/marketplace/carts/_footer.html.erb
+++ b/app/furniture/marketplace/carts/_footer.html.erb
@@ -8,7 +8,7 @@
   <tr>
     <td class="text-left px-3 py-3.5 text-right" colspan="8">
       <%= render "marketplace/carts/total", cart: cart %>
-      <%- if cart.delivery_address.present? && cart.contact_phone_number.present?%>
+      <%- if cart.ready_for_delivery? %>
         <%= button_to("Checkout", cart.location(child: :checkout), data: { turbo: false }) %>
       <%- end %>
     </td>

--- a/app/furniture/marketplace/locales/en.yml
+++ b/app/furniture/marketplace/locales/en.yml
@@ -1,7 +1,7 @@
 
 en:
   marketplace:
-    edit_delivery_info:
+    delivery_info:
       edit: "Update Delivery Info"
     contact_phone_number:
       edit: "Change Phone Number"

--- a/app/furniture/marketplace/locales/en.yml
+++ b/app/furniture/marketplace/locales/en.yml
@@ -1,6 +1,10 @@
 
 en:
   marketplace:
+    edit_delivery_info:
+      edit: "Update Delivery Info"
+    contact_phone_number:
+      edit: "Change Phone Number"
     delivery_address:
       edit: "Change Address"
     marketplace:

--- a/app/furniture/marketplace/order.rb
+++ b/app/furniture/marketplace/order.rb
@@ -12,6 +12,7 @@ class Marketplace
     has_many :products, through: :ordered_products, inverse_of: :orders
 
     has_encrypted :delivery_address
+    has_encrypted :contact_phone_number
 
     enum status: {
       pre_checkout: "pre_checkout",

--- a/app/furniture/marketplace/order_received_mailer/notification.html.erb
+++ b/app/furniture/marketplace/order_received_mailer/notification.html.erb
@@ -10,3 +10,4 @@
 <p>Total: <%= humanized_money_with_symbol(order.price_total) %></p>
 <p>Deliver To: <%= order.delivery_address %>
 <p>Contact Email: <%= order.contact_email %>
+<p>Contact Phone Number: <%= order.contact_phone_number %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_07_212232) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_09_012225) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -136,6 +136,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_07_212232) do
     t.string "stripe_session_id"
     t.string "contact_email"
     t.text "delivery_address_ciphertext"
+    t.string "contact_phone_number_ciphertext"
     t.index ["marketplace_id"], name: "index_marketplace_orders_on_marketplace_id"
     t.index ["shopper_id"], name: "index_marketplace_orders_on_shopper_id"
   end

--- a/spec/furniture/marketplace/carts_controller_request_spec.rb
+++ b/spec/furniture/marketplace/carts_controller_request_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Marketplace::CartsController, type: :request do
 
       it { is_expected.to redirect_to(room.location) }
       specify { expect { perform_request }.to change { cart.reload.delivery_address }.from(nil).to("123 N West St") }
+      specify { expect { perform_request }.to change { cart.reload.contact_phone_number }.from(nil).to("(415)-123-4567") }
     end
 
     context "when a `Neighbor`" do
@@ -28,6 +29,7 @@ RSpec.describe Marketplace::CartsController, type: :request do
 
       it { is_expected.to redirect_to(room.location) }
       specify { expect { perform_request }.to change { cart.reload.delivery_address }.from(nil).to("123 N West St") }
+      specify { expect { perform_request }.to change { cart.reload.contact_phone_number }.from(nil).to("(415)-123-4567") }
     end
   end
 end

--- a/spec/furniture/marketplace/carts_controller_request_spec.rb
+++ b/spec/furniture/marketplace/carts_controller_request_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Marketplace::CartsController, type: :request do
 
   describe "#update" do
     subject(:perform_request) do
-      put polymorphic_path(cart.location), params: {cart: {delivery_address: "123 N West St"}}
+      put polymorphic_path(cart.location), params: {cart: {delivery_address: "123 N West St", contact_phone_number: "(415)-123-4567"}}
       response
     end
 

--- a/spec/mailers/previews/marketplace/order_received_mailer_preview.rb
+++ b/spec/mailers/previews/marketplace/order_received_mailer_preview.rb
@@ -5,7 +5,7 @@ class Marketplace::OrderReceivedMailerPreview < ActionMailer::Preview
     marketplace = FactoryBot.build(:marketplace, delivery_fee_cents: (10_00..25_00).to_a.sample)
     order = FactoryBot.build(:marketplace_order, :with_products, marketplace: marketplace,
       product_count: (1..5).to_a.sample, delivery_address: Faker::Address.full_address,
-      contact_email: Faker::Internet.safe_email)
+      contact_email: Faker::Internet.safe_email, contact_phone_number: Faker::PhoneNumber.cell_phone)
     order.marketplace.notify_emails = "distributor@example.com,vendor@example.com"
 
     Marketplace::OrderReceivedMailer.notification(order)


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/831

Shopper can add a contact Phone Number to their order during the Checkout flow and it displays in the order_received_mailer.

![added phone field to checkout page](https://user-images.githubusercontent.com/16140873/224187729-9a7c35ea-db3c-45fb-9f7a-e897687912d2.jpg)

![phone field and updated button text](https://user-images.githubusercontent.com/16140873/223900904-f0dfa8c7-95d2-4575-8cdb-0d5ab7eabc0e.jpg)

**mobile mode**
![fields stack in mobile mode](https://user-images.githubusercontent.com/16140873/224187766-655d9306-03d7-4ca3-b40d-d70179ff2ec4.jpg)

**mailer**
![add phone to mailer](https://user-images.githubusercontent.com/16140873/224187799-8d65b162-926f-4889-9e6e-3ddf3507e08b.jpg)

Co-authored-by: Zee Spencer <zspencer@users.noreply.github.com>
Co-authored-by: Ana <anaulin@users.noreply.github.com>
Co-authored-by: Dalton Pruitt <daltonrpruitt@users.noreply.github.com>
