### PR TITLE
🐞 `Marketplace`: catch Stripe errors during account connect and show them to the end user

### DIFF
--- a/app/furniture/marketplace/marketplace.rb
+++ b/app/furniture/marketplace/marketplace.rb
@@ -39,6 +39,10 @@ class Marketplace
       settings["stripe_account"] = stripe_account
     end
 
+    def stripe_account_connected?
+      stripe_account.present? && stripe_webhook_endpoint.present? && stripe_webhook_endpoint_secret.present?
+    end
+
     def stripe_webhook_endpoint
       settings["stripe_webhook_endpoint"]
     end

--- a/app/furniture/marketplace/marketplace.rb
+++ b/app/furniture/marketplace/marketplace.rb
@@ -64,6 +64,7 @@ class Marketplace
     end
     monetize :delivery_fee_cents
 
+    # @raises Stripe::InvalidRequestError if something is sad
     def stripe_account_link(refresh_url:, return_url:)
       account = if stripe_account.blank?
         Stripe::Account.create({type: "standard"}, {
@@ -85,9 +86,6 @@ class Marketplace
       }, {
         api_key: stripe_api_key
       })
-    rescue Stripe::InvalidRequestError => e
-      Rails.logger.error({summary: "Stripe account creation is sad!", detail: e.message})
-      nil
     end
 
     def create_stripe_webhook_endpoint(webhook_url:)

--- a/app/furniture/marketplace/marketplaces/edit.html.erb
+++ b/app/furniture/marketplace/marketplaces/edit.html.erb
@@ -3,7 +3,7 @@
 <%= render "form", marketplace: marketplace %>
 
 <%- if marketplace.stripe_api_key? %>
-  <%- if marketplace.stripe_account.present? %>
+  <%- if marketplace.stripe_account_connected? %>
     <%= t('.stripe_connected') %>
   <%- end %>
   <%= button_to t('.connect_stripe'),

--- a/app/furniture/marketplace/stripe_accounts_controller.rb
+++ b/app/furniture/marketplace/stripe_accounts_controller.rb
@@ -10,11 +10,9 @@ class Marketplace
 
       marketplace.create_stripe_webhook_endpoint(webhook_url: polymorphic_url(marketplace.location(child: :stripe_events)))
 
-      if stripe_account_link.present?
-        redirect_to stripe_account_link.url, status: :see_other, allow_other_host: true
-      else
-        redirect_to marketplace.location(:edit), notice: "Stripe Re-Connected!"
-      end
+      redirect_to stripe_account_link.url, status: :see_other, allow_other_host: true
+    rescue Stripe::InvalidRequestError => e
+      redirect_to marketplace.location(:edit), alert: "Something went wrong! #{e.message}"
     end
 
     helper_method def marketplace


### PR DESCRIPTION
Fixes https://github.com/zinc-collective/convene/issues/1113

With this change:
![image](https://user-images.githubusercontent.com/6729309/223909240-e415ef9a-b92c-40d5-8b0f-82e05be915f7.png)
