### PR TITLE
✨🥔 `Marketplace`: `Shopper` and `Distributor` `Order` History

### DIFF
--- a/app/furniture/marketplace/breadcrumbs.rb
+++ b/app/furniture/marketplace/breadcrumbs.rb
@@ -18,8 +18,13 @@ crumb :marketplace_checkout do |checkout|
 end
 
 crumb :marketplace_order do |order|
-  parent :marketplace, order.marketplace
+  parent :marketplace_orders, order.marketplace
   link "Order from #{order.created_at.to_fs(:long_ordinal)}", order.location
+end
+
+crumb :marketplace_orders do |marketplace|
+  parent :marketplace, marketplace
+  link t("marketplace.order.index"), marketplace.location(child: :orders)
 end
 
 crumb :marketplace_products do |marketplace|

--- a/app/furniture/marketplace/locales/en.yml
+++ b/app/furniture/marketplace/locales/en.yml
@@ -17,6 +17,8 @@ en:
       update:
         success: "Marketplace updated successfully!"
         failure: "Marketplace could not be updated."
+    order:
+      index: "Order History"
     product:
       index: "Configure Products"
     products:

--- a/app/furniture/marketplace/marketplaces/_marketplace.html.erb
+++ b/app/furniture/marketplace/marketplaces/_marketplace.html.erb
@@ -12,4 +12,8 @@ end %>
   <%- if policy(marketplace).edit? %>
     <%= link_to t('marketplace.marketplace.edit'), marketplace.location(:edit) %>
   <%- end %>
+
+  <%- if policy(marketplace.orders).index? %>
+  <%= link_to t('marketplace.order.index'), marketplace.location(child: :orders) %>
+  <%- end %>
 </div>

--- a/app/furniture/marketplace/order_policy.rb
+++ b/app/furniture/marketplace/order_policy.rb
@@ -4,7 +4,10 @@ class Marketplace
   class OrderPolicy < Policy
     class Scope < ApplicationScope
       def resolve
-        scope.all
+        return scope.all if person.operator?
+
+        scope.joins(marketplace: [:room]).where(rooms: {space_id: person.spaces})
+          .or(scope.where(shopper: Shopper.where(person: person)))
       end
     end
   end

--- a/app/furniture/marketplace/orders/index.html.erb
+++ b/app/furniture/marketplace/orders/index.html.erb
@@ -1,0 +1,5 @@
+<%- breadcrumb :marketplace_orders, marketplace %>
+<%- @pagy, @records = pagy(orders) %>
+
+<%= render @records %>
+<%== pagy_nav(@pagy, nav_extra: 'flex justify-between') %>

--- a/app/furniture/marketplace/orders_controller.rb
+++ b/app/furniture/marketplace/orders_controller.rb
@@ -4,8 +4,15 @@ class Marketplace
       authorize(order)
     end
 
+    def index
+    end
+
+    helper_method def orders
+      policy_scope(marketplace.orders)
+    end
+
     helper_method def order
-      policy_scope(marketplace.orders).find(params[:id])
+      orders.find(params[:id])
     end
   end
 end

--- a/app/furniture/marketplace/routes.rb
+++ b/app/furniture/marketplace/routes.rb
@@ -11,7 +11,7 @@ class Marketplace
 
         router.resources :tax_rates
 
-        router.resources :orders, only: [:show]
+        router.resources :orders, only: [:show, :index]
         router.resources :products
         router.resource :stripe_account
       end

--- a/spec/furniture/marketplace/order_policy_spec.rb
+++ b/spec/furniture/marketplace/order_policy_spec.rb
@@ -31,4 +31,35 @@ RSpec.describe Marketplace::OrderPolicy, type: :policy do
     it { is_expected.to permit(member, Marketplace::Order) }
     it { is_expected.to permit(operator, Marketplace::Order) }
   end
+
+  describe Marketplace::OrderPolicy::Scope do
+    subject(:results) { described_class.new(actor, Marketplace::Order).resolve }
+
+    let!(:guest_order) { create(:marketplace_order, marketplace: marketplace, shopper: create(:marketplace_shopper)) }
+    let!(:neighbor_order) { create(:marketplace_order, marketplace: marketplace, shopper: create(:marketplace_shopper, person: neighbor)) }
+
+    context "when an operator" do
+      let(:actor) { operator }
+
+      it { is_expected.to contain_exactly(guest_order, neighbor_order) }
+    end
+
+    context "when the neighbor who placed the order" do
+      let(:actor) { neighbor }
+
+      it { is_expected.to contain_exactly(neighbor_order) }
+    end
+
+    context "when a guest" do
+      let(:actor) { guest }
+
+      it { is_expected.to be_empty }
+    end
+
+    context "when a member of the space" do
+      let(:actor) { member }
+
+      it { is_expected.to contain_exactly(guest_order, neighbor_order) }
+    end
+  end
 end


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/831

`Neighbor`s can see all their past `Order`s! And `Member`s can see all the `Order`s for a given `Marketplace`
![Screenshot 2023-03-10 at 3 36 32 PM](https://user-images.githubusercontent.com/50284/224448223-787e78a4-b066-4449-91ac-541b3a1c8212.png)
![Screenshot 2023-03-10 at 3 36 38 PM](https://user-images.githubusercontent.com/50284/224448227-8894de13-eb08-48a9-85a0-860a6288387a.png)

It would be lovely if someone would take the `_order` partial and turn it into a `ViewComponent` that looks v pretty, instead of this hideous table monster I spawned.