### PR TITLE
Loosen RSpec maximum line limit for examples

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,3 +24,6 @@ RSpec/MultipleMemoizedHelpers:
 
 RSpec/NestedGroups:
   Max: 5
+
+RSpec/ExampleLength:
+  Max: 10


### PR DESCRIPTION
I was going to disable the `MultipleExpectations` cop, as a result of the convo on https://github.com/zinc-collective/convene/pull/1211, but it is already disabled!