### PR TITLE
✨ `Marketplace`: `Distributor` may set `Marketplace#delivery_window`

### DIFF
--- a/app/furniture/marketplace/carts/_cart.html.erb
+++ b/app/furniture/marketplace/carts/_cart.html.erb
@@ -7,6 +7,7 @@
 
       <%= cart_form.submit t('marketplace.delivery_info.edit') %>
     <%- end %>
+
   <%- else %>
     <div class="flex justify-between flex-wrap">
       <div class="sm:w-1/2 w-full flex items-center justify-between text-sm">
@@ -47,4 +48,6 @@
       </table>
     </div>
   <%- end %>
+
+  <p class="italic text-right py-2 text-sm">Delivers on <%= cart.marketplace.delivery_window %></p>
 </div>

--- a/app/furniture/marketplace/marketplace.rb
+++ b/app/furniture/marketplace/marketplace.rb
@@ -68,6 +68,14 @@ class Marketplace
     end
     monetize :delivery_fee_cents
 
+    def delivery_window
+      settings["delivery_window"]
+    end
+
+    def delivery_window=(delivery_window)
+      settings["delivery_window"] = delivery_window
+    end
+
     # @raises Stripe::InvalidRequestError if something is sad
     def stripe_account_link(refresh_url:, return_url:)
       account = if stripe_account.blank?

--- a/app/furniture/marketplace/marketplace_policy.rb
+++ b/app/furniture/marketplace/marketplace_policy.rb
@@ -2,6 +2,10 @@
 
 class Marketplace
   class MarketplacePolicy < Policy
+    def permitted_attributes(_params)
+      [:delivery_fee, :notify_emails, :delivery_window]
+    end
+
     alias_method :marketplace, :object
     def show?
       true

--- a/app/furniture/marketplace/marketplaces/_form.html.erb
+++ b/app/furniture/marketplace/marketplaces/_form.html.erb
@@ -1,6 +1,7 @@
 <%= form_with model: marketplace.location do |f| %>
   <%= render "money_field", { attribute: :delivery_fee, form: f, min: 0, step: 0.01} %>
   <%= render "text_field", { attribute: :notify_emails, form: f } %>
+  <%= render "text_field", { attribute: :delivery_window, form: f } %>
 
   <%= f.submit %>
 <% end %>

--- a/app/furniture/marketplace/marketplaces_controller.rb
+++ b/app/furniture/marketplace/marketplaces_controller.rb
@@ -23,7 +23,7 @@ class Marketplace
     end
 
     def marketplace_params
-      params.require(:marketplace).permit([:delivery_fee, :notify_emails])
+      policy(Marketplace).permit(params.require(:marketplace))
     end
   end
 end

--- a/app/policies/utility_policy.rb
+++ b/app/policies/utility_policy.rb
@@ -5,6 +5,8 @@ class UtilityPolicy < ApplicationPolicy
 
   class Scope < ApplicationScope
     def resolve
+      return scope.all if person.operator?
+
       scope.where(space: person.spaces)
     end
   end

--- a/spec/furniture/marketplace/marketplaces_controller_request_spec.rb
+++ b/spec/furniture/marketplace/marketplaces_controller_request_spec.rb
@@ -26,9 +26,10 @@ RSpec.describe Marketplace::MarketplacesController, type: :request do
     before { sign_in(space, member) }
 
     it "updates the attributes" do
-      put polymorphic_path(marketplace.location), params: {marketplace: {delivery_fee: 50.00}}
+      put polymorphic_path(marketplace.location), params: {marketplace: {delivery_fee: 50.00, delivery_window: "Tomorrow, mahhhhn..."}}
 
       expect(marketplace.reload.delivery_fee_cents).to eq(50_00)
+      expect(marketplace.reload.delivery_window).to eq("Tomorrow, mahhhhn...")
     end
   end
 end


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1185

Added a `Marketplace#delivery_window` attribute, which is a plain-old-string for now. It's going to quickly become insufficient, because we *may* need to do date and time crap at one point.

But "quickly" could mean "months from now!" sooooooo.