### PR TITLE
`Furniture`: Add a way for furniture to signal they have their own controller, and add link to kind-specific `edit` from Room edit form

### DIFF
--- a/app/furniture/markdown_text_block.rb
+++ b/app/furniture/markdown_text_block.rb
@@ -4,6 +4,8 @@
 class MarkdownTextBlock < Furniture
   include RendersMarkdown
 
+  self.location_parent = :room
+
   def to_html
     render_markdown(content)
   end

--- a/app/furniture/marketplace/marketplace.rb
+++ b/app/furniture/marketplace/marketplace.rb
@@ -10,6 +10,10 @@ class Marketplace
 
     has_many :tax_rates, inverse_of: :marketplace
 
+    def has_controller_edit?
+      true
+    end
+
     # The Secret Stripe API key belonging to the owner of the Marketplace
     def stripe_api_key
       space.utilities.find_by!(utility_slug: :stripe).utility.api_token

--- a/app/models/furniture.rb
+++ b/app/models/furniture.rb
@@ -41,6 +41,11 @@ class Furniture < ApplicationRecord
     furniture.form_template != "furnitures/noop"
   end
 
+  # @returns true if this Furniture kind has its own controller with an :edit action
+  def has_controller_edit?
+    false
+  end
+
   def write_attribute(name, value)
     super
   rescue ActiveModel::MissingAttributeError => _e
@@ -73,5 +78,9 @@ class Furniture < ApplicationRecord
   def self.from_placement(placement)
     furniture_class = registry.fetch(placement.furniture_kind.to_sym)
     placement.becomes(furniture_class)
+  end
+
+  def to_kind_class
+    becomes(Furniture.registry.fetch(furniture_kind.to_sym))
   end
 end

--- a/app/views/furnitures/_furniture.html.erb
+++ b/app/views/furnitures/_furniture.html.erb
@@ -1,23 +1,27 @@
+<% edit_href = nil %>
+<% edit_href = furniture.location(:edit) if furniture.configurable? %>
+<% edit_href = furniture.to_kind_class.location(:edit) if furniture.to_kind_class.has_controller_edit? %>
+
 <section id="<%= dom_id(furniture) %>" class="mt-4 relative">
   <%- if local_assigns[:editing] %>
-    <header class="flex border-b border-dashed border-primary-900">
-      <h4 class="grow">
-        <%= furniture.title %>
-      </h4>
-      <%- if furniture.configurable? %>
-        <%= render ButtonComponent.new(
-                      label: t('icons.edit'),
-                      href: [:edit, furniture.room.space, furniture.room, furniture],
-                      method: :get,
-                      title: t('.edit_title', name: furniture.furniture.model_name.human.titleize)) %>
-      <%- end %>
+    <header class="flex border-b border-dashed border-primary-900 justify-between">
+      <h4><%= furniture.title %></h4>
+      <div>
+        <%- if edit_href.present? %>
+          <%= render ButtonComponent.new(
+                        label: t('icons.edit'),
+                        href: edit_href,
+                        method: :get,
+                        title: t('.edit_title', name: furniture.furniture.model_name.human.titleize)) %>
+        <%- end %>
 
-      <%= render ButtonComponent.new(
-                    label: t('icons.remove'),
-                    href: [furniture.room.space, furniture.room, furniture],
-                    title: t('.remove_title', name: furniture.furniture.model_name.human.titleize),
-                    method: :delete,
-                    confirm: t('.confirm_destroy')) %>
+        <%= render ButtonComponent.new(
+                      label: t('icons.remove'),
+                      href: [furniture.room.space, furniture.room, furniture],
+                      title: t('.remove_title', name: furniture.furniture.model_name.human.titleize),
+                      method: :delete,
+                      confirm: t('.confirm_destroy')) %>
+        </div>
     </header>
     <%- if local_assigns[:include_form] %>
       <%= render partial: 'furnitures/form', locals: { furniture: furniture } %>

--- a/app/views/rooms/edit.html.erb
+++ b/app/views/rooms/edit.html.erb
@@ -1,15 +1,15 @@
 <% breadcrumb :edit_room, room %>
 
+<h1>Configure <%= room.name %></h1>
+
 <%= render partial: 'form', locals: { room: room } %>
 
-
-<section id="furnitures">
+<section id="furnitures" class="overflow-hidden rounded-lg bg-white shadow p-3 mt-3">
+  <h2>Furniture</h2>
   <%= render room.furnitures.rank(:slot), editing: true %>
 </section>
 
 <%- new_furniture = room.furnitures.new %>
-
 <%- if policy(new_furniture).new? %>
   <%= render "furnitures/new", furniture: new_furniture %>
-
 <%- end %>


### PR DESCRIPTION
I noticed that the Marketplace was not showing the `edit` gear in the Room edit form, so this PR fixes that. This is not the most elegant code I've ever written, but it communicates the intent and works. If we like this approach, we can polish it to have better method naming, etc.

Also took the chance to improve the Room `edit` page look a bit.

### Before
![image](https://user-images.githubusercontent.com/6729309/225490798-6c8c3198-dfdc-4cef-b0c5-73500b1dd946.png)


### After
![image](https://user-images.githubusercontent.com/6729309/225490752-936e4c40-ff06-4782-9db3-1b48ff0fdca3.png)
