### PR TITLE
✨ `Marketplace`: `Order#index` is ordered chronologically

### DIFF
--- a/app/furniture/marketplace/orders_controller.rb
+++ b/app/furniture/marketplace/orders_controller.rb
@@ -8,7 +8,7 @@ class Marketplace
     end
 
     helper_method def orders
-      policy_scope(marketplace.orders)
+      policy_scope(marketplace.orders).order(created_at: :desc)
     end
 
     helper_method def order


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/831

There is another 😬 with our `Order` and `Cart` table being the same, as technically `Order#created_at` is the `Cart#created_at` which may not be when the order is placed...

But this at least makes it look less chaotic.

It would have been nice to get some tests but I didn't have time, since I need to run!