### PR TITLE
🥔✨ `Marketplace`: Introduce `TaxRate#index`

### DIFF
--- a/app/furniture/marketplace/breadcrumbs.rb
+++ b/app/furniture/marketplace/breadcrumbs.rb
@@ -47,12 +47,17 @@ crumb :edit_marketplace_product do |product|
   link "Edit", product.location(:edit)
 end
 
+crumb :marketplace_tax_rates do |marketplace|
+  parent :edit_marketplace, marketplace
+  link t("marketplace.tax_rates.index.link_to"), marketplace.location(child: :tax_rates)
+end
+
 crumb :new_tax_rate do |tax_rate|
-  parent :edit_marketplace, tax_rate.marketplace
+  parent :marketplace_tax_rates, tax_rate.marketplace
   link "Add a Tax Rate", marketplace.location(:new, child: :tax_rate)
 end
 
 crumb :edit_tax_rate do |tax_rate|
-  parent :edit_marketplace, tax_rate.marketplace
+  parent :marketplace_tax_rates, tax_rate.marketplace
   link "Edit Tax Rate '#{tax_rate.label}'", marketplace.location(:new, child: :tax_rate)
 end

--- a/app/furniture/marketplace/locales/en.yml
+++ b/app/furniture/marketplace/locales/en.yml
@@ -30,6 +30,8 @@ en:
         remove: Remove Product
         edit: Edit Product
     tax_rates:
+      index:
+        link_to: "Tax Rates"
       new:
         link_to: Add Tax Rate
     cart_products:

--- a/app/furniture/marketplace/marketplaces/edit.html.erb
+++ b/app/furniture/marketplace/marketplaces/edit.html.erb
@@ -8,7 +8,7 @@
     <%- end %>
 
     <%- if policy(marketplace.tax_rates.new).create? %>
-      <%= link_to(t("marketplace.tax_rates.new.link_to"), marketplace.location(:new, child: :tax_rate)) %>
+      <%= link_to(t("marketplace.tax_rates.index.link_to"), marketplace.location(child: :tax_rates)) %>
     <%- end %>
 
     <%- if marketplace.stripe_api_key? %>

--- a/app/furniture/marketplace/tax_rate_component.html.erb
+++ b/app/furniture/marketplace/tax_rate_component.html.erb
@@ -1,0 +1,6 @@
+
+<%= render CardComponent.new(classes: "py-2") do %>
+  <%= link_to tax_rate.location(:edit) do %>
+    <%= tax_rate.label %>: <%= number_to_percentage(tax_rate.tax_rate, precision: 1) %>
+  <%- end %>
+<%- end %>

--- a/app/furniture/marketplace/tax_rate_component.rb
+++ b/app/furniture/marketplace/tax_rate_component.rb
@@ -1,0 +1,11 @@
+class Marketplace
+  class TaxRateComponent < ApplicationComponent
+    attr_accessor :tax_rate
+
+    def initialize(tax_rate:, data: {}, classes: "")
+      super(data: data, classes: classes)
+
+      self.tax_rate = tax_rate
+    end
+  end
+end

--- a/app/furniture/marketplace/tax_rates/index.html.erb
+++ b/app/furniture/marketplace/tax_rates/index.html.erb
@@ -1,0 +1,12 @@
+<%- breadcrumb(:marketplace_tax_rates, marketplace) %>
+
+<section class="max-w-2xl self-stretch mx-auto">
+  <main>
+    <div class="mt-3 grid grid-cols-1 gap-5 sm:gap-6 sm:grid-cols-2 lg:grid-cols-4">
+      <%= render Marketplace::TaxRateComponent.with_collection(tax_rates) %>
+    </div>
+  </main>
+  <footer class="text-center">
+    <%= link_to(t("marketplace.tax_rates.new.link_to"), marketplace.location(:new, child: :tax_rate)) %>
+  </footer>
+</section>

--- a/app/furniture/marketplace/tax_rates_controller.rb
+++ b/app/furniture/marketplace/tax_rates_controller.rb
@@ -4,9 +4,12 @@ class Marketplace
       tax_rate
     end
 
+    def index
+    end
+
     def create
       if tax_rate.save
-        redirect_to marketplace.location(:edit)
+        redirect_to marketplace.location(child: :tax_rates)
       else
         render :new
       end
@@ -14,7 +17,7 @@ class Marketplace
 
     def update
       if tax_rate.update(tax_rate_params)
-        redirect_to marketplace.location(:edit)
+        redirect_to marketplace.location(child: :tax_rates)
       else
         render :edit
       end
@@ -26,14 +29,18 @@ class Marketplace
 
     helper_method def tax_rate
       @tax_rate ||= if params[:id]
-        policy_scope(marketplace.tax_rates).find(params[:id])
+        tax_rates.find(params[:id])
       elsif params[:tax_rate]
-        marketplace.tax_rates.new(tax_rate_params)
+        tax_rates.new(tax_rate_params)
       else
-        marketplace.tax_rates.new
+        tax_rates.new
       end.tap do |tax_rate|
         authorize(tax_rate)
       end
+    end
+
+    helper_method def tax_rates
+      @tax_rates ||= policy_scope(marketplace.tax_rates)
     end
   end
 end

--- a/spec/components/previews/marketplace/tax_rate_component_preview.rb
+++ b/spec/components/previews/marketplace/tax_rate_component_preview.rb
@@ -1,0 +1,7 @@
+class Marketplace
+  class TaxRateComponentPreview < ViewComponent::Preview
+    def card
+      render(TaxRateComponent.new(tax_rate: TaxRate.all.sample))
+    end
+  end
+end

--- a/spec/furniture/marketplace/tax_rates_controller_request_spec.rb
+++ b/spec/furniture/marketplace/tax_rates_controller_request_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Marketplace::TaxRatesController, type: :request do
       post polymorphic_path(marketplace.location(child: :tax_rates)), params: {tax_rate: attributes_for(:marketplace_tax_rate)}
     end
 
-    it { is_expected.to redirect_to(marketplace.location(:edit)) }
+    it { is_expected.to redirect_to(marketplace.location(child: :tax_rates)) }
   end
 
   describe "#update" do
@@ -32,7 +32,7 @@ RSpec.describe Marketplace::TaxRatesController, type: :request do
       put polymorphic_path(tax_rate.location), params: {tax_rate: {label: "Hey", tax_rate: 23}}
     end
 
-    it { is_expected.to redirect_to(marketplace.location(:edit)) }
+    it { is_expected.to redirect_to(marketplace.location(child: :tax_rates)) }
     specify { expect { result }.to change { tax_rate.reload.label }.to("Hey") }
     specify { expect { result }.to change { tax_rate.reload.tax_rate }.to(23) }
   end


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1137
- https://github.com/zinc-collective/convene/pull/1222

In a previous commit, we had tidied up the `Markeplace#edit` screen quite a bit, but we had also removed the list of `TaxRate`s on that screen.

This sprouts a `TaxRate#index` screen, that is linked to from `Marketplace#edit`, so that `Member`s of a `Space` may set the `TaxRate` for their Clients.

## After
![Screenshot 2023-03-19 at 1 34 24 PM](https://user-images.githubusercontent.com/50284/226207381-11be4dbf-ffc7-466f-9b59-619dc7b58c02.png)

