### PR TITLE
Set `Order` datetime based off actual order creation

### DIFF
--- a/app/furniture/marketplace/stripe_events_controller.rb
+++ b/app/furniture/marketplace/stripe_events_controller.rb
@@ -28,6 +28,7 @@ class Marketplace
             "#{shipping_address.city}, #{shipping_address.state} #{shipping_address.postal_code}"].compact.join("\n")
         order.update(delivery_address: delivery_address,
           status: :paid,
+          placed_at: DateTime.now,
           contact_email: event.data.object.customer_details.email)
 
         OrderReceivedMailer.notification(order).deliver_later

--- a/db/migrate/20230319173737_add_placed_at_to_marketplace_orders.rb
+++ b/db/migrate/20230319173737_add_placed_at_to_marketplace_orders.rb
@@ -1,0 +1,5 @@
+class AddPlacedAtToMarketplaceOrders < ActiveRecord::Migration[7.0]
+  def change
+    add_column :marketplace_orders, :placed_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_11_011858) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_19_173737) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -137,6 +137,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_11_011858) do
     t.string "contact_email"
     t.text "delivery_address_ciphertext"
     t.string "contact_phone_number_ciphertext"
+    t.datetime "placed_at"
     t.index ["marketplace_id"], name: "index_marketplace_orders_on_marketplace_id"
     t.index ["shopper_id"], name: "index_marketplace_orders_on_shopper_id"
   end

--- a/spec/furniture/marketplace/stripe_events_controller_request_spec.rb
+++ b/spec/furniture/marketplace/stripe_events_controller_request_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Marketplace::StripeEventsController, type: :request do
     specify { call && expect(Stripe::Transfer).to(have_received(:create).with({amount: order.price_total.cents - balance_transaction.fee, currency: "usd", destination: marketplace.stripe_account, transfer_group: order.id}, {api_key: marketplace.stripe_api_key})) }
 
     specify { expect { call }.to have_enqueued_mail(Marketplace::OrderReceivedMailer, :notification).with(order) }
-
+    specify { expect { call }.to change { order.reload.placed_at }.from(nil) }
     specify { expect { call }.to change { order.reload.contact_email }.to("test@example.com") }
     specify { expect { call }.to change { order.reload.delivery_address }.to("Test\n123 N West\napt 1\nOakland, CA 94609") }
 


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/831

Currently the `Order` datetime is based off when the `Cart` was created and not when the `Order` was created.

This fixes that by setting `placed_at` for `Order` after the order is successfully created in Stripe.

note: The `Cart` is created when the Marketplace page is loaded.