### PR TITLE
✨🥗 `Marketplace`: Show `Tax` on `OrderReceivedMailer`

### DIFF
--- a/app/furniture/marketplace/locales/en.yml
+++ b/app/furniture/marketplace/locales/en.yml
@@ -19,6 +19,8 @@ en:
         failure: "Marketplace could not be updated."
     order:
       index: "Order History"
+    order_received_mailer:
+      subject: "Order Received for %{marketplace_name}: %{order_id}"
     product:
       index:
     products:

--- a/app/furniture/marketplace/order_received_mailer.rb
+++ b/app/furniture/marketplace/order_received_mailer.rb
@@ -4,7 +4,9 @@ class Marketplace
     helper_method :order
     def notification(order)
       @order = order
-      mail(to: order.marketplace.notify_emails.split(","))
+      mail(to: order.marketplace.notify_emails.split(","),
+        subject: t(".subject", marketplace_name: order.marketplace.room.name,
+          order_id: order.id))
     end
   end
 end

--- a/app/furniture/marketplace/order_received_mailer/notification.html.erb
+++ b/app/furniture/marketplace/order_received_mailer/notification.html.erb
@@ -1,13 +1,59 @@
-<h3>Order #<%= order.id %></h3>
+<style>
+.align-top { vertical-align: top; }
+.table-fixed { table-layout: fixed; }
+.text-center { text-align: center; }
+.text-right { text-align: right; }
+.w-full { width: 100%; }
+</style>
 
-<ul>
-  <%- order.ordered_products.each do |ordered_product|%>
-    <li><%= ordered_product.name %> (<%= ordered_product.quantity %>) - <%= humanized_money_with_symbol(ordered_product.price) %></li>
-  <%- end %>
-  <li>Delivery Fee: <%= humanized_money_with_symbol(order.delivery_fee) %>
-</ul>
+<h3 class="w-full text-center">
+  <%= link_to "Order #{order.id}", order.persisted? ? order.location : "#" %>
+</h3>
 
-<p>Total: <%= humanized_money_with_symbol(order.price_total) %></p>
-<p>Deliver To: <%= order.delivery_address %>
-<p>Contact Email: <%= order.contact_email %>
-<p>Contact Phone Number: <%= order.contact_phone_number %>
+
+<table class="w-full table-fixed">
+<tr><th colspan="3">Products</th></tr>
+<%- order.ordered_products.each do |ordered_product|%>
+  <tr>
+    <td class="text-right"><%= ordered_product.name %></td>
+    <td class="text-center">x <%= ordered_product.quantity %></td>
+    <td><%= humanized_money_with_symbol(ordered_product.price) %></td>
+  </tr>
+<%- end %>
+<tr>
+  <th class="text-right" colspan="1">Subtotal</th>
+  <td></td>
+  <td><%= humanized_money_with_symbol(order.product_total) %></td>
+</tr>
+<tr><th colspan="3">Taxes and Fees</th></tr>
+<tr>
+  <td class="text-right">Taxes</td>
+  <td></td>
+  <td><%= humanized_money_with_symbol(order.tax_total) %></td>
+</tr>
+<tr>
+  <td class="text-right">Delivery</td>
+  <td></td>
+  <td><%= humanized_money_with_symbol(order.delivery_fee) %></td>
+</tr>
+<tr>
+  <th class="text-right">Total</th>
+  <td></td>
+  <td><%= humanized_money_with_symbol(order.price_total) %></td>
+</tr>
+<tfoot>
+<tr><th colspan="3">Delivery Details</th></tr>
+<tr>
+  <td class="text-right">Buyer Email:</td>
+  <td colspan="2"><%= order.contact_email %></td>
+</tr>
+<tr>
+  <td class="text-right">Phone Number:</td>
+  <td colspan="2"><%= order.contact_phone_number %></td>
+</tr>
+<tr>
+  <td class="text-right align-top">Address:</td>
+  <td colspan="2"><%= order.delivery_address %></td>
+</tr>
+</tfoot>
+</table>

--- a/spec/mailers/previews/marketplace/order_received_mailer_preview.rb
+++ b/spec/mailers/previews/marketplace/order_received_mailer_preview.rb
@@ -1,13 +1,22 @@
 # Preview at http://localhost:3000/rails/mailers/marketplace/order_received_mailer
 
-class Marketplace::OrderReceivedMailerPreview < ActionMailer::Preview
-  def order_with_products
-    marketplace = FactoryBot.build(:marketplace, delivery_fee_cents: (10_00..25_00).to_a.sample)
-    order = FactoryBot.build(:marketplace_order, :with_products, marketplace: marketplace,
-      product_count: (1..5).to_a.sample, delivery_address: Faker::Address.full_address,
-      contact_email: Faker::Internet.safe_email, contact_phone_number: Faker::PhoneNumber.cell_phone)
-    order.marketplace.notify_emails = "distributor@example.com,vendor@example.com"
+class Marketplace
+  class OrderReceivedMailerPreview < ActionMailer::Preview
+    def order_with_products
+      OrderReceivedMailer.notification(order)
+    end
 
-    Marketplace::OrderReceivedMailer.notification(order)
+    private def order
+      marketplace = FactoryBot.build(:marketplace, delivery_fee_cents: (10_00..25_00).to_a.sample,
+        notify_emails: "distributor@example.com,vendor@example.com")
+
+      tax_rate = FactoryBot.build(:marketplace_tax_rate, marketplace: marketplace)
+      order = FactoryBot.build(:marketplace_order, :with_products, marketplace: marketplace,
+        product_count: (1..5).to_a.sample, delivery_address: Faker::Address.full_address,
+        contact_email: Faker::Internet.safe_email, contact_phone_number: Faker::PhoneNumber.cell_phone)
+
+      order.ordered_products.first.product.tax_rates << tax_rate
+      order
+    end
   end
 end


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1137

I took some time to:

- Tidy up the layout
- Write a subject line

So this should be pretty functional!

Stuff that's missing (because we don't have it):

1. Contact Name
2. Pickup Time
3. Delivery Time

I still feel dissatisfied with how we present the tax collected (Like I think we should break it out by type mayhaps?); but I think it's probably OK for now?

## After

![Screenshot 2023-03-20 at 11 16 07 AM](https://user-images.githubusercontent.com/50284/226430610-e995d9d4-3364-45ec-9d69-027e08abbc70.png)

## Before
![Screenshot 2023-03-20 at 11 16 47 AM](https://user-images.githubusercontent.com/50284/226430773-fb3e5209-e4be-490e-80c7-574db8b9b188.png)
