### PR TITLE
🐞 `Marketplace`: `StripeEvent#create` was failing

### DIFF
--- a/app/furniture/marketplace/stripe_events_controller.rb
+++ b/app/furniture/marketplace/stripe_events_controller.rb
@@ -17,6 +17,7 @@ class Marketplace
         order = Order.find(payment_intent.transfer_group)
 
         return if order.paid?
+
         latest_charge = Stripe::Charge.retrieve(payment_intent.latest_charge, api_key: marketplace.stripe_api_key)
         balance_transaction = Stripe::BalanceTransaction.retrieve(latest_charge.balance_transaction, api_key: marketplace.stripe_api_key)
 

--- a/app/furniture/marketplace/stripe_events_controller.rb
+++ b/app/furniture/marketplace/stripe_events_controller.rb
@@ -17,18 +17,10 @@ class Marketplace
         order = Order.find(payment_intent.transfer_group)
 
         return if order.paid?
+        latest_charge = Stripe::Charge.retrieve(payment_intent.latest_charge, api_key: marketplace.stripe_api_key)
+        balance_transaction = Stripe::BalanceTransaction.retrieve(latest_charge.balance_transaction, api_key: marketplace.stripe_api_key)
 
-        balance_transaction = Stripe::BalanceTransaction.retrieve(payment_intent.charges.first.balance_transaction, api_key: marketplace.stripe_api_key)
-
-        shipping_address = event.data.object.shipping.address
-        delivery_address =
-          [event.data.object.shipping.name,
-            shipping_address.line1,
-            shipping_address.line2,
-            "#{shipping_address.city}, #{shipping_address.state} #{shipping_address.postal_code}"].compact.join("\n")
-        order.update(delivery_address: delivery_address,
-          status: :paid,
-          placed_at: DateTime.now,
+        order.update(status: :paid, placed_at: DateTime.now,
           contact_email: event.data.object.customer_details.email)
 
         OrderReceivedMailer.notification(order).deliver_later

--- a/spec/furniture/marketplace/stripe_events_controller_request_spec.rb
+++ b/spec/furniture/marketplace/stripe_events_controller_request_spec.rb
@@ -15,8 +15,7 @@ RSpec.describe Marketplace::StripeEventsController, type: :request do
   let(:balance_transaction) { double(Stripe::BalanceTransaction, fee: 100) }
 
   let(:payment_intent) do
-    double(Stripe::PaymentIntent, transfer_group: order.id,
-      latest_charge: "ch_1234")
+    double(Stripe::PaymentIntent, transfer_group: order.id, latest_charge: "ch_1234")
   end
 
   let(:charge) {

--- a/spec/furniture/marketplace/stripe_events_controller_request_spec.rb
+++ b/spec/furniture/marketplace/stripe_events_controller_request_spec.rb
@@ -9,18 +9,19 @@ RSpec.describe Marketplace::StripeEventsController, type: :request do
 
   let(:stripe_event) do
     double(Stripe::Event, type: "checkout.session.completed",
-      data: double(object: double(payment_intent: "pi_1234",
-        customer_details: double(email: "test@example.com"),
-        shipping: double(name: "Test",
-          address: double(line1: "123 N West", line2: "apt 1", city: "Oakland", state: "CA", postal_code: "94609")))))
+      data: double(object: double(payment_intent: "pi_1234", customer_details: double(email: "test@example.com"))))
   end
 
   let(:balance_transaction) { double(Stripe::BalanceTransaction, fee: 100) }
 
   let(:payment_intent) do
     double(Stripe::PaymentIntent, transfer_group: order.id,
-      charges: [double(Stripe::Charge, balance_transaction: "btx_2234")])
+      latest_charge: "ch_1234")
   end
+
+  let(:charge) {
+    double(Stripe::Charge, balance_transaction: "btx_2234")
+  }
 
   before do
     allow(Stripe::Webhook).to receive(:construct_event).with(anything, "sig_1234", marketplace.stripe_webhook_endpoint_secret).and_return(stripe_event)
@@ -28,6 +29,7 @@ RSpec.describe Marketplace::StripeEventsController, type: :request do
     allow(Stripe::PaymentIntent).to receive(:retrieve).with("pi_1234", anything).and_return(payment_intent)
     allow(Stripe::Transfer).to receive(:create)
     allow(Stripe::BalanceTransaction).to receive(:retrieve).with("btx_2234", anything).and_return(balance_transaction)
+    allow(Stripe::Charge).to receive(:retrieve).with("ch_1234", anything).and_return(charge)
   end
 
   describe "#create" do
@@ -43,7 +45,6 @@ RSpec.describe Marketplace::StripeEventsController, type: :request do
     specify { expect { call }.to have_enqueued_mail(Marketplace::OrderReceivedMailer, :notification).with(order) }
     specify { expect { call }.to change { order.reload.placed_at }.from(nil) }
     specify { expect { call }.to change { order.reload.contact_email }.to("test@example.com") }
-    specify { expect { call }.to change { order.reload.delivery_address }.to("Test\n123 N West\napt 1\nOakland, CA 94609") }
 
     context "when stripe sends us an event we can't handle" do
       let(:stripe_event) { double(Stripe::Event, type: "a.weird.event") }


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1236

It looks like the `PaymentIntent` shape changes depending on what features we request. In particular, `charges` is sometimes absent and since we're not collecting the address from them on `Checkout` it's not included.

It may be worth taking time to write a shot-across-the-bow feature test that:

1. Sets up Stripe in a Space
2. Sets up the Marketplace in a Space
3. Places an Order
4. Confirms the Order was received and emails went out

But that also sounds hard.