### PR TITLE
🛠️ `Marketplace`: Encrypt `Order#contact_email`

### DIFF
--- a/app/furniture/marketplace/cart.rb
+++ b/app/furniture/marketplace/cart.rb
@@ -17,6 +17,7 @@ class Marketplace
 
     has_encrypted :delivery_address
     has_encrypted :contact_phone_number
+    has_encrypted :contact_email, migrating: true
 
     enum status: {
       pre_checkout: "pre_checkout",

--- a/app/furniture/marketplace/order.rb
+++ b/app/furniture/marketplace/order.rb
@@ -13,6 +13,7 @@ class Marketplace
 
     has_encrypted :delivery_address
     has_encrypted :contact_phone_number
+    has_encrypted :contact_email, migrating: true
 
     enum status: {
       pre_checkout: "pre_checkout",

--- a/db/migrate/20230320210304_encrypt_marketplace_order_contact_email.rb
+++ b/db/migrate/20230320210304_encrypt_marketplace_order_contact_email.rb
@@ -1,0 +1,5 @@
+class EncryptMarketplaceOrderContactEmail < ActiveRecord::Migration[7.0]
+  def change
+    add_column :marketplace_orders, :contact_email_ciphertext, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_20_190449) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_20_210304) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -139,6 +139,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_20_190449) do
     t.string "contact_phone_number_ciphertext"
     t.datetime "placed_at"
     t.string "delivery_window"
+    t.string "contact_email_ciphertext"
     t.index ["marketplace_id"], name: "index_marketplace_orders_on_marketplace_id"
     t.index ["shopper_id"], name: "index_marketplace_orders_on_shopper_id"
   end


### PR DESCRIPTION
- https://github.com/ankane/lockbox#migrating-existing-data
- https://github.com/zinc-collective/convene/issues/831

We already have a `Lockbox.migrate(Order)` in the post-release script; which I forgot to take out when I was migrating the other stuff.

Also, thanks to @KellyAH for suggesting this a while back and I punted on it until now but now I did it! Yah!