### PR TITLE
🥗 `Marketplace`: Capture `Cart#delivery_window` as a DateTime

### DIFF
--- a/app/furniture/marketplace/cart.rb
+++ b/app/furniture/marketplace/cart.rb
@@ -29,7 +29,12 @@ class Marketplace
     end
 
     def delivery_window
-      marketplace.delivery_window.presence || super
+      return marketplace.delivery_window if marketplace.delivery_window.present?
+      return nil if super.blank?
+
+      DateTime.parse(super) || 48.hours.from_now
+    rescue Date::Error => _e
+      48.hours.from_now
     end
 
     def delivery_fee

--- a/app/furniture/marketplace/carts/_cart.html.erb
+++ b/app/furniture/marketplace/carts/_cart.html.erb
@@ -3,7 +3,7 @@
   <%- if !cart.ready_for_shopping? %>
     <%= form_with model: cart.location do |cart_form| %>
       <%= render "text_field", attribute: :delivery_address, form: cart_form %>
-      <%= render "text_field", attribute: :delivery_window, form: cart_form, disabled?: cart.marketplace.delivery_window.present? %>
+      <%= render "datetime_field", attribute: :delivery_window, form: cart_form, disabled?: cart.marketplace.delivery_window.present? %>
       <%= render "text_field", attribute: :contact_phone_number, form: cart_form %>
 
       <%= cart_form.submit t('marketplace.delivery_info.edit') %>
@@ -50,12 +50,12 @@
     </div>
   <%- end %>
 
-  <p class="italic text-right py-2 text-sm">
+  <p class="text-right py-2 text-sm">
     <%- if cart.marketplace.delivery_window.present? %>
       Orders placed by <%= cart.marketplace.order_by %>
-      are delivered on <%= cart.marketplace.delivery_window %>.
+      are delivered on <%= cart.marketplace.delivery_window %>
     <%- elsif cart.delivery_window.present? %>
-      Place orders <%= cart.marketplace.order_by %> to ensure an on-time delivery for <%= cart.delivery_window%>.<br />
+      Place orders <%= cart.marketplace.order_by %> to ensure an on-time delivery for <%= l(cart.delivery_window, format: :day_month_date_hour_minute) %><br />
       <%= render ButtonComponent.new(href: cart.location.concat([params: { cart: { delivery_window: nil } }]), label: t('marketplace.delivery_window.edit'), title: nil, classes: "shrink font-light text-xs m-0 bg-primary-200 underline") %>
     <%- end %>
   </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,3 +36,7 @@ en:
       create: "Create ➕"
   home:
     title: "Home"
+  time:
+    formats:
+      day_month_date_year_hour_minute: "%A %B %d, %Y %l:%M%p"
+      day_month_date_hour_minute: "%A %B %d %l:%M%p"

--- a/spec/furniture/marketplace/carts_controller_request_spec.rb
+++ b/spec/furniture/marketplace/carts_controller_request_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Marketplace::CartsController, type: :request do
 
   describe "#update" do
     subject(:perform_request) do
-      put polymorphic_path(cart.location), params: {cart: {delivery_address: "123 N West St", delivery_window: "Tomorrow at 3pm", contact_phone_number: "(415)-123-4567"}}
+      put polymorphic_path(cart.location), params: {cart: {delivery_address: "123 N West St", delivery_window: "2022-01-05 15:00:00", contact_phone_number: "(415)-123-4567"}}
       response
     end
 
@@ -20,7 +20,7 @@ RSpec.describe Marketplace::CartsController, type: :request do
       it { is_expected.to redirect_to(room.location) }
       specify { expect { perform_request }.to change { cart.reload.delivery_address }.from(nil).to("123 N West St") }
       specify { expect { perform_request }.to change { cart.reload.contact_phone_number }.from(nil).to("(415)-123-4567") }
-      specify { expect { perform_request }.to change { cart.reload.delivery_window }.from(nil).to("Tomorrow at 3pm") }
+      specify { expect { perform_request }.to change { cart.reload.delivery_window }.from(nil).to(DateTime.parse("2022-01-05 15:00:00")) }
     end
 
     context "when a `Neighbor`" do


### PR DESCRIPTION
We probably want to do something a bit smerter with like, an `ActiveRecord::Attribute`, but for now this lets us handle nil or unparsed values more effectively

### After:
![Screenshot 2023-03-22 at 5 46 04 PM](https://user-images.githubusercontent.com/50284/227070409-20213149-37e5-46d7-a50b-3ba8ce9e0136.png)
![Screenshot 2023-03-22 at 5 45 45 PM](https://user-images.githubusercontent.com/50284/227070411-ef7fe480-9616-4498-a521-1abce11ff03a.png)


### Before:

![Screenshot 2023-03-22 at 5 47 27 PM](https://user-images.githubusercontent.com/50284/227070502-9584857f-7dfd-4985-9930-7660127bd104.png)
![Screenshot 2023-03-22 at 5 47 18 PM](https://user-images.githubusercontent.com/50284/227070507-78888b3f-8855-4892-a05c-6c718a1143cf.png)
