### PR TITLE
🌸 `Neighborhood`: Tidy up "Account" page

### DIFF
--- a/app/components/card_component.html.erb
+++ b/app/components/card_component.html.erb
@@ -1,3 +1,3 @@
-<div <%== attributes(classes: "grid grid-cols-1 grid-rows-2 grid-flow-col shadow rounded-lg px-3 bg-white") %>>
+<div <%== attributes(classes: "grid grid-cols-1 grid-rows-2 grid-flow-col shadow rounded-lg p-3 bg-white") %>>
   <%= content %>
 </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,11 +1,10 @@
 <header>
   <%= render partial: "breadcrumbs" %>
 
-
   <nav aria-label="Menu" class="profile-menu" data-person-email="<%= current_person.email %>">
     <%- if current_person.authenticated? %>
       <%- if current_membership.present? %>
-        <%= link_to "Account", [current_space, current_membership], title: current_membership.member.email %>
+        <%= link_to "Your Account", [current_space, current_membership], title: current_membership.member.email %>
       <%- end %>
       <%= link_to "Sign out", [current_space, :authenticated_session].compact, data: { turbo: true, turbo_method: :delete }, class: 'sign-out' %>
     <%- else %>

--- a/app/views/memberships/show.html.erb
+++ b/app/views/memberships/show.html.erb
@@ -1,10 +1,19 @@
 <%- breadcrumb :show_membership, membership %>
-<h1><%= membership.member.name %></h1>
-<p><%= membership.member.email %></p>
+<%= render CardComponent.new(classes: "mt-3") do %>
+  <h1><%= membership.member.name %></h1>
+  <p><%= membership.member.email %></p>
+<% end %>
 
-<section>
+<%= render CardComponent.new(classes: "mt-3") do %>
   <h3><%= t('invitations.invited_members_heading') %></h3>
-  <ul>
-    <%= render membership.sent_invitations %>
-  </ul>
-</section>
+  <% if membership.sent_invitations.present? %>
+    <ul>
+      <%= render membership.sent_invitations %>
+    </ul>
+  <% else %>
+    <%= t('invitations.no_invitations_sent') %>
+  <% end %>
+  <p class="mt-3">
+    <%= link_to t('invitations.send_invitations'), [space, :invitations] %>
+  </p>
+<% end %>

--- a/config/locales/invitation/en.yml
+++ b/config/locales/invitation/en.yml
@@ -9,6 +9,9 @@ en:
   invitations:
     heading: Invitations
     summary: Members Invited to '%{space_name}'
+    invited_members_heading: Invitations you've sent
+    no_invitations_sent: You haven't sent any invitations
+    send_invitations: Send new invitations
     new:
       heading: Invite Members to '%{space_name}'
     create:


### PR DESCRIPTION
This PR improves the look of the "Account" placeholder for logged-in users.

This also tweaks the styling for the Card Component to give it a little bit more breathing room.

### Before
![image](https://user-images.githubusercontent.com/6729309/227070866-1e4f4117-b1b3-4ae3-9354-78e8e458ca97.png)

![image](https://user-images.githubusercontent.com/6729309/227070908-9c3ec264-e591-4a8b-b591-c55d7d9d1a9f.png)

### After
![image](https://user-images.githubusercontent.com/6729309/227070797-d7f7c55d-8a26-4f2a-998a-9467f3c06ad7.png)

![image](https://user-images.githubusercontent.com/6729309/227070975-817ea5f4-805b-4261-935d-e23bbc84b9e5.png)

