### PR TITLE
🧹 `Furniture`: Add a facility to add attribute-like fields backed by `settings`

### DIFF
--- a/app/furniture/marketplace/marketplace.rb
+++ b/app/furniture/marketplace/marketplace.rb
@@ -11,6 +11,9 @@ class Marketplace
     has_many :tax_rates, inverse_of: :marketplace
 
     setting :notify_emails
+    setting :order_by
+    setting :stripe_webhook_endpoint
+    setting :stripe_webhook_endpoint_secret
 
     def has_controller_edit?
       true
@@ -41,22 +44,6 @@ class Marketplace
       stripe_account.present? && stripe_webhook_endpoint.present? && stripe_webhook_endpoint_secret.present?
     end
 
-    def stripe_webhook_endpoint
-      settings["stripe_webhook_endpoint"]
-    end
-
-    def stripe_webhook_endpoint=stripe_webhook_endpoint
-      settings["stripe_webhook_endpoint"] = stripe_webhook_endpoint
-    end
-
-    def stripe_webhook_endpoint_secret
-      settings["stripe_webhook_endpoint_secret"]
-    end
-
-    def stripe_webhook_endpoint_secret=stripe_webhook_endpoint_secret
-      settings["stripe_webhook_endpoint_secret"] = stripe_webhook_endpoint_secret
-    end
-
     def delivery_fee_cents= delivery_fee_cents
       settings["delivery_fee_cents"] = delivery_fee_cents
     end
@@ -72,14 +59,6 @@ class Marketplace
 
     def delivery_window=(delivery_window)
       settings["delivery_window"] = delivery_window
-    end
-
-    def order_by
-      settings["order_by"]
-    end
-
-    def order_by=(order_by)
-      settings["order_by"] = order_by
     end
 
     # @raises Stripe::InvalidRequestError if something is sad

--- a/app/furniture/marketplace/marketplace.rb
+++ b/app/furniture/marketplace/marketplace.rb
@@ -10,6 +10,8 @@ class Marketplace
 
     has_many :tax_rates, inverse_of: :marketplace
 
+    settings_attribute :notify_emails
+
     def has_controller_edit?
       true
     end
@@ -23,14 +25,6 @@ class Marketplace
       stripe_api_key.present?
     rescue ActiveRecord::RecordNotFound
       false
-    end
-
-    def notify_emails
-      settings["notify_emails"]
-    end
-
-    def notify_emails=(notify_emails)
-      settings["notify_emails"] = notify_emails
     end
 
     # @todo Probably want to rename this for-reals but lazy

--- a/app/furniture/marketplace/marketplace.rb
+++ b/app/furniture/marketplace/marketplace.rb
@@ -10,7 +10,7 @@ class Marketplace
 
     has_many :tax_rates, inverse_of: :marketplace
 
-    settings_attribute :notify_emails
+    setting :notify_emails
 
     def has_controller_edit?
       true

--- a/app/models/furniture.rb
+++ b/app/models/furniture.rb
@@ -46,12 +46,6 @@ class Furniture < ApplicationRecord
     false
   end
 
-  def write_attribute(name, value)
-    super
-  rescue ActiveModel::MissingAttributeError => _e
-    settings[name] = value
-  end
-
   def self.router
     return const_get(:Routes) if const_defined?(:Routes)
     return class_name.constantize.const_get(:Routes) if class_name.constantize.const_defined?(:Routes)

--- a/app/models/furniture.rb
+++ b/app/models/furniture.rb
@@ -85,7 +85,7 @@ class Furniture < ApplicationRecord
   end
 
   # Adds a writer and a reader for a value backed by `settings`
-  def self.settings_attribute(setting_name)
+  def self.setting(setting_name)
     define_method(setting_name.to_s) do
       settings[setting_name.to_s]
     end

--- a/app/models/furniture.rb
+++ b/app/models/furniture.rb
@@ -83,4 +83,15 @@ class Furniture < ApplicationRecord
   def to_kind_class
     becomes(Furniture.registry.fetch(furniture_kind.to_sym))
   end
+
+  # Adds a writer and a reader for a value backed by `settings`
+  def self.settings_attribute(setting_name)
+    define_method(setting_name.to_s) do
+      settings[setting_name.to_s]
+    end
+
+    define_method("#{setting_name}=") do |value|
+      settings[setting_name.to_s] = value
+    end
+  end
 end

--- a/app/models/furniture.rb
+++ b/app/models/furniture.rb
@@ -46,6 +46,12 @@ class Furniture < ApplicationRecord
     false
   end
 
+  def write_attribute(name, value)
+    super
+  rescue ActiveModel::MissingAttributeError => _e
+    settings[name] = value
+  end
+
   def self.router
     return const_get(:Routes) if const_defined?(:Routes)
     return class_name.constantize.const_get(:Routes) if class_name.constantize.const_defined?(:Routes)

--- a/spec/models/furniture_spec.rb
+++ b/spec/models/furniture_spec.rb
@@ -41,9 +41,9 @@ RSpec.describe Furniture do
     end
   end
 
-  describe "#settings_attribute" do
+  describe "#setting" do
     class TestFurniture < described_class # rubocop:disable Lint/ConstantDefinitionInBlock, RSpec/LeakyConstantDeclaration
-      settings_attribute :name
+      setting :name
     end
 
     let(:furniture) { TestFurniture.new }

--- a/spec/models/furniture_spec.rb
+++ b/spec/models/furniture_spec.rb
@@ -40,4 +40,22 @@ RSpec.describe Furniture do
       expect(new_placement.slot_position).to eq(:last)
     end
   end
+
+  describe "#settings_attribute" do
+    class TestFurniture < described_class # rubocop:disable Lint/ConstantDefinitionInBlock, RSpec/LeakyConstantDeclaration
+      settings_attribute :name
+    end
+
+    let(:furniture) { TestFurniture.new }
+
+    it "adds a writer for the setting" do
+      furniture.name = "fancy name"
+      expect(furniture.settings["name"]).to eq("fancy name")
+    end
+
+    it "adds a reader for the setting" do
+      furniture.settings["name"] = "fancier name"
+      expect(furniture.name).to eq("fancier name")
+    end
+  end
 end


### PR DESCRIPTION
This is a proposal for tightening our manually-added "settings-backed attribute" methods. What do y'all think?

Also maybe this is partially duplicative with the [existing `write_attribute` method](https://github.com/zinc-collective/convene/blob/main/app/models/furniture.rb#L49-L53)? Maybe a better approach is to add a `read_attribute`? (if that exists?)