### PR TITLE
🌸 `Neighborhood`: Apply standard form input styling to date-time input

### DIFF
--- a/app/assets/stylesheets/components/form.scss
+++ b/app/assets/stylesheets/components/form.scss
@@ -23,6 +23,7 @@
     }
 
     input[type="email"],
+    input[type="datetime-local"],
     input[type="number"],
     input[type="password"],
     input[type="search"],
@@ -46,6 +47,7 @@
 
     .field_with_errors {
       input[type="email"],
+      input[type="datetime-local"],
       input[type="number"],
       input[type="password"],
       input[type="search"],


### PR DESCRIPTION
We forgot to style date-time inputs in the same way as all the other inputs. This PR fixes that.

### Before
![image](https://user-images.githubusercontent.com/6729309/227088898-16107a7c-7b95-48e3-add3-55192a9e3530.png)

### After
![image](https://user-images.githubusercontent.com/6729309/227088824-1018889f-44cd-4e04-b0ec-e9987b1acdc4.png)