### PR TITLE
🧹 `Furniture`: Improve `Furniture#setting` helper, and migrate all Furniture kinds to use it

### DIFF
--- a/app/furniture/embedded_form.rb
+++ b/app/furniture/embedded_form.rb
@@ -1,13 +1,7 @@
 # frozen_string_literal: true
 
 class EmbeddedForm < Furniture
-  def form_url=(form_url)
-    settings["form_url"] = form_url
-  end
-
-  def form_url
-    settings["form_url"]
-  end
+  setting :form_url
 
   def embeddable_form_url
     form_id = form_url

--- a/app/furniture/livestream.rb
+++ b/app/furniture/livestream.rb
@@ -2,29 +2,9 @@
 
 # Renders a Twitch Livestream in a Room
 class Livestream < Furniture
-  def channel=(channel)
-    settings["channel"] = channel
-  end
-
-  def channel
-    settings.fetch("channel", "")
-  end
-
-  def provider=(provider)
-    settings["provider"] = provider
-  end
-
-  def provider
-    settings.fetch("provider", "twitch")
-  end
-
-  def layout=(layout)
-    settings["layout"] = layout
-  end
-
-  def layout
-    settings.fetch("layout", "")
-  end
+  setting :channel, default: ""
+  setting :layout, default: ""
+  setting :provider, default: "twitch"
 
   def form_template
     "livestreams/form"

--- a/app/furniture/markdown_text_block.rb
+++ b/app/furniture/markdown_text_block.rb
@@ -6,16 +6,10 @@ class MarkdownTextBlock < Furniture
 
   self.location_parent = :room
 
+  setting :content, default: ""
+
   def to_html
     render_markdown(content)
-  end
-
-  def content=(content)
-    settings["content"] = content
-  end
-
-  def content
-    settings.fetch("content", "")
   end
 
   # @todo can we make it so we don't need to define this?

--- a/app/furniture/marketplace/marketplace.rb
+++ b/app/furniture/marketplace/marketplace.rb
@@ -10,8 +10,13 @@ class Marketplace
 
     has_many :tax_rates, inverse_of: :marketplace
 
+    setting :delivery_fee_cents, default: 0
+    monetize :delivery_fee_cents
+    setting :delivery_window
     setting :notify_emails
     setting :order_by
+    setting :stripe_account
+    alias_method :vendor_stripe_account, :stripe_account
     setting :stripe_webhook_endpoint
     setting :stripe_webhook_endpoint_secret
 
@@ -30,35 +35,8 @@ class Marketplace
       false
     end
 
-    # @todo Probably want to rename this for-reals but lazy
-    def stripe_account
-      settings["stripe_account"]
-    end
-    alias_method :vendor_stripe_account, :stripe_account
-
-    def stripe_account=stripe_account
-      settings["stripe_account"] = stripe_account
-    end
-
     def stripe_account_connected?
       stripe_account.present? && stripe_webhook_endpoint.present? && stripe_webhook_endpoint_secret.present?
-    end
-
-    def delivery_fee_cents= delivery_fee_cents
-      settings["delivery_fee_cents"] = delivery_fee_cents
-    end
-
-    def delivery_fee_cents
-      settings["delivery_fee_cents"] || 0
-    end
-    monetize :delivery_fee_cents
-
-    def delivery_window
-      settings["delivery_window"]
-    end
-
-    def delivery_window=(delivery_window)
-      settings["delivery_window"] = delivery_window
     end
 
     # @raises Stripe::InvalidRequestError if something is sad

--- a/app/models/furniture.rb
+++ b/app/models/furniture.rb
@@ -47,11 +47,12 @@ class Furniture < ApplicationRecord
   end
 
   # Adds a writer and a reader for a value backed by `settings`
-  def self.setting(setting_name)
+  def self.setting(setting_name, options = {})
     setting_name_str = setting_name.to_s
+    default = options.fetch(:default, nil)
 
     define_method(setting_name_str) do
-      settings[setting_name_str]
+      settings.fetch(setting_name_str, default)
     end
 
     define_method("#{setting_name_str}=") do |value|

--- a/app/models/furniture.rb
+++ b/app/models/furniture.rb
@@ -48,12 +48,14 @@ class Furniture < ApplicationRecord
 
   # Adds a writer and a reader for a value backed by `settings`
   def self.setting(setting_name)
-    define_method(setting_name.to_s) do
-      settings[setting_name.to_s]
+    setting_name_str = setting_name.to_s
+
+    define_method(setting_name_str) do
+      settings[setting_name_str]
     end
 
-    define_method("#{setting_name}=") do |value|
-      settings[setting_name.to_s] = value
+    define_method("#{setting_name_str}=") do |value|
+      settings[setting_name_str] = value
     end
   end
 

--- a/app/models/furniture.rb
+++ b/app/models/furniture.rb
@@ -46,6 +46,19 @@ class Furniture < ApplicationRecord
     false
   end
 
+  # Adds a writer and a reader for a value backed by `settings`
+  def self.setting(setting_name)
+    define_method(setting_name.to_s) do
+      settings[setting_name.to_s]
+    end
+
+    define_method("#{setting_name}=") do |value|
+      settings[setting_name.to_s] = value
+    end
+  end
+
+  # Makes it possible to do Rails-y things like:
+  #   furniture.update(some_settings_field)
   def write_attribute(name, value)
     super
   rescue ActiveModel::MissingAttributeError => _e
@@ -82,16 +95,5 @@ class Furniture < ApplicationRecord
 
   def to_kind_class
     becomes(Furniture.registry.fetch(furniture_kind.to_sym))
-  end
-
-  # Adds a writer and a reader for a value backed by `settings`
-  def self.setting(setting_name)
-    define_method(setting_name.to_s) do
-      settings[setting_name.to_s]
-    end
-
-    define_method("#{setting_name}=") do |value|
-      settings[setting_name.to_s] = value
-    end
   end
 end

--- a/spec/models/furniture_spec.rb
+++ b/spec/models/furniture_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Furniture do
 
   describe "#setting" do
     class TestFurniture < described_class # rubocop:disable Lint/ConstantDefinitionInBlock, RSpec/LeakyConstantDeclaration
-      setting :name
+      setting :name, default: "some default value"
     end
 
     let(:furniture) { TestFurniture.new }
@@ -56,6 +56,10 @@ RSpec.describe Furniture do
     it "adds a reader for the setting" do
       furniture.settings["name"] = "fancier name"
       expect(furniture.name).to eq("fancier name")
+    end
+
+    it "can set a default value" do
+      expect(furniture.name).to eq("some default value")
     end
   end
 end


### PR DESCRIPTION
As a follow-up to https://github.com/zinc-collective/convene/pull/1254, this PR:
* updates the `Furniture#setting` method to only convert the setting name to string once
* extends `Furniture#setting` to allow setting a default value
* updates all existing Furniture to use the `Furniture#setting` method to define their settings