### PR TITLE
Update yarn.lock file to fix broken Heroku build

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4461,10 +4461,10 @@ webpack-sources@^3.2.3:
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
-webpack@5.76.0:
-  version "5.76.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.76.0.tgz#f9fb9fb8c4a7dbdcd0d56a98e56b8a942ee2692c"
-  integrity sha512-l5sOdYBDunyf72HW8dF23rFtWq/7Zgvt/9ftMof71E/yUb1YLOBmTgA2K4vQthB3kotMrSj609txVE0dnr2fjA==
+webpack@^5.76.0:
+  version "5.76.3"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.76.3.tgz#dffdc72c8950e5b032fddad9c4452e7787d2f489"
+  integrity sha512-18Qv7uGPU8b2vqGeEEObnfICyw2g39CHlDEK4I7NK13LOur1d0HGmGNKGT58Eluwddpn3oEejwvBPoP4M7/KSA==
   dependencies:
     "@types/eslint-scope" "^3.7.3"
     "@types/estree" "^0.0.51"


### PR DESCRIPTION
Latest Heroku auto-deploy failed with the errors:
```
----> Installing dependencies
       Installing node modules (yarn.lock)
       yarn install v1.22.19
       [1/4] Resolving packages...
       error Your lockfile needs to be updated, but yarn was run with `--frozen-lockfile`.
       info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.

-----> Build failed
 !     Outdated Yarn lockfile
       Your application contains a Yarn lockfile (yarn.lock) which does not
       match the dependencies in package.json. This can happen if you use npm
       to install or update a dependency instead of Yarn.
       Please run the following command in your application directory and check
       in the new yarn.lock file:
       $ yarn install
       $ git add yarn.lock
       $ git commit -m "Updated Yarn lockfile"
       $ git push heroku main
```

I think I merged https://github.com/zinc-collective/convene/pull/1262 after tweaking `package.json`, but forgot to run `yarn install` to update the `.lock` file. This fixes that.