### PR TITLE
🐞 `Marketplace`: fix `delivery_window` type issues by giving more structure (and types!) to `Marketplace#settings`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,8 @@ gem "friendly_id", "~> 5.5.0"
 gem "bcrypt", "~> 3.1.18"
 gem "lockbox", "1.2.0"
 gem "rotp", "~> 6.2"
+# Wrap json columns in ActiveModel-like classes
+gem "store_model", "~> 1.6.2"
 
 # Use postgresql for data persistence
 gem "pg", "~> 1.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -392,6 +392,8 @@ GEM
       rubocop-performance (~> 1.16.0)
     stimulus-rails (1.2.1)
       railties (>= 6.0.0)
+    store_model (1.6.2)
+      activerecord (>= 5.2)
     stripe (8.4.0)
     thor (1.2.1)
     tilt (2.0.11)
@@ -475,6 +477,7 @@ DEPENDENCIES
   sprockets-rails
   standard (~> 1.25)
   stimulus-rails
+  store_model (~> 1.6.2)
   stripe
   turbo-rails
   tzinfo-data (~> 1.2021)

--- a/app/furniture/marketplace/cart.rb
+++ b/app/furniture/marketplace/cart.rb
@@ -36,7 +36,7 @@ class Marketplace
       return marketplace.delivery_window if marketplace.delivery_window.present?
       return nil if super.blank?
 
-      DateTime.parse(super) || 48.hours.from_now
+      DateTime.parse(super)
     rescue Date::Error => _e
       48.hours.from_now
     end

--- a/app/furniture/marketplace/marketplace.rb
+++ b/app/furniture/marketplace/marketplace.rb
@@ -10,15 +10,18 @@ class Marketplace
 
     has_many :tax_rates, inverse_of: :marketplace
 
-    setting :delivery_fee_cents, default: 0
+    attribute :settings, ::Marketplace::Settings.to_type, default: {}
+    delegate :delivery_fee_cents, :delivery_fee_cents=,
+      :delivery_window, :delivery_window=,
+      :notify_emails, :notify_emails=,
+      :order_by, :order_by=,
+      :stripe_account, :stripe_account=,
+      :stripe_webhook_endpoint, :stripe_webhook_endpoint=,
+      :stripe_webhook_endpoint_secret, :stripe_webhook_endpoint_secret=,
+      to: :settings
+
     monetize :delivery_fee_cents
-    setting :delivery_window
-    setting :notify_emails
-    setting :order_by
-    setting :stripe_account
     alias_method :vendor_stripe_account, :stripe_account
-    setting :stripe_webhook_endpoint
-    setting :stripe_webhook_endpoint_secret
 
     def has_controller_edit?
       true

--- a/app/furniture/marketplace/settings.rb
+++ b/app/furniture/marketplace/settings.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Marketplace
+  class Settings
+    include StoreModel::Model
+
+    attribute :delivery_fee_cents, :integer, default: 0
+    attribute :delivery_window, :datetime
+    attribute :notify_emails, :string
+    attribute :order_by, :string
+    attribute :stripe_account, :string
+    attribute :stripe_webhook_endpoint, :string
+    attribute :stripe_webhook_endpoint_secret, :string
+  end
+end

--- a/app/models/furniture.rb
+++ b/app/models/furniture.rb
@@ -47,6 +47,7 @@ class Furniture < ApplicationRecord
   end
 
   # Adds a writer and a reader for a value backed by `settings`
+  # If you want types, validations, etc, for your `settings`, use StoreModel (see Marketplace for an example)
   def self.setting(setting_name, options = {})
     setting_name_str = setting_name.to_s
     default = options.fetch(:default, nil)

--- a/spec/furniture/marketplace/cart_spec.rb
+++ b/spec/furniture/marketplace/cart_spec.rb
@@ -63,4 +63,28 @@ RSpec.describe Marketplace::Cart, type: :model do
 
     it { is_expected.to eql(product_b.price * 0.05) }
   end
+
+  describe "#delivery_window" do
+    let(:cart) { create(:marketplace_cart) }
+
+    before do
+      freeze_time
+    end
+
+    context "when the Marketplace has a delivery window" do
+      before do
+        cart.marketplace.delivery_window = 1.week.from_now
+      end
+
+      it "returns the Marketplace delivery window" do
+        expect(cart.delivery_window).to eq(1.week.from_now)
+      end
+    end
+
+    it "is resilient to non-Time stored values" do
+      cart.delivery_window = "this is not a time"
+      expect(cart.delivery_window).to be_a(Time)
+      expect(cart.delivery_window - Time.zone.now).to eq(48.hours)
+    end
+  end
 end

--- a/spec/furniture/marketplace/marketplace_spec.rb
+++ b/spec/furniture/marketplace/marketplace_spec.rb
@@ -14,4 +14,17 @@ RSpec.describe Marketplace::Marketplace, type: :model do
       specify { expect { marketplace.destroy }.not_to change(orders, :count) }
     end
   end
+
+  describe "#delivery_window" do
+    subject(:marketplace) { described_class.new }
+
+    it "defaults to nil" do
+      expect(marketplace.delivery_window).to be_nil
+    end
+
+    it "is a Time type, not just a string" do
+      marketplace.delivery_window = 2.days.from_now
+      expect(marketplace.delivery_window).to be_a(Time)
+    end
+  end
 end

--- a/spec/furniture/marketplace/marketplaces_controller_request_spec.rb
+++ b/spec/furniture/marketplace/marketplaces_controller_request_spec.rb
@@ -23,13 +23,16 @@ RSpec.describe Marketplace::MarketplacesController, type: :request do
   end
 
   describe "#update" do
-    before { sign_in(space, member) }
+    before do
+      sign_in(space, member)
+      freeze_time
+    end
 
     it "updates the attributes" do
-      put polymorphic_path(marketplace.location), params: {marketplace: {delivery_fee: 50.00, delivery_window: "Tomorrow, mahhhhn...", order_by: "10AM"}}
+      put polymorphic_path(marketplace.location), params: {marketplace: {delivery_fee: 50.00, delivery_window: 2.hours.from_now, order_by: "10AM"}}
 
       expect(marketplace.reload.delivery_fee_cents).to eq(50_00)
-      expect(marketplace.reload.delivery_window).to eq("Tomorrow, mahhhhn...")
+      expect(marketplace.reload.delivery_window).to eq(2.hours.from_now)
       expect(marketplace.reload.order_by).to eq("10AM")
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -64,6 +64,7 @@ RSpec.configure do |config|
 
   config.include(AuthHelpers, type: :request)
   config.include(DomHelpers, type: :request)
+  config.include(ActiveSupport::Testing::TimeHelpers)
 
   config.include ViewComponent::TestHelpers, type: :component
 end


### PR DESCRIPTION
Fixes https://github.com/zinc-collective/convene/issues/1265 by using `StoreModel` to model `Marketplace#settings` with a bit more structure, including types.