### PR TITLE
🐞 `Marketplace`: Fix deleting `Product` with `TaxRate`

### DIFF
--- a/app/furniture/marketplace/product.rb
+++ b/app/furniture/marketplace/product.rb
@@ -16,7 +16,7 @@ class Marketplace
     has_many :ordered_products, inverse_of: :product, dependent: :destroy
     has_many :orders, through: :ordered_products, inverse_of: :products
 
-    has_many :product_tax_rates, inverse_of: :product
+    has_many :product_tax_rates, inverse_of: :product, dependent: :destroy
     has_many :tax_rates, through: :product_tax_rates, inverse_of: :products
 
     attribute :name, :string

--- a/spec/furniture/marketplace/product_spec.rb
+++ b/spec/furniture/marketplace/product_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe Marketplace::Product, type: :model do
   it { is_expected.to belong_to(:marketplace).inverse_of(:products) }
   it { is_expected.to have_many(:cart_products).inverse_of(:product).dependent(:destroy) }
   it { is_expected.to have_many(:carts).through(:cart_products).inverse_of(:products) }
+  it { is_expected.to have_many(:product_tax_rates).inverse_of(:product).dependent(:destroy) }
+  it { is_expected.to have_many(:tax_rates).through(:product_tax_rates).inverse_of(:products) }
 
   describe "#name" do
     it { is_expected.to validate_presence_of(:name) }


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1272

Forgot a `dependent: :destroy`