### PR TITLE
🧹 `Space`, `Furniture`, and `Room`: Fill in missing associations

### DIFF
--- a/app/models/furniture.rb
+++ b/app/models/furniture.rb
@@ -11,8 +11,8 @@ class Furniture < ApplicationRecord
 
   ranks :slot, with_same: [:room_id]
 
-  belongs_to :room
-  delegate :space, to: :room
+  belongs_to :room, inverse_of: :furnitures
+  has_one :space, through: :room, inverse_of: :furnitures
 
   attribute :furniture_kind, :string
 

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -50,6 +50,7 @@ class Room < ApplicationRecord
   end
 
   has_many :furnitures, dependent: :destroy_async, inverse_of: :room
+  accepts_nested_attributes_for :furnitures
 
   def full_slug
     "#{space.slug}--#{slug}"

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -1,7 +1,7 @@
 # A Room in Convene acts as a gathering place.
 class Room < ApplicationRecord
   # The space whose settings govern the default publicity and access controls for the Room.
-  belongs_to :space
+  belongs_to :space, inverse_of: :rooms
   include WithinLocation
   self.location_parent = :space
 
@@ -49,8 +49,7 @@ class Room < ApplicationRecord
     publicity_level&.to_sym == :unlisted
   end
 
-  has_many :furnitures, dependent: :destroy_async
-  accepts_nested_attributes_for :furnitures
+  has_many :furnitures, dependent: :destroy_async, inverse_of: :room
 
   def full_slug
     "#{space.slug}--#{slug}"

--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -37,6 +37,7 @@ class Space < ApplicationRecord
 
   # The Rooms within this Space
   has_many :rooms, inverse_of: :space, dependent: :destroy_async
+  has_many :furnitures, through: :rooms, inverse_of: :space
 
   belongs_to :entrance, class_name: "Room", optional: true
 

--- a/spec/models/furniture_spec.rb
+++ b/spec/models/furniture_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Furniture do
-  it { is_expected.to belong_to(:room) }
-  it { is_expected.to delegate_method(:space).to(:room) }
+  it { is_expected.to belong_to(:room).inverse_of(:furnitures) }
+  it { is_expected.to have_one(:space).through(:room).inverse_of(:furnitures) }
 
   describe "#furniture" do
     it "returns the configured piece of furniture" do

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -2,6 +2,8 @@ require "rails_helper"
 
 RSpec.describe Room do
   let(:space) { Space.new }
+  it { is_expected.to have_many(:furnitures).inverse_of(:room) }
+  it { is_expected.to belong_to(:space).inverse_of(:rooms) }
 
   describe ".slug" do
     it "creates unique slugs by space scope" do

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe Room do
   let(:space) { Space.new }
+
   it { is_expected.to have_many(:furnitures).inverse_of(:room) }
   it { is_expected.to belong_to(:space).inverse_of(:rooms) }
 

--- a/spec/models/space_spec.rb
+++ b/spec/models/space_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 RSpec.describe Space do
   it { is_expected.to have_many(:rooms) }
+  it { is_expected.to have_many(:furnitures).through(:rooms).inverse_of(:space) }
 
   it do
     expect(subject).to belong_to(:entrance).class_name("Room")


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/832
- https://github.com/zinc-collective/convene/issues/1155
- https://github.com/zinc-collective/convene/issues/1154
- https://github.com/zinc-collective/convene/issues/709

As I was working to onboard Piikup, I discovered I couldn't really write an easy script to merge into a space since I didn't have the associations together.

Now they're super tight! Yyyaaaaaaah!