### PR TITLE
🌸 `Components`: improve room card styling

### DIFF
--- a/app/assets/stylesheets/components/icons.scss
+++ b/app/assets/stylesheets/components/icons.scss
@@ -4,10 +4,6 @@
     text-decoration: none;
     @apply pr-2;
 
-    &.--enter::before {
-      content: "🚪";
-    }
-
     &.--configure::before {
       content: "⚙️";
     }

--- a/app/components/card_component.html.erb
+++ b/app/components/card_component.html.erb
@@ -1,3 +1,3 @@
-<div <%== attributes(classes: "grid grid-cols-1 grid-rows-2 grid-flow-col shadow rounded-lg p-3 bg-white") %>>
+<div <%== attributes(classes: "shadow rounded-lg px-6 py-6 bg-white") %>>
   <%= content %>
 </div>

--- a/app/views/rooms/_room.html.erb
+++ b/app/views/rooms/_room.html.erb
@@ -1,4 +1,4 @@
-<div class="flex flex-col content-between justify-end">
+<div class="flex flex-col content-between justify-end mx-auto max-w-7xl sm:px-6 lg:px-8">
   <div class="grow mx-auto w-full">
     <section id="furnitures">
       <%= render room.furnitures.rank(:slot) %>

--- a/app/views/rooms/_room.html.erb
+++ b/app/views/rooms/_room.html.erb
@@ -5,11 +5,9 @@
     </section>
   </div>
 
-  <div class="px-6 pt-3">
-    <ul class="mt-3 grid grid-cols-1 gap-5 sm:gap-6 sm:grid-cols-2 lg:grid-cols-4">
-      <% policy_scope(room.space.rooms.listed).each do |room| %>
-        <%= render partial: 'spaces/room_card', locals: { room: room } %>
-      <% end %>
-    </ul>
+  <div class="mt-3 grid grid-cols-1 gap-5 sm:gap-6 sm:grid-cols-2 lg:grid-cols-4 items-center">
+    <% policy_scope(room.space.rooms.listed).each do |room| %>
+      <%= render partial: 'spaces/room_card', locals: { room: room } %>
+    <% end %>
   </div>
 </div>

--- a/app/views/spaces/_room_card.html.erb
+++ b/app/views/spaces/_room_card.html.erb
@@ -8,7 +8,7 @@
         <%= room.name %>
       </h3>
 
-      <button class="rounded-full bg-purple-800 p-1 ml-2 text-white shadow-sm group-hover:bg-purple-700">
+      <button class="rounded-full bg-purple-800 p-1 ml-2 text-white shadow-sm group-hover:bg-purple-700" data-role="enter">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
           <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
         </svg>

--- a/app/views/spaces/_room_card.html.erb
+++ b/app/views/spaces/_room_card.html.erb
@@ -1,14 +1,18 @@
-<%= render CardComponent.new(data: { access_level: room.access_level, slug: room.slug, model: "room", id: room.id }) do %>
-  <header class="w-full items-center flex">
-    <h3 class="text-neutral-900 text-sm leading-5 font-medium truncate pl-8 mr-4">
-      <%= room.name %>
-    </h3>
-  </header>
-  <footer class="w-full flex flex-col items-center justify-center border-t border-neutral-200">
-    <div data-role="enter" class="flex justify-center text-sm leading-5 text-neutral-700 font-medium transition ease-in-out duration-150 focus:outline-none focus:ring-blue-500 focus:border-blue-300 focus:z-10 hovertext-neutral-500">
-      <%= link_to [room.space, room], class: "flex-1 inline-flex items-center justify-center py-4 no-underline" do %>
-        <span class="icon --enter pl-4" role="img" aria-label="Enter <%= room.name %>">Enter Room</span>
-      <% end %>
+<%= link_to [room.space, room], class: "no-underline" do %>
+  <%= render CardComponent.new(
+      data: { access_level: room.access_level, slug: room.slug, model: "room", id: room.id },
+      classes: "group self-stretch hover:bg-purple-100"
+      ) do %>
+    <div class="px-4 py-5 flex items-center justify-between">
+      <h3 class="text-base font-semibold text-purple-900 group-hover:text-purple-700">
+        <%= room.name %>
+      </h3>
+
+      <button class="rounded-full bg-purple-800 p-1 ml-2 text-white shadow-sm group-hover:bg-purple-700">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+        </svg>
+      </button>
     </div>
-  </footer>
+  <%- end %>
 <%- end %>


### PR DESCRIPTION
This PR updates our Room Cards to:
* look a bit more button-y
* have more space
* better accommodate long room names

Also:
* added more space to standard card component
* tweaked the space around the main content container


### Screenshots
#### Before
![image](https://user-images.githubusercontent.com/6729309/229372827-996e5f4e-37fc-4e4f-b351-ec1b9ea67c1f.png)

#### After (with hover state on Cafe Gabriela)
![image](https://user-images.githubusercontent.com/6729309/229372769-ebfe334c-8416-4657-b1ea-93fe1fcd2a43.png)
