### PR TITLE
🛠️ `Neighborhood`: Add Hotjar session tracking and enable it for all users

### DIFF
--- a/app/views/layouts/_hotjar.html.erb
+++ b/app/views/layouts/_hotjar.html.erb
@@ -1,0 +1,11 @@
+<!-- Hotjar Tracking Code for https://convene.zinc.coop/ -->
+<script>
+    (function(h,o,t,j,a,r){
+        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+        h._hjSettings={hjid:3434638,hjsv:6};
+        a=o.getElementsByTagName('head')[0];
+        r=o.createElement('script');r.async=1;
+        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+        a.appendChild(r);
+    })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+</script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,7 @@
     <%= csp_meta_tag %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= render "layouts/hotjar" %>
   </head>
 
   <body>


### PR DESCRIPTION
Addresses https://github.com/zinc-collective/convene/issues/1279

We had discussed enabling this only for space owners, but thinking more about it, I feel like it would be nice to be able to see guests trying to place a marketplace order as well, so for now I enabled this for all users.