### PR TITLE
🛠️ `Neighborhood`: Report browser JavaScritp errors to Sentry

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,5 +1,8 @@
 // Entry point for the build script in your package.json
 
+import { initializeSentry } from "./sentry.js";
+initializeSentry();
+
 import * as ActiveStorage from "@rails/activestorage";
 ActiveStorage.start();
 

--- a/app/javascript/sentry.js
+++ b/app/javascript/sentry.js
@@ -1,0 +1,19 @@
+import * as Sentry from "@sentry/browser";
+
+export function initializeSentry() {
+  const dsn = document.head.querySelector("meta[name=sentry_dsn]").content;
+  if (!dsn) {
+    return;
+  }
+
+  Sentry.init({
+    dsn: dsn,
+    integrations: [new Sentry.BrowserTracing()],
+    release: document.head.querySelector("meta[name=release_tag").content,
+
+    // Set tracesSampleRate to 1.0 to capture 100%
+    // of transactions for performance monitoring.
+    // We recommend adjusting this value in production
+    tracesSampleRate: 1.0,
+  });
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,6 +3,11 @@
   <head>
     <title><%= page_title %></title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <%# Env variables being made accessible to JavaScript %>
+    <%= tag :meta, name: :sentry_dsn, content: ENV["SENTRY_DSN"] %>
+    <%= tag :meta, name: :release_tag,
+        content: "#{ENV.fetch("APP-BASE", "convene")}@#{ENV.fetch("HEROKU_RELEASE_VERSION", "??")}" %>
+
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@hotwired/turbo-rails": "^7.3.0",
     "@rails/actioncable": "^7.0.4",
     "@rails/activestorage": "^7.0.4",
+    "@sentry/browser": "^7.46.0",
     "@tailwindcss/forms": "^0.5.3",
     "@tailwindcss/typography": "^0.5.9",
     "@webpack-cli/serve": "^1.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -535,6 +535,59 @@
   dependencies:
     spark-md5 "^3.0.1"
 
+"@sentry-internal/tracing@7.46.0":
+  version "7.46.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/tracing/-/tracing-7.46.0.tgz#26febabe21a2c2cab45a3de75809d88753ec07eb"
+  integrity sha512-KYoppa7PPL8Er7bdPoxTNUfIY804JL7hhOEomQHYD22rLynwQ4AaLm3YEY75QWwcGb0B7ZDMV+tSumW7Rxuwuw==
+  dependencies:
+    "@sentry/core" "7.46.0"
+    "@sentry/types" "7.46.0"
+    "@sentry/utils" "7.46.0"
+    tslib "^1.9.3"
+
+"@sentry/browser@^7.46.0":
+  version "7.46.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.46.0.tgz#27b291ddd3c61cc1073cbbb5c48c450b438ed83c"
+  integrity sha512-4rX9hKPjxzfH5LhZzO5DlS5NXQ8qZg2ibepaqEgcDHrpYh5813mjjnE4OQA8wiZ6WuG3xKFgHBrGeliD5jXz9w==
+  dependencies:
+    "@sentry-internal/tracing" "7.46.0"
+    "@sentry/core" "7.46.0"
+    "@sentry/replay" "7.46.0"
+    "@sentry/types" "7.46.0"
+    "@sentry/utils" "7.46.0"
+    tslib "^1.9.3"
+
+"@sentry/core@7.46.0":
+  version "7.46.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.46.0.tgz#f377e556d8679f29bde1cce15b1682b6c689d6b7"
+  integrity sha512-BnNHGh/ZTztqQedFko7vb2u6yLs/kWesOQNivav32ZbsEpVCjcmG1gOJXh2YmGIvj3jXOC9a4xfIuh+lYFcA6A==
+  dependencies:
+    "@sentry/types" "7.46.0"
+    "@sentry/utils" "7.46.0"
+    tslib "^1.9.3"
+
+"@sentry/replay@7.46.0":
+  version "7.46.0"
+  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.46.0.tgz#c5e595d0c2d8d4db2c95d68f518510c42eb122a3"
+  integrity sha512-rHsAFdeEu47JRy6mEwwN+M+zTTWlOFWw9sR/eDCvik2lxAXBN2mXvf/N/MN9zQB3+QnS13ke+SvwVW7CshLOXg==
+  dependencies:
+    "@sentry/core" "7.46.0"
+    "@sentry/types" "7.46.0"
+    "@sentry/utils" "7.46.0"
+
+"@sentry/types@7.46.0":
+  version "7.46.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.46.0.tgz#8573ba8676342c594fcfefff4552123278cfec51"
+  integrity sha512-2FMEMgt2h6u7AoELhNhu9L54GAh67KKfK2pJ1kEXJHmWxM9FSCkizjLs/t+49xtY7jEXr8qYq8bV967VfDPQ9g==
+
+"@sentry/utils@7.46.0":
+  version "7.46.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.46.0.tgz#7a713724db3d1c8bc0aef6d19a7fe2c76db0bdf2"
+  integrity sha512-elRezDAF84guMG0OVIIZEWm6wUpgbda4HGks98CFnPsrnMm3N1bdBI9XdlxYLtf+ir5KsGR5YlEIf/a0kRUwAQ==
+  dependencies:
+    "@sentry/types" "7.46.0"
+    tslib "^1.9.3"
+
 "@sindresorhus/is@^4.0.0":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.0.1.tgz#d26729db850fa327b7cacc5522252194404226f5"
@@ -4338,6 +4391,11 @@ ts-interface-checker@^0.1.9:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz#784fd3d679722bc103b1b4b8030bcddb5db2a699"
   integrity sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==
+
+tslib@^1.9.3:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tslib@^2.0.3, tslib@^2.3.0:
   version "2.3.1"


### PR DESCRIPTION
Resolves https://github.com/zinc-collective/convene/issues/1278

I have not bothered setting up the whole webpack sourcemap integration, because it seems like a pain and also because maybe we'll move away from webpack to import-maps or js-bundling soon-ish. This makes the error report less detailed, so maybe it is not worth it adding this in that case, but I think it might still be helpful to at least see that we have an error.

Looks like this in Sentry:
![image](https://user-images.githubusercontent.com/6729309/229384881-008fbff1-3299-45c3-8d8f-71f6da01d637.png)
https://zinc-collective.sentry.io/issues/4057031271/?project=6052513&query=is%3Aunresolved&referrer=issue-stream&stream_index=0
