### PR TITLE
🛠️ `Component`: `ButtonComponent` supports `GET` Turbo Streams

### DIFF
--- a/app/components/button_component.rb
+++ b/app/components/button_component.rb
@@ -8,7 +8,8 @@ class ButtonComponent < ViewComponent::Base
     method: :put,
     confirm: nil,
     disabled: false,
-    classes: nil
+    classes: nil,
+    turbo_stream: nil
   )
     @label = label
     @title = title
@@ -17,6 +18,7 @@ class ButtonComponent < ViewComponent::Base
     @confirm = confirm
     @disabled = disabled
     @classes = classes
+    @turbo_stream = turbo_stream
   end
 
   attr_accessor :classes
@@ -25,6 +27,7 @@ class ButtonComponent < ViewComponent::Base
 
   def data
     data = {turbo_method: @method, turbo: true}
+    data[:turbo_stream] = true if @turbo_stream
     if @confirm.present?
       data[:turbo_confirm] = @confirm
       data[:confirm] = @confirm

--- a/app/components/button_component.rb
+++ b/app/components/button_component.rb
@@ -9,7 +9,7 @@ class ButtonComponent < ViewComponent::Base
     confirm: nil,
     disabled: false,
     classes: nil,
-    turbo_stream: nil
+    turbo_stream: false
   )
     @label = label
     @title = title


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1187
- https://turbo.hotwired.dev/handbook/streams#streaming-from-http-responses

It turns out that `Turbo` only does turbo-streams when `PUT`/`POST`/`DELETE` are the request methods.

If we want to make `GET` requests use the `turbo-stream` request type, we need to specify it in the HTML output, i.e. `<a href="..." data-turbo-stream=true>`

I wasn't sure if this should be default behavior or not, so I leaned towards making it default to not 🤷