### PR TITLE
Add `DeliveryArea#index` link to the Configure Marketplace page

### DIFF
--- a/app/furniture/marketplace/marketplaces/edit.html.erb
+++ b/app/furniture/marketplace/marketplaces/edit.html.erb
@@ -1,13 +1,13 @@
 <%- breadcrumb :edit_marketplace, marketplace %>
 
-<div class="max-w-2xl self-stretch mx-auto">
+<div class="max-w-3xl self-stretch mx-auto">
   <%= render "form", marketplace: marketplace %>
   <p class="flex justify-between my-5 flex-wrap">
     <%- if policy(marketplace.products.new).create? %>
       <%= link_to t('marketplace.products.index.link_to'), marketplace.location(child: :products) %>
     <%- end %>
 
-<%- if policy(marketplace.products.new).create? %>
+    <%- if policy(marketplace.products.new).create? %>
       <%= link_to t('marketplace.delivery_areas.index.link_to'), marketplace.location(child: :delivery_areas) %>
     <%- end %>
 

--- a/app/furniture/marketplace/marketplaces/edit.html.erb
+++ b/app/furniture/marketplace/marketplaces/edit.html.erb
@@ -7,7 +7,7 @@
       <%= link_to t('marketplace.products.index.link_to'), marketplace.location(child: :products) %>
     <%- end %>
 
-    <%- if policy(marketplace.products.new).create? %>
+    <%- if policy(marketplace.delivery_areas.new).create? %>
       <%= link_to t('marketplace.delivery_areas.index.link_to'), marketplace.location(child: :delivery_areas) %>
     <%- end %>
 

--- a/app/furniture/marketplace/marketplaces/edit.html.erb
+++ b/app/furniture/marketplace/marketplaces/edit.html.erb
@@ -1,6 +1,6 @@
 <%- breadcrumb :edit_marketplace, marketplace %>
 
-<div class="max-w-3xl self-stretch mx-auto">
+<div class="max-w-2xl self-stretch mx-auto">
   <%= render "form", marketplace: marketplace %>
   <p class="flex justify-between my-5 flex-wrap">
     <%- if policy(marketplace.products.new).create? %>

--- a/app/furniture/marketplace/marketplaces/edit.html.erb
+++ b/app/furniture/marketplace/marketplaces/edit.html.erb
@@ -1,8 +1,8 @@
 <%- breadcrumb :edit_marketplace, marketplace %>
 
-<div class="max-w-2xl self-stretch mx-auto">
+<div class="max-w-2xl self-stretch md:container md:mx-auto px-40">
   <%= render "form", marketplace: marketplace %>
-  <p class="flex justify-between my-5 flex-wrap">
+  <p class="flex my-5 flex-col">
     <%- if policy(marketplace.products.new).create? %>
       <%= link_to t('marketplace.products.index.link_to'), marketplace.location(child: :products) %>
     <%- end %>

--- a/app/furniture/marketplace/marketplaces/edit.html.erb
+++ b/app/furniture/marketplace/marketplaces/edit.html.erb
@@ -1,8 +1,8 @@
 <%- breadcrumb :edit_marketplace, marketplace %>
 
-<div class="max-w-2xl self-stretch md:container md:mx-auto px-40">
+<div class="max-w-2xl self-stretch mx-auto">
   <%= render "form", marketplace: marketplace %>
-  <p class="flex my-5 flex-col">
+  <p class="flex justify-between my-5 flex-wrap">
     <%- if policy(marketplace.products.new).create? %>
       <%= link_to t('marketplace.products.index.link_to'), marketplace.location(child: :products) %>
     <%- end %>

--- a/app/furniture/marketplace/marketplaces/edit.html.erb
+++ b/app/furniture/marketplace/marketplaces/edit.html.erb
@@ -7,6 +7,10 @@
       <%= link_to t('marketplace.products.index.link_to'), marketplace.location(child: :products) %>
     <%- end %>
 
+<%- if policy(marketplace.products.new).create? %>
+      <%= link_to t('marketplace.delivery_areas.index.link_to'), marketplace.location(child: :delivery_areas) %>
+    <%- end %>
+
     <%- if policy(marketplace.tax_rates.new).create? %>
       <%= link_to(t("marketplace.tax_rates.index.link_to"), marketplace.location(child: :tax_rates)) %>
     <%- end %>


### PR DESCRIPTION
A continuation of https://github.com/zinc-collective/convene/pull/1255

- add link on Configure Marketplace page so users can access the Delivery Areas index page. Currently the user needs to directly go to the URL e.g. `http://127.0.0.1:3000/spaces/system-test/rooms/listed-room-1/marketplaces/5be4d162-da4f-4ea8-9a15-808ba02e9447/delivery_areas`

![added link - mobile view](https://user-images.githubusercontent.com/16140873/229416556-d6e5496d-e6bc-4f63-a113-188022791bb9.jpg)
![added link - wide view](https://user-images.githubusercontent.com/16140873/229416558-ad3ae856-3553-4a0e-9d22-6a1489654fef.jpg)


------
Note: I tried and failed to Display configuration links in list format on the Configure Marketplace page to try to make them look neater. And to fix the links displaying squished together on wide screens.

# Responsive Layout changes
## Before
**widescreen**
![master_-_links_too_close](https://user-images.githubusercontent.com/16140873/229390071-f27bbf6f-4063-4d6b-80d8-46a9a6537725.jpg)

**Mobile**
<img width="612" alt="master mobile" src="https://user-images.githubusercontent.com/16140873/229390173-d865a843-6bf8-43df-a65d-8f98aff24d37.png">

## After
**widescreen**
<img width="1646" alt="feat change wide screen" src="https://user-images.githubusercontent.com/16140873/229390204-2337e747-0736-4038-bb12-b8fd9e95652d.png">

**Mobile** - **Oops I broke mobile mode view** 😱 
![changing width of the browser window](https://user-images.githubusercontent.com/16140873/229390231-a2e20835-b9a5-4050-a7eb-cd0924047c61.gif)