### PR TITLE
🐛🔨 `Neighborhood`: Update Room policy scope to not show inaccessible rooms to users

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -71,11 +71,6 @@ RSpec/NamedSubject:
     - 'spec/models/membership_spec.rb'
     - 'spec/models/space_spec.rb'
 
-# Offense count: 2
-RSpec/RepeatedExampleGroupDescription:
-  Exclude:
-    - 'spec/models/room_spec.rb'
-
 # Offense count: 15
 # Configuration parameters: IgnoreNameless, IgnoreSymbolicNames.
 RSpec/VerifiedDoubles:

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -40,6 +40,7 @@ class Room < ApplicationRecord
 
   scope :listed, -> { where(publicity_level: :listed) }
   scope :unlisted, -> { where(publicity_level: :unlisted) }
+  scope :public_access, -> { where(access_level: :public) }
 
   def listed?
     publicity_level&.to_sym == :listed

--- a/app/policies/room_policy.rb
+++ b/app/policies/room_policy.rb
@@ -26,7 +26,13 @@ class RoomPolicy < ApplicationPolicy
 
   class Scope < ApplicationScope
     def resolve
-      scope.all
+      if person&.operator?
+        scope.all
+      elsif person&.authenticated?
+        scope.where(space: person.spaces).or(scope.public_access)
+      else
+        scope.public_access
+      end
     end
   end
 end

--- a/spec/furniture/marketplace/stripe_accounts_controller_request_spec.rb
+++ b/spec/furniture/marketplace/stripe_accounts_controller_request_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-# rubocop:disable Rspec/VerifiedDoubles
+# rubocop:disable RSpec/VerifiedDoubles
 RSpec.describe Marketplace::StripeAccountsController, type: :request do
   let(:marketplace) { create(:marketplace) }
   let(:space) { marketplace.space }
@@ -49,4 +49,4 @@ RSpec.describe Marketplace::StripeAccountsController, type: :request do
     end
   end
 end
-# rubocop:enable Rspec/VerifiedDoubles
+# rubocop:enable RSpec/VerifiedDoubles

--- a/spec/furniture/marketplace/stripe_events_controller_request_spec.rb
+++ b/spec/furniture/marketplace/stripe_events_controller_request_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 # `Stripe` gem doesn't support verified doubles for some reason...
-# rubocop:disable Rspec/VerifiedDoubles
+# rubocop:disable RSpec/VerifiedDoubles
 RSpec.describe Marketplace::StripeEventsController, type: :request do
   let(:marketplace) { create(:marketplace, :with_stripe_utility, stripe_account: "sa_1234", stripe_webhook_endpoint_secret: "whsec_1234") }
   let(:space) { marketplace.space }
@@ -52,4 +52,4 @@ RSpec.describe Marketplace::StripeEventsController, type: :request do
     end
   end
 end
-# rubocop:enable Rspec/VerifiedDoubles
+# rubocop:enable RSpec/VerifiedDoubles

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Room do
       it { is_expected.to be_listed }
     end
 
-    context "when set to 'listed'" do
+    context "when set to 'unlisted'" do
       subject { described_class.new(publicity_level: "unlisted", space: space) }
 
       it { is_expected.to be_unlisted }

--- a/spec/policies/room_policy_spec.rb
+++ b/spec/policies/room_policy_spec.rb
@@ -39,19 +39,46 @@ RSpec.describe RoomPolicy do
   end
 
   describe RoomPolicy::Scope do
-    it "includes all the rooms" do
-      space = create(:space)
-      internal_room = create(:room, :internal, space: space)
-      public_room = create(:room, :public, space: space)
-      listed_room = create(:room, :listed, space: space)
-      unlisted_room = create(:room, :unlisted, space: space)
+    subject(:results) { described_class.new(person, space.rooms).resolve }
 
-      results = described_class.new(nil, space.rooms).resolve
+    let(:space) { room.space }
+    let!(:internal_room) { create(:room, :internal, space: space) }
+    let!(:public_room) { create(:room, :public, space: space) }
+    let!(:listed_room) { create(:room, :listed, space: space) }
+    let!(:unlisted_room) { create(:room, :unlisted, space: space) }
 
-      expect(results).to include(internal_room)
-      expect(results).to include(public_room)
-      expect(results).to include(unlisted_room)
-      expect(results).to include(listed_room)
+    context "when person is an operator" do
+      let(:person) { operator }
+
+      it "returns all the rooms" do
+        expect(results).to include(internal_room)
+        expect(results).to include(public_room)
+        expect(results).to include(unlisted_room)
+        expect(results).to include(listed_room)
+      end
+    end
+
+    context "when person is a member" do
+      let(:person) { member }
+
+      it "returns all the rooms" do
+        expect(results).to include(internal_room)
+        expect(results).to include(public_room)
+        expect(results).to include(unlisted_room)
+        expect(results).to include(listed_room)
+      end
+    end
+
+    context "when person is not a member" do
+      let(:person) { non_member }
+
+      it "returns only the public rooms" do
+        expect(results).to include(public_room)
+        expect(results).to include(unlisted_room)
+        expect(results).to include(listed_room)
+
+        expect(results).not_to include(internal_room)
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/zinc-collective/convene/issues/1295

### Before
![image](https://user-images.githubusercontent.com/6729309/229390734-fcc0737f-0bc3-4ef8-930f-39726f574fbb.png)


### After
![image](https://user-images.githubusercontent.com/6729309/229390712-ccbfb73a-90b5-4468-83a3-30665888b4fb.png)
