### PR TITLE
🌸 `Neighborhood`: Improve clarity of Room publicity and access level options

### DIFF
--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -16,38 +16,23 @@ class Room < ApplicationRecord
   extend FriendlyId
   friendly_id :name, use: :scoped, scope: :space
 
-  ACCESS_LEVELS = %i[internal public].freeze
   # A Room's Access Level indicates what a participant must know in order to gain access to the room.
   # `internal` only Members may access the Room
-  attribute :access_level, :string, default: :public
-
-  def internal?
-    access_level&.to_sym == :internal
-  end
-
-  def public?
-    access_level&.to_sym == :public
-  end
+  enum access_level: {
+    internal: "internal",
+    public: "public"
+  }, _suffix: :access
+  alias_method :internal?, :internal_access?
+  alias_method :public?, :public_access?
 
   # A Room's Publicity Level indicates how visible the room is.
   # `listed` - The room is discoverable by anyone in the space lobby.
   # `unlisted` - The room is not listed.
-
-  PUBLICITY_LEVELS = %i[listed unlisted].freeze
-  attribute :publicity_level, :string
-  validates :publicity_level, presence: true, inclusion: {in: PUBLICITY_LEVELS + PUBLICITY_LEVELS.map(&:to_s)}
-
-  scope :listed, -> { where(publicity_level: :listed) }
-  scope :unlisted, -> { where(publicity_level: :unlisted) }
-  scope :public_access, -> { where(access_level: :public) }
-
-  def listed?
-    publicity_level&.to_sym == :listed
-  end
-
-  def unlisted?
-    publicity_level&.to_sym == :unlisted
-  end
+  enum publicity_level: {
+    listed: "listed",
+    unlisted: "unlisted"
+  }
+  validates :publicity_level, presence: true
 
   has_many :furnitures, dependent: :destroy_async, inverse_of: :room
   accepts_nested_attributes_for :furnitures

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -19,8 +19,8 @@ class Room < ApplicationRecord
   # A Room's Access Level indicates what a participant must know in order to gain access to the room.
   # `internal` only Members may access the Room
   enum access_level: {
-    internal: "internal",
-    public: "public"
+    public: "public",
+    internal: "internal"
   }, _suffix: :access
   alias_method :internal?, :internal_access?
   alias_method :public?, :public_access?

--- a/app/views/application/_radio_group.html.erb
+++ b/app/views/application/_radio_group.html.erb
@@ -1,0 +1,11 @@
+<%= form.label attribute %>
+<div class="space-y-4 flex items-center sm:flex sm:items-center sm:space-x-10 sm:space-y-0">
+  <%- options.each do |option| %>
+    <div class="flex items-center mb-0">
+      <%= form.radio_button attribute, option,
+          class: "h-4 w-4 border-gray-300 text-purple-900 focus:ring-purple-600" %>
+      <%= form.label attribute, option, value: option,
+          class: "ml-3 block text-sm leading-6 text-gray-900" %>
+    </div>
+  <%- end %>
+</div>

--- a/app/views/rooms/_form.html.erb
+++ b/app/views/rooms/_form.html.erb
@@ -5,8 +5,8 @@
 
     <h3>Privacy and Security</h3>
 
-    <%= render "select", attribute: :publicity_level, options: Room::PUBLICITY_LEVELS.map(&:to_s), form: room_form %>
-    <%= render "select", attribute: :access_level, options: Room::ACCESS_LEVELS.map(&:to_s), form: room_form %>
+    <%= render "select", attribute: :publicity_level, options: Room::publicity_levels.values, form: room_form %>
+    <%= render "select", attribute: :access_level, options: Room::access_levels.values, form: room_form %>
 
     <footer>
       <%- if policy(room).destroy? && room.persisted? %>

--- a/app/views/rooms/_form.html.erb
+++ b/app/views/rooms/_form.html.erb
@@ -5,8 +5,8 @@
 
     <h3>Privacy and Security</h3>
 
-    <%= render "select", attribute: :publicity_level, options: Room::publicity_levels.values, form: room_form %>
-    <%= render "select", attribute: :access_level, options: Room::access_levels.values, form: room_form %>
+    <%= render "radio_group", attribute: :publicity_level, options: Room::publicity_levels.values, form: room_form %>
+    <%= render "radio_group", attribute: :access_level, options: Room::access_levels.values, form: room_form %>
 
     <footer>
       <%- if policy(room).destroy? && room.persisted? %>

--- a/db/migrate/20230403013014_add_default_publicity.rb
+++ b/db/migrate/20230403013014_add_default_publicity.rb
@@ -1,0 +1,9 @@
+class AddDefaultPublicity < ActiveRecord::Migration[7.0]
+  def up
+    change_column :rooms, :publicity_level, :string, default: :listed, null: false
+  end
+
+  def down
+    change_column :rooms, :publicity_level, :string, default: nil, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_23_010430) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_03_013014) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -214,7 +214,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_23_010430) do
     t.string "name"
     t.string "slug"
     t.string "access_level", default: "public", null: false
-    t.string "publicity_level"
+    t.string "publicity_level", default: "listed", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "space_id"

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Room do
 
   describe "#publicity_level" do
     it { is_expected.to validate_presence_of(:publicity_level) }
-    it { is_expected.to validate_inclusion_of(:publicity_level).in_array(["listed", "unlisted", :listed, :unlisted]) }
+    it { is_expected.to define_enum_for(:publicity_level).backed_by_column_of_type(:string) }
 
     context "when set to 'listed'" do
       subject { described_class.new(publicity_level: "listed", space: space) }


### PR DESCRIPTION
As a follow-up on https://github.com/zinc-collective/convene/pull/1300, this PR replaces the visibility and access level select drop-downs in the Room edit form with radio groups.

My goal is to make the available options and current setting clearer.

I would like to soon add an "explanation text" to each of these options. I was experimenting with using [Tailwind's `peer/...` and `peer/...checked` classes](https://tailwindcss.com/docs/hover-focus-and-other-states#differentiating-peers) and I couldn't get them working reliably, so I've given up on that for now. But I'll be back.

I also:
* added a database-level default for the `publicity_level`
* converted the access and publicity levels to Rails enums, so that we can get the scopes and predicate methods and validations for free

### Screenshots
#### Before
![image](https://user-images.githubusercontent.com/6729309/229406298-b5131442-4436-4b6d-9e69-2922bd834613.png)

#### After
![image](https://user-images.githubusercontent.com/6729309/229406248-2948e0e6-d8bd-4961-9a8b-efd12d2dac4a.png)
