### PR TITLE
modify `DeliveryArea` controller tests

### DIFF
--- a/spec/furniture/marketplace/delivery_areas_controller_request_spec.rb
+++ b/spec/furniture/marketplace/delivery_areas_controller_request_spec.rb
@@ -12,10 +12,18 @@ RSpec.describe Marketplace::DeliveryAreasController, type: :request do
   let(:marketplace) { create(:marketplace) }
   let(:person) { create(:membership, space: space).member }
 
+  describe "#index" do
+    let(:perform_request) { get polymorphic_path(marketplace.location(child: :delivery_areas)) }
+
+    it { is_expected.to be_ok }
+    specify { perform_request && assert_select("a", "Add Delivery Area") }
+  end
+
   describe "#new" do
     let(:perform_request) { get polymorphic_path(marketplace.location(:new, child: :delivery_area)) }
 
     it { is_expected.to be_ok }
+    specify { perform_request && assert_select("form input", 3) && assert_select("#delivery_area_label") && assert_select("#delivery_area_price") }
   end
 
   describe "#create" do
@@ -24,5 +32,6 @@ RSpec.describe Marketplace::DeliveryAreasController, type: :request do
     end
 
     it { is_expected.to redirect_to(marketplace.location(child: :delivery_areas)) }
+    specify { expect { perform_request }.to change { marketplace.delivery_areas.reload.count }.by(1) }
   end
 end


### PR DESCRIPTION
A continuation of https://github.com/zinc-collective/convene/pull/1255

- add `assert_select` to tests to make assertions about what the page will display. 
-  add assertions about how `DeliveryArea` controller #create changes the underlying data