### PR TITLE
🐞🔨 `Marketplace`: Stop dropping `Order#contact_email`

### DIFF
--- a/app/furniture/marketplace/cart.rb
+++ b/app/furniture/marketplace/cart.rb
@@ -19,9 +19,6 @@ class Marketplace
     has_encrypted :delivery_address
     has_encrypted :contact_phone_number
     has_encrypted :contact_email
-    def contact_email
-      super.presence || shopper.person&.email
-    end
 
     enum status: {
       pre_checkout: "pre_checkout",

--- a/app/furniture/marketplace/marketplaces/_marketplace.html.erb
+++ b/app/furniture/marketplace/marketplaces/_marketplace.html.erb
@@ -4,7 +4,7 @@
     Marketplace::Shopper.find_or_create_by(person: current_person)
 end %>
 
-<%- cart = marketplace.carts.create_with(contact_email: shopper.person&.contact_email).find_or_create_by(shopper: shopper, status: :pre_checkout) %>
+<%- cart = marketplace.carts.create_with(contact_email: shopper.person&.email).find_or_create_by(shopper: shopper, status: :pre_checkout) %>
 
 <%= render cart %>
 

--- a/app/furniture/marketplace/marketplaces/_marketplace.html.erb
+++ b/app/furniture/marketplace/marketplaces/_marketplace.html.erb
@@ -4,7 +4,7 @@
     Marketplace::Shopper.find_or_create_by(person: current_person)
 end %>
 
-<%- cart = marketplace.carts.find_or_create_by(shopper: shopper, status: :pre_checkout) %>
+<%- cart = marketplace.carts.create_with(contact_email: shopper.person&.contact_email).find_or_create_by(shopper: shopper, status: :pre_checkout) %>
 
 <%= render cart %>
 

--- a/app/furniture/marketplace/order.rb
+++ b/app/furniture/marketplace/order.rb
@@ -14,9 +14,6 @@ class Marketplace
     has_encrypted :delivery_address
     has_encrypted :contact_phone_number
     has_encrypted :contact_email
-    def contact_email
-      super.presence || shopper.person&.email
-    end
 
     enum status: {
       pre_checkout: "pre_checkout",


### PR DESCRIPTION
- Fixes https://github.com/zinc-collective/convene/issues/1294
- Extracted from https://github.com/zinc-collective/convene/pull/1292

I wrote a unit test on the model to prove the data was being dropped; then fixed the bug, then deleted the test since there was no longer custom code on the model...

Also, the request specs in
https://github.com/zinc-collective/convene/pull/1292 cover this as well.