### PR TITLE
`Authentication`: Downcase email addresses

### DIFF
--- a/app/models/authentication_method.rb
+++ b/app/models/authentication_method.rb
@@ -32,6 +32,10 @@ class AuthenticationMethod < ApplicationRecord
     self.person ||= Person.find_or_create_by(email: contact_location)
   end
 
+  def contact_location=(contact_location)
+    super(contact_location&.downcase)
+  end
+
   def verify?(one_time_password)
     totp.verify(one_time_password).present?
   end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -47,6 +47,10 @@ class Invitation < ApplicationRecord
     created_at.present? && created_at < EXPIRATION_PERIOD.ago
   end
 
+  def email=(email)
+    super(email&.downcase)
+  end
+
   private
 
   def not_ignored_space

--- a/spec/models/authentication_method_spec.rb
+++ b/spec/models/authentication_method_spec.rb
@@ -20,6 +20,13 @@ RSpec.describe AuthenticationMethod do
     end
   end
 
+  describe "#contact_location=" do
+    it "downcases passed in values" do
+      authentication_method.contact_location = "Test@Example.Com"
+      expect(authentication_method.contact_location).to eql("test@example.com")
+    end
+  end
+
   describe "#verify?(one_time_password)" do
     it "returns true when a valid, fresh OTP is used" do
       authentication_method.last_one_time_password_at = Time.zone.now

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -8,6 +8,14 @@ RSpec.describe Invitation do
   it { is_expected.to validate_presence_of(:email) }
   it { is_expected.to validate_presence_of(:name) }
 
+  describe "#email=" do
+    it "is forced to lower case" do
+      invitation = described_class.new
+      invitation.email = "User@example.Com"
+      expect(invitation.email).to eql("user@example.com")
+    end
+  end
+
   describe "#invitor_display_name" do
     it "is the invitors display name" do
       invitor = build(:person)


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1310
- https://github.com/zinc-collective/convene/issues/1311

So, the `AuthenticationMethodcontact_location` field is case insensitive from a *validation* perspective, but not from an assignment or lookup perspective.

So when someone had signed in with `Bob@example.com`, then tried to sign in as `bob@example.com` it had a sad day.

Similarly, `Invitation#email`