### PR TITLE
🥗 `Marketplace`: Destroy `DeliveryArea` when destroying `Marketplace`

### DIFF
--- a/app/furniture/marketplace/marketplace.rb
+++ b/app/furniture/marketplace/marketplace.rb
@@ -9,7 +9,7 @@ class Marketplace
     has_many :orders, inverse_of: :marketplace
 
     has_many :tax_rates, inverse_of: :marketplace
-    has_many :delivery_areas, inverse_of: :marketplace
+    has_many :delivery_areas, inverse_of: :marketplace, dependent: :destroy
 
     setting :delivery_fee_cents, default: 0
     monetize :delivery_fee_cents

--- a/spec/furniture/marketplace/marketplace_spec.rb
+++ b/spec/furniture/marketplace/marketplace_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe Marketplace::Marketplace, type: :model do
   it { is_expected.to have_many(:products).inverse_of(:marketplace).dependent(:destroy) }
   it { is_expected.to have_many(:orders).inverse_of(:marketplace) }
   it { is_expected.to have_many(:carts).inverse_of(:marketplace).dependent(:destroy) }
+  it { is_expected.to have_many(:delivery_areas).inverse_of(:marketplace).dependent(:destroy) }
+  it { is_expected.to have_many(:tax_rates).inverse_of(:marketplace) }
 
   describe "#destroy" do
     let(:marketplace) { create(:marketplace, :with_orders) }


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1136

When pairing with @KellyAH, it turned out she couldn't get rid  of `Marketplace`s in her local database because our `delivery_areas` stick around forever.