### PR TITLE
🌸🥔✨ `Marketplace`: `Shopper` chooses `DeliveryArea` for their `Order`

### DIFF
--- a/app/furniture/marketplace/cart/deliveries/_delivery.html.erb
+++ b/app/furniture/marketplace/cart/deliveries/_delivery.html.erb
@@ -2,15 +2,7 @@
   <div class="flex justify-between flex-wrap">
     <div class="flex items-center justify-between text-sm">
       <span>Delivering to:</span>
-      <%= delivery.delivery_address %>
-    </div>
-
-    <div class="flex items-center justify-between text-sm">
-      <span>Contact Phone Number:</span>
-      <%= delivery.contact_phone_number %>
-    </div>
-
-    <div class="flex items-center justify-between text-sm">
+      <%= render(delivery.delivery_area) if delivery.delivery_area.present? %>
       <%= render Marketplace::Cart::Delivery::EditButtonComponent.new(delivery) %>
     </div>
   </div>

--- a/app/furniture/marketplace/cart/deliveries/_delivery.html.erb
+++ b/app/furniture/marketplace/cart/deliveries/_delivery.html.erb
@@ -1,9 +1,7 @@
 <div id="<%=dom_id(delivery) %>">
-  <div class="flex justify-between flex-wrap">
-    <div class="flex items-center justify-between text-sm">
-      <span>Delivering to:</span>
-      <%= render(delivery.delivery_area) if delivery.delivery_area.present? %>
-      <%= render Marketplace::Cart::Delivery::EditButtonComponent.new(delivery) %>
-    </div>
+  <div class="flex flex-wrap items-center justify-between text-sm">
+    <span>Delivering to: <%= render(delivery.delivery_area) if delivery.delivery_area.present? %></span>
+
+    <%= render Marketplace::Cart::Delivery::EditButtonComponent.new(delivery) %>
   </div>
 </div>

--- a/app/furniture/marketplace/cart/deliveries/_form.html.erb
+++ b/app/furniture/marketplace/cart/deliveries/_form.html.erb
@@ -2,6 +2,7 @@
   <%= form_with model: delivery.location do |delivery_form| %>
     <%= render "text_field", attribute: :delivery_address, form: delivery_form %>
     <%= render "window_field", attribute: :delivery_window, form: delivery_form %>
+    <%= render "select", options: delivery.marketplace.delivery_areas.pluck(:label, :id), include_blank: true, attribute: :delivery_area_id, form: delivery_form %>
     <%= render "email_field", attribute: :contact_email, form: delivery_form %>
     <%= render "text_field", attribute: :contact_phone_number, form: delivery_form %>
     <%= delivery_form.submit %>

--- a/app/furniture/marketplace/cart/delivery.rb
+++ b/app/furniture/marketplace/cart/delivery.rb
@@ -8,6 +8,9 @@ class Marketplace
         delivery_window
       end
 
+      belongs_to :delivery_area
+      validates :delivery_area_id, presence: true # rubocop:disable Rails/RedundantPresenceValidationOnBelongsTo
+
       validates :contact_email, presence: true
       validates :contact_phone_number, presence: true
       validates :delivery_address, presence: true

--- a/app/furniture/marketplace/cart/delivery/edit_button_component.rb
+++ b/app/furniture/marketplace/cart/delivery/edit_button_component.rb
@@ -4,7 +4,7 @@ class Marketplace
       class EditButtonComponent < ButtonComponent
         attr_accessor :delivery
         def initialize(delivery,
-          classes: "shrink font-light text-xs m-0 bg-primary-200 underline",
+          classes: "w-full sm:w-auto font-light text-xs m-0 bg-primary-200 underline",
           label: t("marketplace.cart.deliveries.edit.link_to"))
           self.delivery = delivery
           super(method: :get, href: delivery.location(:edit), label: label, turbo_stream: true, title: nil, classes: classes)

--- a/app/furniture/marketplace/cart/delivery_policy.rb
+++ b/app/furniture/marketplace/cart/delivery_policy.rb
@@ -5,7 +5,7 @@ class Marketplace
     class DeliveryPolicy < Policy
       alias_method :delivery, :object
       def permitted_attributes(_params = nil)
-        %i[delivery_address contact_email contact_phone_number delivery_window]
+        %i[delivery_address contact_email contact_phone_number delivery_window delivery_area_id]
       end
 
       class Scope < ApplicationScope

--- a/app/furniture/marketplace/delivery_areas/_delivery_area.html.erb
+++ b/app/furniture/marketplace/delivery_areas/_delivery_area.html.erb
@@ -1,0 +1,1 @@
+<%= delivery_area.label %>

--- a/db/migrate/20230408033925_carts_have_delivery_area.rb
+++ b/db/migrate/20230408033925_carts_have_delivery_area.rb
@@ -1,0 +1,5 @@
+class CartsHaveDeliveryArea < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :marketplace_orders, :delivery_area, type: :uuid, foreign_key: {to_table: :marketplace_delivery_areas}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_03_013014) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_08_033925) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -149,6 +149,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_03_013014) do
     t.datetime "placed_at"
     t.string "delivery_window"
     t.string "contact_email_ciphertext"
+    t.uuid "delivery_area_id"
+    t.index ["delivery_area_id"], name: "index_marketplace_orders_on_delivery_area_id"
     t.index ["marketplace_id"], name: "index_marketplace_orders_on_marketplace_id"
     t.index ["shopper_id"], name: "index_marketplace_orders_on_shopper_id"
   end
@@ -251,6 +253,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_03_013014) do
   add_foreign_key "marketplace_cart_products", "marketplace_orders", column: "cart_id"
   add_foreign_key "marketplace_cart_products", "marketplace_products", column: "product_id"
   add_foreign_key "marketplace_delivery_areas", "furnitures", column: "marketplace_id"
+  add_foreign_key "marketplace_orders", "marketplace_delivery_areas", column: "delivery_area_id"
   add_foreign_key "marketplace_orders", "marketplace_shoppers", column: "shopper_id"
   add_foreign_key "marketplace_product_tax_rates", "marketplace_products", column: "product_id"
   add_foreign_key "marketplace_product_tax_rates", "marketplace_tax_rates", column: "tax_rate_id"

--- a/spec/factories/furniture/marketplace.rb
+++ b/spec/factories/furniture/marketplace.rb
@@ -30,6 +30,14 @@ FactoryBot.define do
     trait :with_delivery_fees do
       delivery_fee_cents { (10_00..25_00).to_a.sample }
     end
+
+    trait :with_delivery_areas do
+      transient do
+        delivery_area_quantity { 1 }
+      end
+
+      delivery_areas { Array.new(delivery_area_quantity) { association(:marketplace_delivery_area, marketplace: instance) } }
+    end
   end
 
   factory :marketplace_product, class: "Marketplace::Product" do
@@ -92,6 +100,7 @@ FactoryBot.define do
 
     trait :full do
       with_taxed_products
+      with_delivery_areas
 
       transient do
         product_count { (1..5).to_a.sample }
@@ -127,9 +136,12 @@ FactoryBot.define do
   end
 
   factory :marketplace_cart_delivery, class: "Marketplace::Cart::Delivery" do
+    marketplace { association(:marketplace, :with_delivery_areas) }
     delivery_address { Faker::Address.full_address }
     contact_phone_number { Faker::PhoneNumber.phone_number }
     contact_email { Faker::Internet.safe_email }
     delivery_window { Marketplace::Delivery::Window.new(value: Faker::Time.forward(days: 1, period: :evening).to_s) }
+    delivery_area { marketplace.delivery_areas.sample }
+    delivery_area_id { delivery_area.id }
   end
 end

--- a/spec/furniture/marketplace/cart/deliveries_controller_request_spec.rb
+++ b/spec/furniture/marketplace/cart/deliveries_controller_request_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Marketplace::Cart::DeliveriesController, type: :request do
-  let(:marketplace) { create(:marketplace) }
+  let(:marketplace) { create(:marketplace, :with_delivery_areas) }
   let(:space) { marketplace.space }
   let(:room) { marketplace.room }
   let(:shopper) { create(:marketplace_shopper, person: person) }
@@ -24,7 +24,7 @@ RSpec.describe Marketplace::Cart::DeliveriesController, type: :request do
       response.tap { delivery.reload }
     end
 
-    let(:delivery_attributes) { attributes_for(:marketplace_cart_delivery) }
+    let(:delivery_attributes) { attributes_for(:marketplace_cart_delivery, marketplace: marketplace) }
 
     context "when a `Guest`" do
       let(:person) { nil }
@@ -37,6 +37,7 @@ RSpec.describe Marketplace::Cart::DeliveriesController, type: :request do
           .and change(delivery, :contact_phone_number).to(delivery_attributes[:contact_phone_number])
           .and change(delivery, :delivery_window).to(delivery_attributes[:delivery_window])
           .and change(delivery, :delivery_address).to(delivery_attributes[:delivery_address])
+          .and change(delivery, :delivery_area_id).to(delivery_attributes[:delivery_area].id)
       end
     end
 
@@ -53,10 +54,11 @@ RSpec.describe Marketplace::Cart::DeliveriesController, type: :request do
           .and change(delivery, :contact_phone_number).to(delivery_attributes[:contact_phone_number])
           .and change(delivery, :delivery_window).to(delivery_attributes[:delivery_window])
           .and change(delivery, :delivery_address).to(delivery_attributes[:delivery_address])
+          .and change(delivery, :delivery_area_id).to(delivery_attributes[:delivery_area].id)
       end
 
       context "when the delivery is invalid" do
-        let(:delivery_attributes) { attributes_for(:marketplace_cart_delivery).merge(contact_phone_number: "") }
+        let(:delivery_attributes) { attributes_for(:marketplace_cart_delivery, marketplace: marketplace).merge(contact_phone_number: "") }
 
         it { is_expected.to have_rendered_turbo_stream(:replace, delivery, partial: "form") }
       end

--- a/spec/furniture/marketplace/cart/delivery_policy_spec.rb
+++ b/spec/furniture/marketplace/cart/delivery_policy_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe Marketplace::Cart::DeliveryPolicy, type: :policy do
+  subject(:delivery_policy) { described_class.new(person, delivery) }
+
+  let(:person) { nil }
+  let(:delivery) { nil }
+
+  describe "#permitted_attributes" do
+    subject(:permitted_attributes) { delivery_policy.permitted_attributes(nil) }
+
+    it { is_expected.to include(:delivery_area_id) }
+    it { is_expected.to include(:contact_phone_number) }
+    it { is_expected.to include(:contact_email) }
+    it { is_expected.to include(:delivery_address) }
+    it { is_expected.to include(:delivery_window) }
+  end
+end

--- a/spec/furniture/marketplace/cart/delivery_spec.rb
+++ b/spec/furniture/marketplace/cart/delivery_spec.rb
@@ -1,6 +1,9 @@
 require "rails_helper"
 
 RSpec.describe Marketplace::Cart::Delivery, type: :model do
+  it { is_expected.to belong_to(:delivery_area) }
+  it { is_expected.to validate_presence_of(:delivery_area_id) }
+
   describe "#contact_email" do
     it { is_expected.to validate_presence_of(:contact_email) }
   end


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1136

This also gets rid of some of the cruft that has accumulated at the top of the `Marketplace`, but the interaction design could use a much more thoughful eye.

After this, we'll probably want to connect the `DeliveryArea#price` to the `Order#delivery_fee`!


### After

<img width="387" alt="Screenshot 2023-04-07 at 10 56 44 PM" src="https://user-images.githubusercontent.com/50284/230705969-cf8caa0b-13d6-4258-8c33-26df12d7cb60.png">
<img width="1234" alt="Screenshot 2023-04-07 at 10 56 39 PM" src="https://user-images.githubusercontent.com/50284/230705971-7073faf3-bcc1-46aa-8806-b473cd00f357.png">
<img width="901" alt="Screenshot 2023-04-07 at 10 35 51 PM" src="https://user-images.githubusercontent.com/50284/230705261-6367e74e-5d15-47a9-b262-0485274c4614.png">

### Before
<img width="900" alt="Screenshot 2023-04-07 at 10 38 20 PM" src="https://user-images.githubusercontent.com/50284/230705338-6531966e-6cb0-4add-8308-41cc7cf5b203.png">
<img width="897" alt="Screenshot 2023-04-07 at 10 38 15 PM" src="https://user-images.githubusercontent.com/50284/230705339-a6e11332-e725-4fa6-9a0a-4f3719f5bb8f.png">

