### PR TITLE
🧹🥗🥔 `Marketplace`: Use `DeliveryArea#price` to calculate `Cart#price_total`

### DIFF
--- a/app/furniture/marketplace/cart.rb
+++ b/app/furniture/marketplace/cart.rb
@@ -33,12 +33,7 @@ class Marketplace
     def delivery
       @delivery ||= becomes(Delivery)
     end
-
-    def delivery_fee
-      return marketplace.delivery_fee if delivery_address.present?
-
-      0
-    end
+    delegate :fee, to: :delivery, prefix: true
 
     def tax_total
       cart_products.sum(0, &:tax_amount)

--- a/app/furniture/marketplace/cart/delivery.rb
+++ b/app/furniture/marketplace/cart/delivery.rb
@@ -1,15 +1,8 @@
 class Marketplace
   class Cart
-    class Delivery < Cart
+    class Delivery < ::Marketplace::Delivery
       extend StripsNamespaceFromModelName
       location(routed_as: :resource, parent: :cart)
-      attribute :delivery_window, ::Marketplace::Delivery::WindowType.new
-      def window
-        delivery_window
-      end
-
-      belongs_to :delivery_area
-      validates :delivery_area_id, presence: true # rubocop:disable Rails/RedundantPresenceValidationOnBelongsTo
 
       validates :contact_email, presence: true
       validates :contact_phone_number, presence: true

--- a/app/furniture/marketplace/delivery.rb
+++ b/app/furniture/marketplace/delivery.rb
@@ -1,12 +1,20 @@
 class Marketplace
   class Delivery < Record
     self.table_name = "marketplace_orders"
+
     belongs_to :marketplace
     belongs_to :shopper
+    belongs_to :delivery_area
+    validates :delivery_area_id, presence: true # rubocop:disable Rails/RedundantPresenceValidationOnBelongsTo
+
     attribute :delivery_window, WindowType.new
 
     def window
       delivery_window
+    end
+
+    def fee
+      delivery_area&.price.presence || marketplace&.delivery_fee.presence
     end
   end
 end

--- a/app/furniture/marketplace/delivery.rb
+++ b/app/furniture/marketplace/delivery.rb
@@ -7,7 +7,10 @@ class Marketplace
     belongs_to :delivery_area
     validates :delivery_area_id, presence: true # rubocop:disable Rails/RedundantPresenceValidationOnBelongsTo
 
+    has_encrypted :delivery_address
     attribute :delivery_window, WindowType.new
+    has_encrypted :contact_phone_number
+    has_encrypted :contact_email
 
     def window
       delivery_window

--- a/spec/factories/furniture/marketplace.rb
+++ b/spec/factories/furniture/marketplace.rb
@@ -135,6 +135,11 @@ FactoryBot.define do
     price { Faker::Commerce.price }
   end
 
+  factory :marketplace_delivery, class: "Marketplace::Delivery" do
+    marketplace
+    shopper { association(:marketplace_shopper) }
+  end
+
   factory :marketplace_cart_delivery, class: "Marketplace::Cart::Delivery" do
     marketplace { association(:marketplace, :with_delivery_areas) }
     delivery_address { Faker::Address.full_address }

--- a/spec/furniture/marketplace/cart_spec.rb
+++ b/spec/furniture/marketplace/cart_spec.rb
@@ -23,13 +23,7 @@ RSpec.describe Marketplace::Cart, type: :model do
       cart.cart_products.create!(product: product_b, quantity: 2)
     end
 
-    it { is_expected.to eql(product_a.price + product_b.price * 2 + (product_b.price * 2 * 0.05)) }
-
-    context "when the #delivery_address is present" do
-      let(:cart) { create(:marketplace_cart, delivery_address: "123", marketplace: marketplace) }
-
-      it { is_expected.to eql(product_a.price + product_b.price * 2 + marketplace.delivery_fee + (product_b.price * 2 * 0.05)) }
-    end
+    it { is_expected.to eql(product_a.price + product_b.price * 2 + cart.delivery_fee + (product_b.price * 2 * 0.05)) }
   end
 
   describe "#product_total" do

--- a/spec/furniture/marketplace/delivery_spec.rb
+++ b/spec/furniture/marketplace/delivery_spec.rb
@@ -1,7 +1,10 @@
 require "rails_helper"
 
 RSpec.describe Marketplace::Delivery, type: :model do
-  subject(:delivery) { described_class.new }
+  subject(:delivery) { build(:marketplace_delivery, marketplace: marketplace, delivery_area: delivery_area) }
+
+  let(:marketplace) { build(:marketplace) }
+  let(:delivery_area) { nil }
 
   it { is_expected.to belong_to(:marketplace) }
   it { is_expected.to belong_to(:shopper) }
@@ -10,6 +13,28 @@ RSpec.describe Marketplace::Delivery, type: :model do
     subject(:delivery_window) { delivery.delivery_window }
 
     it { is_expected.to be_a(Marketplace::Delivery::Window) }
+  end
+
+  describe "#fee" do
+    subject(:fee) { delivery.fee }
+
+    context "when there is not a marketplace delivery fee or a delivery area delivery fee" do
+      it { is_expected.to eq(0) }
+    end
+
+    context "when the marketplace has a delivery fee and the delivery area has a delivery fee" do
+      let(:marketplace) { build(:marketplace, delivery_fee_cents: 25_00) }
+      let(:delivery_area) { build(:marketplace_delivery_area, price_cents: 50_00, marketplace: marketplace) }
+
+      it { is_expected.to eq(delivery_area.price) }
+    end
+
+    context "when the marketplace has a delivery fee but the delivery area does not" do
+      let(:marketplace) { build(:marketplace, delivery_fee_cents: 25_00) }
+      let(:delivery_area) { build(:marketplace_delivery_area, price_cents: nil, marketplace: marketplace) }
+
+      it { is_expected.to eq(marketplace.delivery_fee) }
+    end
   end
 
   describe "#window" do


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1136

Now the pricing reflects the delivery area when the Marketplace and Cart have them! Fancy!

I feel like this is a reasonable amount of test coverage for this change, but if we want to add `request` or `component` specs or something I could be persuaded...