### PR TITLE
🧹🥔✨ `Utilities`: Tidy up `#edit` and `#destroy` use-cases

### DIFF
--- a/app/controllers/utilities_controller.rb
+++ b/app/controllers/utilities_controller.rb
@@ -29,6 +29,11 @@ class UtilitiesController < ApplicationController
     end
   end
 
+  def destroy
+    utility.destroy
+    redirect_to space.location(:edit), notice: t(".success", name: utility.name, utility_type: utility.utility_slug)
+  end
+
   helper_method def utilities
     @utilities ||= policy_scope(space.utilities).all
   end

--- a/app/views/spaces/edit.html.erb
+++ b/app/views/spaces/edit.html.erb
@@ -41,12 +41,35 @@
 
 
 <fieldset>
-  <h3>Utilities</h3>
-  <%- space.utilities.each do |utility| %>
-    <%- if policy(utility).edit? %>
-      <%= render partial: "utilities/form", locals: { utility: utility } %>
-    <%- end %>
-  <%- end %>
+  <header>
+    <h3><%= t('utilities.index.link_to') %></h3>
+    <p class="text-sm italic"><%= t('utilities.help_text') %></p>
+  </header>
 
-  <%= link_to "Add a Utility", [:new, space, :utility] %>
+  <ul>
+    <%- space.utilities.each do |utility| %>
+      <li>
+        <span class="flex justify-between w-full">
+          <span class="grow"><%= utility.name %> <%= utility.utility_slug  %></span>
+          <span>
+            <%- if policy(utility).edit? %>
+              <%= render ButtonComponent.new(href: utility.location(:edit),
+                                            title: t('utilities.edit.link_to', utility_type: utility.utility_slug, name: utility.name),
+                                            label: t('icons.edit'),
+                                            method: :get) %>
+            <%- end %>
+
+            <%- if policy(utility).destroy? %>
+              <%= render ButtonComponent.new(href: utility.location,
+                                            title: t('utilities.destroy.link_to', utility_type: utility.utility_slug, name: utility.name),
+                                            label: t('icons.destroy'),
+                                            method: :delete) %>
+            <%- end %>
+          </span>
+        </span>
+      </li>
+    <%- end %>
+  </ul>
+
+  <p><%= link_to t('utilities.new.link_to'), space.location(:new, child: :utility) %></p>
 </fieldset>

--- a/app/views/utilities/_form.html.erb
+++ b/app/views/utilities/_form.html.erb
@@ -7,6 +7,10 @@
     </h4>
   </header>
 
+  <div>
+    <%= render "text_field", attribute: :name, form: form %>
+  </div>
+
   <%- if utility.has_form? %>
     <div>
       <%= render partial: utility.utility.form_template, locals: { form: form } %>

--- a/app/views/utilities/edit.html.erb
+++ b/app/views/utilities/edit.html.erb
@@ -1,1 +1,2 @@
+<%- breadcrumb :edit_utility, utility %>
 <%= render partial: "form", locals: { utility: utility } %>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -38,8 +38,13 @@ crumb :utilities do |space|
 end
 
 crumb :new_utility do |utility|
-  link "New Utility", utility.location
-  parent :utilities, utility.space
+  link t("utilities.new.link_to"), utility.location
+  parent :edit_space, utility.space
+end
+
+crumb :edit_utility do |utility|
+  link t("utilities.edit.link_to", name: utility.name, utility_type: utility.utility_slug)
+  parent :edit_space, utility.space
 end
 
 crumb :room do |room|

--- a/config/locales/icon/en.yml
+++ b/config/locales/icon/en.yml
@@ -3,6 +3,7 @@ en:
     edit: '⚙️'
     pencil: '✏️'
     remove: '🗑️'
+    destroy: '🗑️'
     new: '➕'
     plus: '➕'
     minus: '➖'

--- a/config/locales/utilities/en.yml
+++ b/config/locales/utilities/en.yml
@@ -1,4 +1,16 @@
 en:
+  utilities:
+    help_text: "Utilities are how your Space connects to other Services, like Stripe, Airtable, Mastodon, or Owncast"
+    index:
+      link_to: "Utilities"
+    new:
+      link_to: "Add Utility"
+    edit:
+      link_to: "Edit %{utility_type} '%{name}'"
+    destroy:
+      link_to: "Destroy Utility '%{utility_type} - %{name}'"
+      success: "Destroyed Utility '%{utility_type} - '%{name}'!"
+
   activerecord:
     attributes:
       utility:

--- a/spec/requests/utilities_controller_request_spec.rb
+++ b/spec/requests/utilities_controller_request_spec.rb
@@ -82,4 +82,16 @@ RSpec.describe UtilitiesController do
       expect(space.utilities.last.utility.configuration).to eq({})
     end
   end
+
+  describe "#destroy" do
+    subject(:perform_request) do
+      delete polymorphic_path(utility.location)
+      response
+    end
+
+    let(:utility) { create(:utility, space: space) }
+
+    specify { expect { perform_request }.to change { Utility.exists?(utility.id) }.from(true).to(false) }
+    it { is_expected.to redirect_to(space.location(:edit)) }
+  end
 end


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/252

I noticed my local Space had two `Stripe` utilities and I wanted to get rid of one but I couldn't because the feature didn't exist.

So now it does.

I also ditched the `Utility` form from the `Space#edit` page and made the list of utilities look more like the list of furniture, with edit and trash buttons on the right.

## After
<img width="387" alt="Screenshot 2023-04-08 at 4 25 15 PM" src="https://user-images.githubusercontent.com/50284/230746621-38d8f96a-e6e7-456e-86c7-9b8939cad889.png">
<img width="375" alt="Screenshot 2023-04-08 at 4 25 06 PM" src="https://user-images.githubusercontent.com/50284/230746622-f8dbbc28-472b-4563-8b8f-8c7abd85965d.png">
<img width="1728" alt="Screenshot 2023-04-08 at 4 24 54 PM" src="https://user-images.githubusercontent.com/50284/230746625-0fee67d5-e055-424d-9a6d-1ea614599dd9.png">


## Before
<img width="380" alt="Screenshot 2023-04-08 at 4 26 29 PM" src="https://user-images.githubusercontent.com/50284/230746656-ff4669d6-903c-4cc3-8282-a7ade780d829.png">
<img width="383" alt="Screenshot 2023-04-08 at 4 26 18 PM" src="https://user-images.githubusercontent.com/50284/230746660-25571dac-25d1-435f-ba9c-f6a32769d7f3.png">
