### PR TITLE
🥗🧹🥔✨ `Marketplace`: Show `DeliveryArea` in `Order::EmailReceiptComponent`

### DIFF
--- a/app/furniture/marketplace/delivery_area.rb
+++ b/app/furniture/marketplace/delivery_area.rb
@@ -4,6 +4,8 @@ class Marketplace
     location(parent: :marketplace)
 
     belongs_to :marketplace, inverse_of: :delivery_areas
+    has_many :orders, inverse_of: :delivery_area
+    has_many :deliveries, inverse_of: :delivery_area
 
     monetize :price_cents
   end

--- a/app/furniture/marketplace/order.rb
+++ b/app/furniture/marketplace/order.rb
@@ -6,6 +6,8 @@ class Marketplace
     belongs_to :marketplace, inverse_of: :orders
     delegate :space, :room, to: :marketplace
 
+    belongs_to :delivery_area, inverse_of: :orders, optional: true
+
     belongs_to :shopper, inverse_of: :orders
 
     has_many :ordered_products, inverse_of: :order, foreign_key: :cart_id, dependent: :destroy

--- a/app/furniture/marketplace/order/email_receipt_component.html.erb
+++ b/app/furniture/marketplace/order/email_receipt_component.html.erb
@@ -51,6 +51,12 @@
   <td class="text-right">Delivery Schedule:</td>
   <td><%= render(order.delivery_window) %></td>
 </tr>
+<%- if order.delivery_area.present? %>
+  <tr>
+    <td class="text-right">Delivering In:</td>
+    <td><%= order.delivery_area.label %></td>
+  </tr>
+<%- end %>
 <tr>
   <td class="text-right">Buyer Email:</td>
   <td colspan="2"><%= order.contact_email %></td>

--- a/spec/factories/furniture/marketplace.rb
+++ b/spec/factories/furniture/marketplace.rb
@@ -100,15 +100,15 @@ FactoryBot.define do
 
     trait :full do
       with_taxed_products
-      with_delivery_areas
 
       transient do
         product_count { (1..5).to_a.sample }
       end
 
-      marketplace { association(:marketplace, :with_tax_rates, :with_delivery_fees, :with_notify_emails) }
+      marketplace { association(:marketplace, :with_tax_rates, :with_delivery_areas, :with_delivery_fees, :with_notify_emails) }
 
-      delivery_window { Marketplace::Delivery::Window.new(1.hour.from_now) }
+      delivery_window { 1.hour.from_now }
+      delivery_area { marketplace.delivery_areas.sample }
       placed_at { 5.minutes.ago }
       delivery_address { Faker::Address.full_address }
       contact_email { Faker::Internet.safe_email }

--- a/spec/furniture/marketplace/delivery_area_spec.rb
+++ b/spec/furniture/marketplace/delivery_area_spec.rb
@@ -1,0 +1,7 @@
+require "rails_helper"
+
+RSpec.describe Marketplace::DeliveryArea, type: :model do
+  it { is_expected.to belong_to(:marketplace).inverse_of(:delivery_areas) }
+  it { is_expected.to have_many(:orders).inverse_of(:delivery_area) }
+  it { is_expected.to have_many(:deliveries).inverse_of(:delivery_area) }
+end

--- a/spec/furniture/marketplace/delivery_spec.rb
+++ b/spec/furniture/marketplace/delivery_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Marketplace::Delivery, type: :model do
 
   it { is_expected.to belong_to(:marketplace) }
   it { is_expected.to belong_to(:shopper) }
+  it { is_expected.to belong_to(:delivery_area) }
 
   describe "#delivery_window" do
     subject(:delivery_window) { delivery.delivery_window }

--- a/spec/furniture/marketplace/order/email_receipt_component_spec.rb
+++ b/spec/furniture/marketplace/order/email_receipt_component_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Marketplace::Order::EmailReceiptComponent, type: :component do
   subject(:content) { render_inline(component) }
 
   let(:component) { described_class.new(order) }
+  let(:order) { build(:marketplace_order, :full) }
 
   context "when the order has a particular time to be delivered" do
     let(:order) { build(:marketplace_order, delivery_window: 3.hours.from_now) }
@@ -16,4 +17,6 @@ RSpec.describe Marketplace::Order::EmailReceiptComponent, type: :component do
 
     it { is_expected.to have_content("3pm on Sunday") }
   end
+
+  it { is_expected.to have_content(/Delivering In:\s+ #{order.delivery_area.label}/) }
 end

--- a/spec/furniture/marketplace/order_spec.rb
+++ b/spec/furniture/marketplace/order_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Marketplace::Order, type: :model do
   it { is_expected.to belong_to(:marketplace).class_name("Marketplace::Marketplace").inverse_of(:orders) }
 
   it { is_expected.to belong_to(:shopper).inverse_of(:orders) }
+  it { is_expected.to belong_to(:delivery_area).inverse_of(:orders).optional }
 
   describe "#price_total" do
     subject(:price_total) { order.price_total }


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1325
- https://github.com/zinc-collective/convene/issues/1324
- https://github.com/zinc-collective/convene/issues/1326

I didn't use the `marketplace_order, :full` factory outside of the `Order::PlacedMailerPreview` and `Order::ReceivedMailerPreview`; and apparently had flubbed the implementation; so that was not working...

So I fixed it and used it in the `Order::EmailReceiptComponent` spec to test the `Order#delivery_area`

I also noticed we didn't wire in associations between the `Marketplace::DeliveryArea` into the `Marketplace::Cart` and `Marketplace::Order` so I added some specs for those.