### PR TITLE
🌸 `Components`: Reduce `Card` padding on small screens

### DIFF
--- a/app/components/card_component.html.erb
+++ b/app/components/card_component.html.erb
@@ -1,3 +1,3 @@
-<div <%== attributes(classes: "shadow rounded-lg px-6 py-6 bg-white") %>>
+<div <%== attributes(classes: "shadow rounded-lg bg-white p-4 sm:p-6") %>>
   <%= content %>
 </div>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -5,6 +5,7 @@ module.exports = {
     './app/furniture/**/*.html.erb',
     './app/utilities/**/*.html.erb',
     './app/views/**/*.html.erb',
+    './app/components/**/*.{erb,rb}',
 
     './app/helpers/**/*.rb',
     './app/javascript/**/*.js'


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1187

The `p-6` felt like just a bit too much on mobile screens; so I made it `p-4` and then when we get to tablet size it's `p-6`.

### After 
<img width="378" alt="Screenshot 2023-04-09 at 12 49 53 PM" src="https://user-images.githubusercontent.com/50284/230793754-13045151-2226-4081-9467-11832f7b73f9.png">
<img width="381" alt="Screenshot 2023-04-09 at 12 49 46 PM" src="https://user-images.githubusercontent.com/50284/230793756-8f669233-1237-465f-b3ca-5bf1b02b1404.png">
