### PR TITLE
🛠️ `Neighborhood`: Add error field workaround to display association errors correctly on forms

### DIFF
--- a/app/furniture/marketplace/delivery.rb
+++ b/app/furniture/marketplace/delivery.rb
@@ -5,7 +5,6 @@ class Marketplace
     belongs_to :marketplace
     belongs_to :shopper
     belongs_to :delivery_area
-    validates :delivery_area_id, presence: true # rubocop:disable Rails/RedundantPresenceValidationOnBelongsTo
 
     has_encrypted :delivery_address
     attribute :delivery_window, WindowType.new

--- a/app/furniture/marketplace/locales/en.yml
+++ b/app/furniture/marketplace/locales/en.yml
@@ -1,5 +1,12 @@
 
 en:
+  activerecord:
+    errors:
+      models:
+        marketplace/delivery:
+          attributes:
+            delivery_area:
+              required: "can't be blank"
   marketplace:
     cart:
       deliveries:

--- a/app/views/application/_error.html.erb
+++ b/app/views/application/_error.html.erb
@@ -1,3 +1,12 @@
-<%- if model.errors.messages_for(attribute).present? %>
-  <p class="field_with_errors"><%= model.errors.messages_for(attribute).join(', ') %></p>
+<% error_messages = model.errors.messages_for(attribute) %>
+<% %w(_id _ids).each do |suffix| %>
+  <%# Workaround for the fact that Rails doesn't add errors from the association foreign key to
+      the association itself. Yet. See: https://github.com/rails/rails/issues/28772 %>
+  <% attribute_str = attribute.to_s %>
+  <% next unless attribute_str.to_s.ends_with?(suffix) %>
+  <% error_messages += model.errors.messages_for(attribute_str.chomp(suffix)) %>
+<% end %>
+
+<%- if error_messages.present? %>
+  <p class="field_with_errors"><%= error_messages.join(', ') %></p>
 <%- end %>

--- a/spec/furniture/marketplace/cart/delivery_spec.rb
+++ b/spec/furniture/marketplace/cart/delivery_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Marketplace::Cart::Delivery, type: :model do
   it { is_expected.to belong_to(:delivery_area) }
-  it { is_expected.to validate_presence_of(:delivery_area_id) }
+  it { is_expected.to validate_presence_of(:delivery_area) }
 
   describe "#contact_email" do
     it { is_expected.to validate_presence_of(:contact_email) }


### PR DESCRIPTION
This PR extends our `errors` partial to show association validation errors on the association foreign key field. This removes the need to have a duplicate presence validation on non-optional `belongs_to` relationships.

A more full solution is possible by patching ActionView::Helpers::ActiveModelInstanceTag, but it also would be more complex and doesn't seem worth it at the moment. If/when https://github.com/rails/rails/issues/28772 is resolved, we won't need this workaround anymore.

For an example of the more complete patch, see: https://web.archive.org/web/20190605211237/http://iada.nl/blog/article/rails-tip-display-association-validation-errors-fields

After this change, form errors look like so:
![image](https://user-images.githubusercontent.com/6729309/230795890-fc778ded-f085-4e8b-814e-01ffab142912.png)
