### PR TITLE
🌸`Marketplace`: Bring `Product` and `TaxRate` UI closer

### DIFF
--- a/app/furniture/marketplace/locales/en.yml
+++ b/app/furniture/marketplace/locales/en.yml
@@ -55,9 +55,10 @@ en:
       create:
         success: "Added Product '%{name}'"
       edit:
-        link_to: "Edit Product '%{name}'"
+        link_to: "Change"
+        link_to: "Change Product '%{name}'"
       destroy:
-        link_to: "Remove Product '%{name}"
+        link_to: "Remove"
     tax_rates:
       index:
         link_to: "Tax Rates"

--- a/app/furniture/marketplace/locales/en.yml
+++ b/app/furniture/marketplace/locales/en.yml
@@ -57,7 +57,7 @@ en:
       edit:
         link_to: "Edit Product '%{name}'"
       destroy:
-        link_to: "Remove"
+        link_to: "Remove Product '%{name}'"
     tax_rates:
       index:
         link_to: "Tax Rates"

--- a/app/furniture/marketplace/locales/en.yml
+++ b/app/furniture/marketplace/locales/en.yml
@@ -55,8 +55,7 @@ en:
       create:
         success: "Added Product '%{name}'"
       edit:
-        link_to: "Change"
-        link_to: "Change Product '%{name}'"
+        link_to: "Edit Product '%{name}'"
       destroy:
         link_to: "Remove"
     tax_rates:

--- a/app/furniture/marketplace/products/_form.html.erb
+++ b/app/furniture/marketplace/products/_form.html.erb
@@ -1,7 +1,9 @@
-<%= form_with model: product.location do |f| %>
-  <%= render "text_field", { attribute: :name, form: f} %>
-  <%= render "text_area", { attribute: :description, form: f} %>
-  <%= render "money_field", { attribute: :price, form: f, min: 0, step: 0.01} %>
-  <%= render "collection_check_boxes", { attribute: :tax_rate_ids, collection: marketplace.tax_rates, value_method: :id, text_method: :label, form: f} %>
-  <%= f.submit %>
-<% end %>
+<%= render CardComponent.new(dom_id: dom_id(product), classes: "mt-3") do %>
+  <%= form_with model: product.location do |f| %>
+    <%= render "text_field", { attribute: :name, form: f} %>
+    <%= render "text_area", { attribute: :description, form: f} %>
+    <%= render "money_field", { attribute: :price, form: f, min: 0, step: 0.01} %>
+    <%= render "collection_check_boxes", { attribute: :tax_rate_ids, collection: marketplace.tax_rates, value_method: :id, text_method: :label, form: f} %>
+    <%= f.submit %>
+  <% end %>
+<%- end %>

--- a/app/furniture/marketplace/products/_product.html.erb
+++ b/app/furniture/marketplace/products/_product.html.erb
@@ -1,20 +1,24 @@
 
-<%= render CardComponent.new(dom_id: dom_id(product)) do %>
-  <div class="flex justify-between">
+<%= render CardComponent.new(dom_id: dom_id(product), classes: "flex flex-col justify-between max-w-prose") do %>
+  <header>
     <h3 class="py-2"><%= product.name %></h3>
-    <span class="flex justify-between">
-      <%= render ButtonComponent.new(label: "#{t('icons.pencil')}",  title: t('marketplace.products.edit.link_to', name: product.name), href: product.location(:edit), method: :get) %>
-      <%= render ButtonComponent.new(label: t('icons.remove'), title: t('marketplace.products.destroy.link_to', name: product.name), href: product.location, method: :delete) %>
-    </span>
-  </div>
-  <div class="text-sm italic">
-    <%= product.description %>
-  </div>
+  </header>
 
-  <div class="text-right">
-    <p><%= humanized_money_with_symbol(product.price) %></p>
-    <div class="text-xs italic">
-      <%= product.tax_rates.map { |tax_rate| "#{tax_rate.label} #{number_to_percentage(tax_rate.tax_rate, precision: 2)}" }.to_sentence %>
+  <div class="grow flex flex-col justify-between">
+    <div class="text-sm italic">
+      <%= product.description %>
+    </div>
+
+    <div class="text-right mt-3">
+      <div class="text-xs italic">
+        <%= product.tax_rates.map { |tax_rate| "#{tax_rate.label} #{number_to_percentage(tax_rate.tax_rate, precision: 2)}" }.to_sentence %>
+      </div>
+      <p><%= humanized_money_with_symbol(product.price) %></p>
     </div>
   </div>
+
+  <footer class="mt-3 flex justify-between">
+    <%= render ButtonComponent.new(label: "#{t('icons.edit')} #{t('edit.link_to')}",  title: t('marketplace.products.edit.link_to'), href: product.location(:edit), method: :get) %>
+    <%= render ButtonComponent.new(label: "#{t('icons.destroy')} #{t('destroy.link_to')}", title: t('marketplace.products.destroy.link_to', name: product.name), href: product.location, method: :delete) %>
+  </footer>
 <%- end %>

--- a/app/furniture/marketplace/products/index.html.erb
+++ b/app/furniture/marketplace/products/index.html.erb
@@ -1,14 +1,14 @@
 <%- breadcrumb :marketplace_products, marketplace%>
-<div class="grid grid-cols-1 gap-4 sm:grid-cols-2 mt-2 sm:mt-4 max-w-prose mx-auto">
+<div class="grid grid-cols-1 md:grid-cols-3 gap-3 sm:gap-5 mt-3 mx-auto">
   <%= render marketplace.products %>
+</div>
 
-  <div class="sm:col-span-2 text-right">
-    <%- new_product = marketplace.products.new %>
-    <%- if policy(new_product).create? %>
-      <%= render ButtonComponent.new(
-        label: "#{t('marketplace.products.new.link_to')} #{t('icons.new')}",
-        title: t('marketplace.products.new.link_to'),
-        href: marketplace.location(:new, child: :product), method: :get) %>
-    <%- end %>
-  </div>
+<div class="text-center mt-3">
+  <%- new_product = marketplace.products.new %>
+  <%- if policy(new_product).create? %>
+    <%= render ButtonComponent.new(
+      label: "#{t('marketplace.products.new.link_to')} #{t('icons.new')}",
+      title: t('marketplace.products.new.link_to'),
+      href: marketplace.location(:new, child: :product), method: :get) %>
+  <%- end %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,3 +40,7 @@ en:
     formats:
       day_month_date_year_hour_minute: "%A %B %d, %Y %l:%M%p"
       day_month_date_hour_minute: "%A %B %d %l:%M%p"
+  edit:
+    link_to: "Change"
+  destroy:
+    link_to: "Remove"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,6 +41,6 @@ en:
       day_month_date_year_hour_minute: "%A %B %d, %Y %l:%M%p"
       day_month_date_hour_minute: "%A %B %d %l:%M%p"
   edit:
-    link_to: "Change"
+    link_to: "Edit"
   destroy:
     link_to: "Remove"


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1137
- https://github.com/zinc-collective/convene/issues/1324
- https://github.com/zinc-collective/convene/pull/1338

I think I like the consistency of using the `icons.edit` / `edit.link_to` and `icons.destroy` / destroy.link_to` in the footer of the card, so there are words with the icons by default.

### After
<img width="390" alt="Screenshot 2023-04-09 at 7 39 05 PM" src="https://user-images.githubusercontent.com/50284/230815265-d10b8325-560a-431e-8da9-e8df02b6d7b2.png">
<img width="373" alt="Screenshot 2023-04-09 at 7 39 00 PM" src="https://user-images.githubusercontent.com/50284/230815268-68d72ee5-7200-4e7e-a33f-8c029834fa6f.png">
<img width="1055" alt="Screenshot 2023-04-09 at 7 38 52 PM" src="https://user-images.githubusercontent.com/50284/230815272-68498c93-c5cc-4d8a-92e3-539b9e96ac27.png">

### Before 
<img width="417" alt="Screenshot 2023-04-09 at 7 48 23 PM" src="https://user-images.githubusercontent.com/50284/230815550-02bcda6e-11bd-41e5-b4a0-b7d6d4004d1e.png">
<img width="400" alt="Screenshot 2023-04-09 at 7 48 17 PM" src="https://user-images.githubusercontent.com/50284/230815556-dc01a888-5053-4342-9b9b-da2c993dae20.png">
<img width="1728" alt="Screenshot 2023-04-09 at 7 48 09 PM" src="https://user-images.githubusercontent.com/50284/230815560-367f8d8d-7420-457e-aeb7-d358f9a6f615.png">
