### PR TITLE
🛠️ `Components`: Tailwind Look for classes in `Furniture`

### DIFF
--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -2,7 +2,7 @@ const colors = require('tailwindcss/colors')
 
 module.exports = {
   content: [
-    './app/furniture/**/*.html.erb',
+    './app/furniture/**/*{_component.rb,.html.erb}',
     './app/utilities/**/*.html.erb',
     './app/views/**/*.html.erb',
     './app/components/**/*.{erb,rb}',


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1187
- https://github.com/zinc-collective/convene/issues/709

Apparenltly our tailwind config wasn't detecting classes in furniture's `_component.rb` files. Womp. Womp.