### PR TITLE
✨🥗 `Marketplace`: `TaxRate` actions support Turbo

### DIFF
--- a/app/furniture/marketplace/tax_rates_controller.rb
+++ b/app/furniture/marketplace/tax_rates_controller.rb
@@ -15,11 +15,57 @@ class Marketplace
       end
     end
 
+    def edit
+      respond_to do |format|
+        format.turbo_stream do
+          render turbo_stream: turbo_stream.replace(tax_rate, partial: "form")
+        end
+
+        format.html
+      end
+    end
+
     def update
-      if tax_rate.update(tax_rate_params)
-        redirect_to marketplace.location(child: :tax_rates)
-      else
-        render :edit
+      tax_rate.update(tax_rate_params)
+
+      respond_to do |format|
+        format.turbo_stream do
+          if tax_rate.errors.empty?
+            render turbo_stream: turbo_stream.replace(tax_rate, TaxRateComponent.new(tax_rate: tax_rate).render_in(view_context))
+          else
+            render turbo_stream: turbo_stream.replace(tax_rate, partial: "form")
+          end
+        end
+
+        format.html do
+          if tax_rate.errors.empty?
+            redirect_to marketplace.location(child: :tax_rates)
+          else
+            render :edit
+          end
+        end
+      end
+    end
+
+    def destroy
+      tax_rate.destroy
+
+      respond_to do |format|
+        format.turbo_stream do
+          if tax_rate.destroyed?
+            render turbo_stream: turbo_stream.remove(tax_rate)
+          else
+            render turbo_stream: turbo_stream.replace(tax_rate)
+          end
+        end
+
+        format.html do
+          if tax_rate.destroyed?
+            redirect_to marketplace.location(child: :tax_rates)
+          else
+            render :show
+          end
+        end
       end
     end
 

--- a/spec/furniture/marketplace/tax_rates_controller_request_spec.rb
+++ b/spec/furniture/marketplace/tax_rates_controller_request_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Marketplace::TaxRatesController, type: :request do
   subject(:result) do
     perform_request
-    test_response
+    response
   end
 
   before { sign_in(space, person) }
@@ -11,11 +11,15 @@ RSpec.describe Marketplace::TaxRatesController, type: :request do
   let(:space) { marketplace.space }
   let(:marketplace) { create(:marketplace) }
   let(:person) { create(:membership, space: space).member }
+  let(:as) { :html }
 
   describe "#new" do
-    let(:perform_request) { get polymorphic_path(marketplace.location(:new, child: :tax_rate)) }
+    let(:perform_request) do
+      get polymorphic_path(marketplace.location(:new, child: :tax_rate))
+    end
 
     it { is_expected.to be_ok }
+    it { is_expected.to render_template(:new) }
   end
 
   describe "#create" do
@@ -26,14 +30,72 @@ RSpec.describe Marketplace::TaxRatesController, type: :request do
     it { is_expected.to redirect_to(marketplace.location(child: :tax_rates)) }
   end
 
-  describe "#update" do
-    let(:tax_rate) { create(:marketplace_tax_rate, marketplace: marketplace) }
+  describe "#edit" do
     let(:perform_request) do
-      put polymorphic_path(tax_rate.location), params: {tax_rate: {label: "Hey", tax_rate: 23}}
+      get polymorphic_path(tax_rate.location(:edit)), as: as
+    end
+    let(:tax_rate) { create(:marketplace_tax_rate, marketplace: marketplace) }
+
+    it { is_expected.to render_template(:edit) }
+
+    # @todo For some reason "as" doesn't appear to work with get requests
+    # context "when a turbo stream" do
+    #   let(:as) { :turbo_steam }
+
+    #   it { is_expected.to have_rendered_turbo_stream(:replace, tax_rate, partial: "form") }
+    # end
+  end
+
+  describe "#update" do
+    let(:perform_request) do
+      put(polymorphic_path(tax_rate.location), as: as, params: {tax_rate: tax_rate_params}).tap do
+        tax_rate.reload
+      end
+    end
+
+    let(:tax_rate) { create(:marketplace_tax_rate, marketplace: marketplace, tax_rate: 15) }
+    let(:tax_rate_params) { {label: "Hey", tax_rate: 23} }
+
+    specify { expect { result }.to change(tax_rate, :label).to("Hey") }
+    specify { expect { result }.to change(tax_rate, :tax_rate).from(15).to(23) }
+    it { is_expected.to redirect_to(marketplace.location(child: :tax_rates)) }
+
+    context "when a turbo stream" do
+      let(:as) { :turbo_stream }
+
+      it { is_expected.to have_rendered_turbo_stream(:replace, tax_rate, Marketplace::TaxRateComponent.new(tax_rate: tax_rate.reload).render_in(controller.view_context)) }
+    end
+
+    context "when the tax rate cannot be updated" do
+      let(:tax_rate_params) { {tax_rate: 0} }
+
+      it { is_expected.to render_template(:edit) }
+
+      context "when a a turbo stream" do
+        let(:as) { :turbo_stream }
+
+        it { is_expected.to have_rendered_turbo_stream(:replace, tax_rate, partial: "form") }
+      end
+    end
+  end
+
+  describe "#destroy" do
+    let(:perform_request) do
+      delete polymorphic_path(tax_rate.location), as: as
+    end
+
+    let(:tax_rate) { create(:marketplace_tax_rate, marketplace: marketplace) }
+
+    specify do
+      expect { perform_request }.to(change { Marketplace::TaxRate.exists?(tax_rate.id) }.to(false))
     end
 
     it { is_expected.to redirect_to(marketplace.location(child: :tax_rates)) }
-    specify { expect { result }.to change { tax_rate.reload.label }.to("Hey") }
-    specify { expect { result }.to change { tax_rate.reload.tax_rate }.to(23) }
+
+    context "when a turbo_stream" do
+      let(:as) { :turbo_stream }
+
+      it { is_expected.to have_rendered_turbo_stream(:remove, tax_rate) }
+    end
   end
 end


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1137
- https://github.com/zinc-collective/convene/pull/1338

I don't know why the get actions and passing `as` do not play nicely together, but it is annoying as heck.