### PR TITLE
🧹`Marketplace`: Remove unused `TaxRate` partial!

### DIFF
--- a/app/furniture/marketplace/tax_rates/_tax_rate.html.erb
+++ b/app/furniture/marketplace/tax_rates/_tax_rate.html.erb
@@ -1,3 +1,0 @@
-<%= link_to tax_rate.location(:edit) do %>
-  <%= tax_rate.label %>: <%= number_to_percentage(tax_rate.tax_rate, precision: 2) %>
-<%- end %>

--- a/spec/support/turbo.rb
+++ b/spec/support/turbo.rb
@@ -25,6 +25,7 @@ module Spec
       def matches?(response)
         @response = response
         assert_turbo_stream(action: action, target: target) do
+          rendering[:allow_inferred_rendering] = false if action == :remove
           assert_dom_equal(turbo_stream.action(action, target, content, **rendering), response.body)
         end
       rescue Minitest::Assertion => e


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1137

This also makes our `have_rendered_turbo_stream` matcher play more nicely with `remove` actions.
Co-authored-by: Kelly Hong <KellyAH@users.noreply.github.com