### PR TITLE
🛠 `Neighborhood`: Adds strong_migrations gem 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ gem "friendly_id", "~> 5.5.0"
 gem "bcrypt", "~> 3.1.18"
 gem "lockbox", "1.2.0"
 gem "rotp", "~> 6.2"
+gem "strong_migrations", "~> 1.4"
 
 # Use postgresql for data persistence
 gem "pg", "~> 1.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -405,6 +405,8 @@ GEM
     stimulus-rails (1.2.1)
       railties (>= 6.0.0)
     stripe (8.5.0)
+    strong_migrations (1.4.4)
+      activerecord (>= 5.2)
     thor (1.2.1)
     tilt (2.1.0)
     timeout (0.3.2)
@@ -489,6 +491,7 @@ DEPENDENCIES
   standard (~> 1.26)
   stimulus-rails
   stripe
+  strong_migrations (~> 1.4)
   turbo-rails
   tzinfo-data (~> 1.2021)
   view_component (~> 2.82)

--- a/config/initializers/strong_migrations.rb
+++ b/config/initializers/strong_migrations.rb
@@ -1,0 +1,26 @@
+# Mark existing migrations as safe
+StrongMigrations.start_after = 20230413004439
+
+# Set timeouts for migrations
+# If you use PgBouncer in transaction mode, delete these lines and set timeouts on the database user
+StrongMigrations.lock_timeout = 10.seconds
+StrongMigrations.statement_timeout = 1.hour
+
+# Analyze tables after indexes are added
+# Outdated statistics can sometimes hurt performance
+StrongMigrations.auto_analyze = true
+
+# Set the version of the production database
+# so the right checks are run in development
+# StrongMigrations.target_version = 10
+
+# Add custom checks
+# StrongMigrations.add_check do |method, args|
+#   if method == :add_index && args[0].to_s == "users"
+#     stop! "No more indexes on the users table"
+#   end
+# end
+
+# Make some operations safe by default
+# See https://github.com/ankane/strong_migrations#safe-by-default
+# StrongMigrations.safe_by_default = true


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1177

This change is part of an effort to add guard rails for devs writing migrations and catch *unsafe* and *illegal* operations on the database.

NOTE: There are other types of "bad" migrations that will not be caught by this gem. For example, referencing an Active Record model to execute DML. For those cases we should consider other static analysis methods like rubocop.