### PR TITLE
🌸✨ `Marketplace`: Require confirmation before deleting `Product`s and `TaxRate`s

### DIFF
--- a/app/furniture/marketplace/products/_product.html.erb
+++ b/app/furniture/marketplace/products/_product.html.erb
@@ -19,6 +19,6 @@
 
   <footer class="mt-3 flex justify-between">
     <%= render Buttons::SecondaryComponent.new(label: "#{t('icons.edit')} #{t('edit.link_to')}",  title: t('marketplace.products.edit.link_to'), href: product.location(:edit), method: :get) %>
-    <%= render Buttons::SecondaryComponent.new(label: "#{t('icons.destroy')} #{t('destroy.link_to')}", title: t('marketplace.products.destroy.link_to', name: product.name), href: product.location, method: :delete) %>
+    <%= render Buttons::SecondaryComponent.new(label: "#{t('icons.destroy')} #{t('destroy.link_to')}", title: t('marketplace.products.destroy.link_to', name: product.name), href: product.location, method: :delete, confirm: t("destroy.confirm")) %>
   </footer>
 <%- end %>

--- a/app/furniture/marketplace/tax_rate_component.rb
+++ b/app/furniture/marketplace/tax_rate_component.rb
@@ -20,7 +20,8 @@ class Marketplace
         label: "#{t("icons.edit")} #{t("edit.link_to")}",
         title: t("marketplace.tax_rates.edit.link_to", name: tax_rate.label),
         href: tax_rate.location(:edit), turbo_stream: true,
-        method: :get)
+        method: :get
+      )
     end
 
     def edit_button?
@@ -35,7 +36,8 @@ class Marketplace
         title: t("marketplace.tax_rates.destroy.link_to", name: tax_rate.label),
         href: tax_rate.location, turbo_stream: true,
         method: :delete,
-        confirm: t("destroy.confirm"))
+        confirm: t("destroy.confirm")
+      )
     end
 
     def destroy_button?

--- a/app/furniture/marketplace/tax_rate_component.rb
+++ b/app/furniture/marketplace/tax_rate_component.rb
@@ -16,10 +16,11 @@ class Marketplace
     def edit_button
       return unless edit_button?
 
-      ButtonComponent.new label: "#{t("icons.edit")} #{t("edit.link_to")}",
+      Buttons::SecondaryComponent.new(
+        label: "#{t("icons.edit")} #{t("edit.link_to")}",
         title: t("marketplace.tax_rates.edit.link_to", name: tax_rate.label),
         href: tax_rate.location(:edit), turbo_stream: true,
-        method: :get
+        method: :get)
     end
 
     def edit_button?
@@ -29,10 +30,12 @@ class Marketplace
     def destroy_button
       return unless destroy_button?
 
-      ButtonComponent.new label: "#{t("icons.destroy")} #{t("destroy.link_to")}",
+      Buttons::SecondaryComponent.new(
+        label: "#{t("icons.destroy")} #{t("destroy.link_to")}",
         title: t("marketplace.tax_rates.destroy.link_to", name: tax_rate.label),
         href: tax_rate.location, turbo_stream: true,
-        method: :delete
+        method: :delete,
+        confirm: t("destroy.confirm"))
     end
 
     def destroy_button?


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1324

# problem
I noticed when deleting a `Marketplace::Product` or `Marketplace::TaxRate`, there was no "are you sure?" confirmation modal. This could lead to customer's accidentally deleting a product or tax rate.

# Changes
- add deletion confirmation modal to `Marketplace::Product`.
- add deletion confirmation modal to `Marketplace::TaxRate`.
- apply new button component to `Marketplace::TaxRate` edit and delete buttons.

**before**
<img width="1058" alt="Screenshot 2023-04-12 at 9 57 44 PM" src="https://user-images.githubusercontent.com/16140873/231657590-6c04934c-7116-45f5-8e71-aeb44f65a81d.png">


**after**
<img width="1004" alt="Screenshot 2023-04-12 at 9 49 52 PM" src="https://user-images.githubusercontent.com/16140873/231657603-4d6d7478-edb9-48f3-97fd-ae80d54387bb.png">


<img width="1035" alt="Screenshot 2023-04-12 at 9 49 40 PM" src="https://user-images.githubusercontent.com/16140873/231657182-bdc9be41-1782-4821-8875-7b1a1f887e7f.png">

<img width="1015" alt="Screenshot 2023-04-12 at 9 51 11 PM" src="https://user-images.githubusercontent.com/16140873/231657184-fdf2f837-91d4-45c8-9f50-e7468ea256a5.png">
