### PR TITLE
🧹`Components`: Pull `edit_button` up into `ApplicationComponent`

### DIFF
--- a/app/components/application_component.rb
+++ b/app/components/application_component.rb
@@ -36,4 +36,9 @@ class ApplicationComponent < ViewComponent::Base
   def current_person
     @current_person ||= helpers.current_person
   end
+
+  def edit_button(title:, href:, label: "#{t("icons.edit")} #{t("edit.link_to")}")
+    Buttons::SecondaryComponent.new label: label, title: title,
+      href: href, turbo_stream: true, method: :get
+  end
 end

--- a/app/furniture/marketplace/delivery_area_component.rb
+++ b/app/furniture/marketplace/delivery_area_component.rb
@@ -12,12 +12,8 @@ class Marketplace
     delegate :price, to: :delivery_area
 
     def edit_button
-      return unless edit_button?
-
-      Buttons::SecondaryComponent.new(label: "#{t("icons.edit")} #{t("edit.link_to")}",
-        title: t("marketplace.delivery_areas.edit.link_to", name: delivery_area.label),
-        href: delivery_area.location(:edit), turbo_stream: true,
-        method: :get)
+      super(title: t("marketplace.delivery_areas.edit.link_to", name: delivery_area.label),
+            href: delivery_area.location(:edit))
     end
 
     def edit_button?

--- a/app/furniture/marketplace/tax_rate_component.rb
+++ b/app/furniture/marketplace/tax_rate_component.rb
@@ -14,14 +14,8 @@ class Marketplace
     end
 
     def edit_button
-      return unless edit_button?
-
-      Buttons::SecondaryComponent.new(
-        label: "#{t("icons.edit")} #{t("edit.link_to")}",
-        title: t("marketplace.tax_rates.edit.link_to", name: tax_rate.label),
-        href: tax_rate.location(:edit), turbo_stream: true,
-        method: :get
-      )
+      super(title: t("marketplace.tax_rates.edit.link_to", name: tax_rate.label),
+            href: tax_rate.location(:edit))
     end
 
     def edit_button?


### PR DESCRIPTION
-  https://github.com/zinc-collective/convene/issues/1187

This gives us a little tiny factory method so it's easy to drop an `edit_button` into a page and have it look and feel very much like all our edit buttons.

I don't know that `ApplicationComponent` is the right target for pulling this up. Part of me wants a `ModelComponent` or something that inherits from `ApplicationComponent` and is used in cases where the component is for a particular `Model`, but I'm also available to wait on that until we start seeing more stuff that wants to be grouped into such a `Component`.