### PR TITLE
🥔🥗✨`Space`: have `Agreement`s for "Terms of Service" etc.

### DIFF
--- a/app/lib/space_routes.rb
+++ b/app/lib/space_routes.rb
@@ -1,5 +1,6 @@
 module SpaceRoutes
   def self.append_routes(router)
+    router.resource :agreements, only: %i[show]
     router.resource :authenticated_session, only: %i[new create update destroy show]
     router.resources :invitations, only: %i[create destroy index] do
       router.resource :rsvp, only: %i[show update]

--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -37,6 +37,8 @@ class Space < ApplicationRecord
   has_many :rooms, inverse_of: :space, dependent: :destroy_async
   has_many :furnitures, through: :rooms, inverse_of: :space
 
+  has_many :agreements, inverse_of: :space, dependent: :destroy
+
   belongs_to :entrance, class_name: "Room", optional: true
 
   # @see {Utility}

--- a/app/models/space/agreement.rb
+++ b/app/models/space/agreement.rb
@@ -1,0 +1,18 @@
+class Space
+  class Agreement < ApplicationRecord
+    self.table_name = "space_agreements"
+    extend FriendlyId
+    friendly_id :name, use: :slugged
+    validates :name, presence: true, uniqueness: {scope: :space_id}
+    validates :slug, uniqueness: {scope: :space_id}
+
+    belongs_to :space, inverse_of: :agreements
+
+    attribute :body, :string
+    validates :body, presence: true
+
+    def to_html
+      render_markdown(body)
+    end
+  end
+end

--- a/db/migrate/20230414040205_create_agreements.rb
+++ b/db/migrate/20230414040205_create_agreements.rb
@@ -1,0 +1,13 @@
+class CreateAgreements < ActiveRecord::Migration[7.0]
+  def change
+    create_table :space_agreements, id: :uuid do |t|
+      t.belongs_to :space, type: :uuid, foreign_key: true
+      t.string :name, null: false
+      t.string :slug, null: false
+      t.text :body, null: false
+      t.index [:space_id, :slug], unique: true
+      t.index [:space_id, :name], unique: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_08_033925) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_14_040205) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -224,6 +224,18 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_08_033925) do
     t.index ["space_id"], name: "index_rooms_on_space_id"
   end
 
+  create_table "space_agreements", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "space_id"
+    t.string "name", null: false
+    t.string "slug", null: false
+    t.text "body", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["space_id", "name"], name: "index_space_agreements_on_space_id_and_name", unique: true
+    t.index ["space_id", "slug"], name: "index_space_agreements_on_space_id_and_slug", unique: true
+    t.index ["space_id"], name: "index_space_agreements_on_space_id"
+  end
+
   create_table "spaces", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "client_id"
     t.string "name"
@@ -261,5 +273,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_08_033925) do
   add_foreign_key "marketplace_shoppers", "people"
   add_foreign_key "marketplace_tax_rates", "furnitures", column: "marketplace_id"
   add_foreign_key "memberships", "invitations"
+  add_foreign_key "space_agreements", "spaces"
   add_foreign_key "spaces", "rooms", column: "entrance_id"
 end

--- a/spec/factories/space/agreement.rb
+++ b/spec/factories/space/agreement.rb
@@ -1,5 +1,7 @@
 FactoryBot.define do
   factory :space_agreement, class: "Space::Agreement" do
+    space
+
     name { Faker::Cannabis.cannabinoid }
     body { "#{Faker::Emotion.adjective} #{Faker::Emotion.noun}" }
   end

--- a/spec/factories/space/agreement.rb
+++ b/spec/factories/space/agreement.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :space_agreement, class: "Space::Agreement" do
+    name { Faker::Cannabis.cannabinoid }
+    body { "#{Faker::Emotion.adjective} #{Faker::Emotion.noun}" }
+  end
+end

--- a/spec/models/space/agreement_spec.rb
+++ b/spec/models/space/agreement_spec.rb
@@ -9,4 +9,15 @@ RSpec.describe Space::Agreement do
   it { is_expected.to validate_presence_of :name }
   it { is_expected.to validate_uniqueness_of(:name).scoped_to(:space_id) }
   it { is_expected.to validate_uniqueness_of(:slug).scoped_to(:space_id) }
+
+  describe ".friendly" do
+    subject(:friendly) do
+      agreement_a
+      described_class.friendly
+    end
+
+    let(:agreement_a) { create(:space_agreement, name: "Agreement A") }
+
+    specify { expect(friendly.find("agreement-a")).to eql(agreement_a) }
+  end
 end

--- a/spec/models/space/agreement_spec.rb
+++ b/spec/models/space/agreement_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.describe Space::Agreement do
+  subject(:agreement) { build(:space_agreement) }
+
+  it { is_expected.to belong_to(:space).inverse_of(:agreements) }
+  it { is_expected.to validate_presence_of :body }
+
+  it { is_expected.to validate_presence_of :name }
+  it { is_expected.to validate_uniqueness_of(:name).scoped_to(:space_id) }
+  it { is_expected.to validate_uniqueness_of(:slug).scoped_to(:space_id) }
+end

--- a/spec/models/space_spec.rb
+++ b/spec/models/space_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe Space do
   it { is_expected.to have_many(:rooms) }
   it { is_expected.to have_many(:furnitures).through(:rooms).inverse_of(:space) }
 
+  it { is_expected.to have_many(:agreements).inverse_of(:space).dependent(:destroy) }
+
   it do
     expect(subject).to belong_to(:entrance).class_name("Room")
       .optional(true).dependent(false)


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1154

So, I don't really know what each Space's Terms of Service, Privacy Policy, or Content Policy will be.

I would love for us to offer a set of different terms of service tailored for different use-cases; but for now I think it's probably best to put the responsibility on the Space Members to make sure they have the appropriate agreements in place.

It's kind of a weird position to take, and not one I would advocate for if we had a space ~$30k to invest in legal, but we don't and I'm not sure if we have any capacity to do the work ourselves or find someone who can do it pro-bono.

So we have a very tiny `Agreement` Model which `Space`s can have many of, and maybe I'll even get to adding a `controller` with a `#show` action and finding a place in the UI to enumerate the `space#agreements`.