### PR TITLE
🧹 `Space`: `Invitation`s request spec lives where it should

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -40,7 +40,6 @@ RSpec/ExampleLength:
     - 'spec/models/room_spec.rb'
     - 'spec/policies/room_policy_spec.rb'
     - 'spec/requests/rsvps_controller_request_spec.rb'
-    - 'spec/requests/spaces/invitations_request_spec.rb'
     - 'spec/requests/spaces_controller_request_spec.rb'
     - 'spec/support/shared_examples/a_space_member_only_route.rb'
 
@@ -70,12 +69,6 @@ RSpec/NamedSubject:
     - 'spec/models/invitation_spec.rb'
     - 'spec/models/membership_spec.rb'
     - 'spec/models/space_spec.rb'
-
-# Offense count: 15
-# Configuration parameters: IgnoreNameless, IgnoreSymbolicNames.
-RSpec/VerifiedDoubles:
-  Exclude:
-    - 'spec/requests/spaces/invitations_request_spec.rb'
 
 # Offense count: 6
 # Configuration parameters: Database, Include.

--- a/spec/requests/invitations_controller_request_spec.rb
+++ b/spec/requests/invitations_controller_request_spec.rb
@@ -4,24 +4,27 @@ require "rails_helper"
 
 RSpec.describe InvitationsController do
   describe "#create" do
-    it "creates and sends an invitation for a space" do
-      mail = double(deliver_later: true)
+    let(:mail) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
+    let(:membership) { create(:membership) }
+    let(:space) { membership.space }
+    let(:member) { membership.member }
+    let(:invitation) {
+      space.invitations.find_by(name: "foobar",
+        email: "foobar@example.com")
+    }
+
+    before do
       allow(SpaceInvitationMailer).to receive(:space_invitation_email)
         .and_return(mail)
-
-      membership = create(:membership)
-      space = membership.space
-      member = membership.member
 
       sign_in(space, member)
 
       post space_invitations_path(space), params: {
         invitation: {name: "foobar", email: "foobar@example.com"}
       }
+    end
 
-      invitation = space.invitations.find_by(name: "foobar",
-        email: "foobar@example.com")
-
+    it "creates and sends an invitation for a space" do
       expect(invitation).to be_present
       expect(invitation.status).to eq("pending")
 

--- a/spec/requests/invitations_request_spec.rb
+++ b/spec/requests/invitations_request_spec.rb
@@ -2,8 +2,8 @@
 
 require "rails_helper"
 
-RSpec.describe "/spaces/:space_id/invitations" do # rubocop:disable RSpec/DescribeClass
-  describe "POST" do
+RSpec.describe InvitationsController do
+  describe "#create" do
     it "creates and sends an invitation for a space" do
       mail = double(deliver_later: true)
       allow(SpaceInvitationMailer).to receive(:space_invitation_email)
@@ -64,7 +64,7 @@ RSpec.describe "/spaces/:space_id/invitations" do # rubocop:disable RSpec/Descri
     end
   end
 
-  describe "DELETE /:invitation_id" do
+  describe "#destroy" do
     it "Revokes the Invitation" do
       membership = create(:membership)
       space = membership.space


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/117

I noticed a leftover from when I had been exploring organizing our request specs based upon path.

Now this aligns with the `rubocop-rspec` defaults! Wooo!!!


