### PR TITLE
🥔✨ `Agreements`: List `Agremeent`s  on `Space#edit`

### DIFF
--- a/app/views/spaces/edit.html.erb
+++ b/app/views/spaces/edit.html.erb
@@ -73,3 +73,17 @@
 
   <p><%= link_to t('utilities.new.link_to'), space.location(:new, child: :utility) %></p>
 </fieldset>
+
+<fieldset>
+  <header>
+    <h3><%= t('space.agreements.index.link_to') %></h3>
+    <p class="text-sm italic"><%= t('space.agreements.help_text') %></p>
+  </header>
+  <div>
+    <%- space.agreements.each do |agreement| %>
+      <span class="flex justify-between w-full rounded border p-2 my-2 border-t-0 border-l-0">
+          <span class="grow"><%= agreement.name %></span>
+      </span>
+    <%- end %>
+  <div>
+</fieldset>

--- a/config/locales/agreement/en.yml
+++ b/config/locales/agreement/en.yml
@@ -1,0 +1,6 @@
+en:
+  space:
+    agreements:
+      help_text: Such as Privacy Policies, Content Policies, Terms of Service, etc.
+      index:
+        link_to: "Agreements"


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1364

This doesn't link to the Agreements, but it gives me a hook to add in the `#new`, `#edit` and `#destroy` bits in further PRs.

## After
<img width="386" alt="Screenshot 2023-04-15 at 4 16 58 PM" src="https://user-images.githubusercontent.com/50284/232257896-99883c06-6708-4692-8ce0-56455fffe547.png">

<img width="1055" alt="Screenshot 2023-04-15 at 4 17 27 PM" src="https://user-images.githubusercontent.com/50284/232257907-893ff02d-55d4-4af6-8d0a-9a81415ba1e4.png">
