### PR TITLE
🥗🥔✨ `Marketplace`: add `order_by` and `delivery_window` to `DeliveryArea`

### DIFF
--- a/app/furniture/marketplace/delivery/windows/_window.html.erb
+++ b/app/furniture/marketplace/delivery/windows/_window.html.erb
@@ -1,5 +1,8 @@
+delivery
 <%- if window.time_like? %>
-  <%= l(window.value, format: :day_month_date_hour_minute) %>
+  at <%= l(window.value, format: :day_month_date_hour_minute) %>
+<%- elsif window.blank? %>
+  at your chosen time
 <%- else %>
-  <%= window.value %>
+  for <%= window.value %>
 <%- end %>

--- a/app/furniture/marketplace/delivery_area_component.html.erb
+++ b/app/furniture/marketplace/delivery_area_component.html.erb
@@ -4,12 +4,21 @@
     <%= label %>
   </header>
 
-  <div class="italic">
-    <%= price  %>
+  <div class="grow flex flex-col justify-between">
+    <div class="text-sm">
+      <%- if order_by.present? %>
+        Place orders by <%= order_by %> to ensure an on-time
+      <%- end %>
+      <%= render(delivery_window) %>
+    </div>
+
+    <div class="text-right mt-3 italic">
+      <%= price  %>
+    </div>
   </div>
 
-  <div class="flex flex-row justify-between">
+  <footer class="mt-3 flex flex-row justify-between">
     <%= render edit_button if edit_button? %>
     <%= render destroy_button if destroy_button?  %>
-  </div>
+  </footer>
 <%- end %>

--- a/app/furniture/marketplace/delivery_area_component.rb
+++ b/app/furniture/marketplace/delivery_area_component.rb
@@ -3,13 +3,21 @@ class Marketplace
     attr_accessor :delivery_area
     delegate :label, to: :delivery_area
 
-    def initialize(delivery_area:, data: {}, classes: "")
-      super(data: data, classes: classes)
+    def initialize(delivery_area:, **kwargs)
+      super(**kwargs)
 
       self.delivery_area = delivery_area
     end
 
-    delegate :price, to: :delivery_area
+    def price
+      helpers.humanized_money_with_symbol(delivery_area.price)
+    end
+
+    delegate :order_by, to: :delivery_area
+
+    def delivery_window
+      Delivery::Window.new(value: delivery_area.delivery_window)
+    end
 
     def edit_button
       super(title: t("marketplace.delivery_areas.edit.link_to", name: delivery_area.label),

--- a/app/furniture/marketplace/delivery_area_policy.rb
+++ b/app/furniture/marketplace/delivery_area_policy.rb
@@ -9,7 +9,7 @@ class Marketplace
     alias_method :update?, :create?
 
     def permitted_attributes(_)
-      [:label, :price]
+      [:label, :price, :order_by, :delivery_window]
     end
 
     class Scope < ApplicationScope

--- a/app/furniture/marketplace/delivery_areas/_form.html.erb
+++ b/app/furniture/marketplace/delivery_areas/_form.html.erb
@@ -1,6 +1,8 @@
 <%= form_with(model: delivery_area.location) do |delivery_area_form| %>
   <%= render "text_field", attribute: :label, form: delivery_area_form %>
   <%= render "money_field", attribute: :price, form: delivery_area_form, required: true, step: 0.01, min: 0 %>
+  <%= render "text_field", attribute: :order_by, form: delivery_area_form %>
+  <%= render "text_field", attribute: :delivery_window, form: delivery_area_form %>
 
   <%= delivery_area_form.submit %>
 <%- end %>

--- a/app/furniture/marketplace/delivery_areas_controller.rb
+++ b/app/furniture/marketplace/delivery_areas_controller.rb
@@ -20,7 +20,7 @@ class Marketplace
 
     def update
       if delivery_area.update(delivery_area_params)
-        redirect_to marketplace.location(child: :delivery_areas)
+        redirect_to marketplace.location(child: :delivery_areas), notice: t(".success", name: delivery_area.label)
       else
         render :edit
       end

--- a/app/furniture/marketplace/locales/en.yml
+++ b/app/furniture/marketplace/locales/en.yml
@@ -19,6 +19,8 @@ en:
         link_to: "Add Delivery Area"
       edit:
         link_to: "Edit Delivery Area '%{name}'"
+      update:
+        success: "Changed Delivery Area '%{name}'"
       destroy:
         link_to: "Remove Delivery Area '%{name}'"
     delivery_window:

--- a/db/migrate/20230416172045_add_order_by_and_delivery_window_to_marketplace_delivery_areas.rb
+++ b/db/migrate/20230416172045_add_order_by_and_delivery_window_to_marketplace_delivery_areas.rb
@@ -1,0 +1,10 @@
+class AddOrderByAndDeliveryWindowToMarketplaceDeliveryAreas < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      change_table :marketplace_delivery_areas, bulk: true do |t|
+        t.string :delivery_window, default: nil
+        t.string :order_by, default: nil
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_14_040205) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_16_172045) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -134,6 +134,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_14_040205) do
     t.string "price_currency", default: "USD", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "delivery_window"
+    t.string "order_by"
     t.index ["marketplace_id"], name: "index_marketplace_delivery_areas_on_marketplace_id"
   end
 

--- a/spec/factories/furniture/marketplace.rb
+++ b/spec/factories/furniture/marketplace.rb
@@ -132,6 +132,8 @@ FactoryBot.define do
   end
 
   factory :marketplace_delivery_area, class: "Marketplace::DeliveryArea" do
+    marketplace
+
     label { Faker::Address.city }
     price { Faker::Commerce.price }
   end

--- a/spec/furniture/marketplace/delivery_area_component_spec.rb
+++ b/spec/furniture/marketplace/delivery_area_component_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe Marketplace::DeliveryAreaComponent, type: :component do
+  subject(:output) { render_inline(component) }
+
+  let(:operator) { create(:person, operator: true) }
+
+  let(:component) { described_class.new(delivery_area: delivery_area, current_person: operator) }
+  let(:delivery_area) { create(:marketplace_delivery_area) }
+
+  it { is_expected.to have_content(delivery_area.label) }
+  it { is_expected.to have_content(controller.view_context.humanized_money_with_symbol(delivery_area.price)) }
+
+  it { is_expected.to have_selector("a[href='#{polymorphic_path(delivery_area.location)}'][data-turbo=true][data-turbo-stream=true][data-turbo-method=delete][data-method=delete][data-confirm='#{I18n.t("destroy.confirm")}']") }
+  it { is_expected.to have_selector("a[href='#{polymorphic_path(delivery_area.location(:edit))}'][data-turbo=true][data-turbo-method=get][data-turbo-stream=true]") }
+
+  context "when `#delivery_window` is empty" do
+    it { is_expected.to have_content "at your chosen time" }
+  end
+
+  context "when `#delivery_window`` is a string" do
+    let(:delivery_area) { create(:marketplace_delivery_area, delivery_window: "dinnertime same day") }
+
+    it { is_expected.to have_content "for #{delivery_area.delivery_window}" }
+  end
+
+  context "when #order_by is blank" do
+    it { is_expected.not_to have_content "Place orders by" }
+  end
+
+  context "when `#order_by` is set" do
+    let(:delivery_area) { create(:marketplace_delivery_area, order_by: "noon") }
+
+    it { is_expected.to have_content "by #{delivery_area.order_by}" }
+  end
+end


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1185

In order to support different timing for different `DeliveryArea`s, we've given them `delivery_window` and `order_by` fields.

These fields will be used to communicate on the `Cart#show` and `Order#show` screens what the timing expectations are for particular orders.

Example:

- Catering orders for Lions Dance Cafe can be placed any time and delivered anytime, but
- Dinner orders must be placed the same day by 3pm

### After
![Screenshot 2023-04-16 at 10 56 24 AM](https://user-images.githubusercontent.com/50284/232332194-f55236fa-2e61-4706-8dbb-5a2d801657a7.png)
![Screenshot 2023-04-16 at 10 56 15 AM](https://user-images.githubusercontent.com/50284/232332197-a25c6fd2-8495-4ebe-8ddf-e09a2154e590.png)
![Screenshot 2023-04-16 at 10 56 09 AM](https://user-images.githubusercontent.com/50284/232332199-0d20819d-7876-4425-88cc-372ddf3e1c81.png)
