### PR TITLE
🥗🥔✨ `Marketplace`: Show `DeliveryArea`'s `#order_by` and `#delivery_window`

### DIFF
--- a/app/furniture/marketplace/delivery/windows/_window.html.erb
+++ b/app/furniture/marketplace/delivery/windows/_window.html.erb
@@ -1,5 +1,8 @@
+delivery
 <%- if window.time_like? %>
-  <%= l(window.value, format: :day_month_date_hour_minute) %>
+  at <%= l(window.value, format: :day_month_date_hour_minute) %>
+<%- elsif window.blank? %>
+  at your chosen time
 <%- else %>
-  <%= window.value %>
+  for <%= window.value %>
 <%- end %>

--- a/app/furniture/marketplace/delivery_area_component.html.erb
+++ b/app/furniture/marketplace/delivery_area_component.html.erb
@@ -4,12 +4,21 @@
     <%= label %>
   </header>
 
-  <div class="italic">
-    <%= price  %>
+  <div class="grow flex flex-col justify-between">
+    <div class="text-sm">
+      <%- if order_by.present? %>
+        Place orders by <%= order_by %> to ensure an on-time
+      <%- end %>
+      <%= render(delivery_window) %>
+    </div>
+
+    <div class="text-right mt-3 italic">
+      <%= price  %>
+    </div>
   </div>
 
-  <div class="flex flex-row justify-between">
+  <footer class="mt-3 flex flex-row justify-between">
     <%= render edit_button if edit_button? %>
     <%= render destroy_button if destroy_button?  %>
-  </div>
+  </footer>
 <%- end %>

--- a/app/furniture/marketplace/delivery_area_component.rb
+++ b/app/furniture/marketplace/delivery_area_component.rb
@@ -3,13 +3,21 @@ class Marketplace
     attr_accessor :delivery_area
     delegate :label, to: :delivery_area
 
-    def initialize(delivery_area:, data: {}, classes: "")
-      super(data: data, classes: classes)
+    def initialize(delivery_area:, **kwargs)
+      super(**kwargs)
 
       self.delivery_area = delivery_area
     end
 
-    delegate :price, to: :delivery_area
+    def price
+      helpers.humanized_money_with_symbol(delivery_area.price)
+    end
+
+    delegate :order_by, to: :delivery_area
+
+    def delivery_window
+      Delivery::Window.new(value: delivery_area.delivery_window)
+    end
 
     def edit_button
       super(title: t("marketplace.delivery_areas.edit.link_to", name: delivery_area.label),

--- a/spec/factories/furniture/marketplace.rb
+++ b/spec/factories/furniture/marketplace.rb
@@ -132,6 +132,8 @@ FactoryBot.define do
   end
 
   factory :marketplace_delivery_area, class: "Marketplace::DeliveryArea" do
+    marketplace
+
     label { Faker::Address.city }
     price { Faker::Commerce.price }
   end

--- a/spec/furniture/marketplace/delivery_area_component_spec.rb
+++ b/spec/furniture/marketplace/delivery_area_component_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe Marketplace::DeliveryAreaComponent, type: :component do
+  subject(:output) { render_inline(component) }
+
+  let(:operator) { create(:person, operator: true) }
+
+  let(:component) { described_class.new(delivery_area: delivery_area, current_person: operator) }
+  let(:delivery_area) { create(:marketplace_delivery_area) }
+
+  it { is_expected.to have_content(delivery_area.label) }
+  it { is_expected.to have_content(controller.view_context.humanized_money_with_symbol(delivery_area.price)) }
+
+  it { is_expected.to have_selector("a[href='#{polymorphic_path(delivery_area.location)}'][data-turbo=true][data-turbo-stream=true][data-turbo-method=delete][data-method=delete][data-confirm='#{I18n.t("destroy.confirm")}']") }
+  it { is_expected.to have_selector("a[href='#{polymorphic_path(delivery_area.location(:edit))}'][data-turbo=true][data-turbo-method=get][data-turbo-stream=true]") }
+
+  context "when `#delivery_window` is empty" do
+    it { is_expected.to have_content "at your chosen time" }
+  end
+
+  context "when `#delivery_window`` is a string" do
+    let(:delivery_area) { create(:marketplace_delivery_area, delivery_window: "dinnertime same day") }
+
+    it { is_expected.to have_content "for #{delivery_area.delivery_window}" }
+  end
+
+  context "when #order_by is blank" do
+    it { is_expected.not_to have_content "Place orders by" }
+  end
+
+  context "when `#order_by` is set" do
+    let(:delivery_area) { create(:marketplace_delivery_area, order_by: "noon") }
+
+    it { is_expected.to have_content "by #{delivery_area.order_by}" }
+  end
+end


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1185

We added some tests to the `DeliveryAreaComponent` to make sure it looks reasonable in each use-case:

- `#delivery_window` with no data
- `#delivery window` with a string
- `#order_by` with no data
- `#order_by` with a string

We also included "by" in the `_window.html.erb` partial so that people don't have to write it in their `order_by`.