### PR TITLE
🥗🥔🧹✨ `Marketplace`: Test how we communicate `DeliveryExpectations`

### DIFF
--- a/app/furniture/marketplace/cart/delivery_expectations_component.html.erb
+++ b/app/furniture/marketplace/cart/delivery_expectations_component.html.erb
@@ -1,0 +1,10 @@
+<%- if cart.marketplace.order_by.present? && cart.marketplace.delivery_window.present? %>
+  Orders placed <%= cart.marketplace.order_by %>
+  are delivered <%= cart.marketplace.delivery_window %>
+<%- elsif cart.marketplace.order_by.blank? && cart.marketplace.delivery_window.present? %>
+  Orders are delivered <%= cart.marketplace.delivery_window %>
+<%- elsif cart.delivery_window.present? && cart.marketplace.order_by.present? %>
+  Place orders <%= cart.marketplace.order_by %> to ensure an on-time delivery for <%= render(cart.delivery_window) %>
+<%- elsif cart.delivery_window.present? %>
+  Delivering at <%= render(cart.delivery_window) %>
+<%- end %>

--- a/app/furniture/marketplace/cart/delivery_expectations_component.rb
+++ b/app/furniture/marketplace/cart/delivery_expectations_component.rb
@@ -1,0 +1,13 @@
+class Marketplace
+  class Cart
+    class DeliveryExpectationsComponent < ApplicationComponent
+      attr_accessor :cart
+
+      def initialize(cart:, **kwargs)
+        super(**kwargs)
+
+        self.cart = cart
+      end
+    end
+  end
+end

--- a/app/furniture/marketplace/carts/_cart.html.erb
+++ b/app/furniture/marketplace/carts/_cart.html.erb
@@ -25,11 +25,6 @@
   </div>
 
   <p class="text-right px-2 sm:px-4 py-2 text-sm">
-    <%- if cart.marketplace.delivery_window.present? %>
-      Orders placed by <%= cart.marketplace.order_by %>
-      are delivered on <%= cart.marketplace.delivery_window %>
-    <%- elsif cart.delivery_window.present? %>
-      Place orders <%= cart.marketplace.order_by %> to ensure an on-time delivery for <%= render(cart.delivery_window) %>
-    <%- end %>
+    <%= render(Marketplace::Cart::DeliveryExpectationsComponent.new(cart: cart)) %>
   </p>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,7 +39,7 @@ en:
   time:
     formats:
       day_month_date_year_hour_minute: "%A %B %d, %Y %l:%M%p"
-      day_month_date_hour_minute: "%A %B %d %l:%M%p"
+      day_month_date_hour_minute: "%A %B %d%l:%M%p"
   show:
     link_to: "%{name}"
   edit:

--- a/spec/furniture/marketplace/cart/delivery_expectations_component_spec.rb
+++ b/spec/furniture/marketplace/cart/delivery_expectations_component_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe Marketplace::Cart::DeliveryExpectationsComponent, type: :component do
+  subject(:output) { render_inline(component) }
+
+  let(:operator) { create(:person, operator: true) }
+
+  let(:component) { described_class.new(cart: cart, current_person: operator) }
+  let(:marketplace) { build(:marketplace) }
+
+  context "when the cart does not have a `delivery_area`" do
+    let(:cart) { build(:marketplace_cart, marketplace: marketplace, delivery_window: 1.hour.from_now) }
+
+    context "when the `marketplace` has an `order_by` without a `delivery_window`" do
+      let(:marketplace) { build(:marketplace, order_by: "by 8AM") }
+
+      it { is_expected.to have_content("to ensure an on-time delivery for #{I18n.l(1.hour.from_now, format: :day_month_date_hour_minute)}", normalize_ws: true) }
+    end
+
+    context "when the `marketplace` has a `delivery_window` without an `order_by`" do
+      let(:marketplace) { build(:marketplace, delivery_window: "at Noon") }
+
+      it { is_expected.to have_content("Orders are delivered at Noon", normalize_ws: true) }
+    end
+
+    context "when the `marketplace` has `delivery_window` and an `order_by`" do
+      let(:marketplace) { build(:marketplace, delivery_window: "at Noon", order_by: "by 8AM") }
+
+      it { is_expected.to have_content("Orders placed by 8AM are delivered at Noon", normalize_ws: true) }
+    end
+
+    context "when the `marketplace` has neither an `order_by` nor a `delivery_window`" do
+      let(:marketplace) { build(:marketplace) }
+
+      it {
+        expect(output).to have_content("Delivering at #{I18n.l(1.hour.from_now, format: :day_month_date_hour_minute)}",
+          normalize_ws: true)
+      }
+    end
+  end
+end


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1185

As we were beginning to implement how we communicate the different expectations based on delivery area, we noticed there were not many tests on the current behavior; and that chunk of behavior had many many many permutations that were meaningful.

So we took some time to pull out a `DeliveryExpectationsComponent` that can take care of handling those permutations, and start to test them.

There is some minor wording improvements included here, specifically because we noticed things didn't always make a ton of sense as we added those tests; so it *does* include a bit of behavior changes.