### PR TITLE
🥗🥔✨ `Agreements`: can be `created`!

### DIFF
--- a/app/controllers/space/agreements_controller.rb
+++ b/app/controllers/space/agreements_controller.rb
@@ -3,6 +3,10 @@ class Space
     def show
     end
 
+    def new
+      agreement
+    end
+
     def create
       agreement.save
 
@@ -16,8 +20,10 @@ class Space
     helper_method def agreement
       @agreement ||= if params[:id]
         policy_scope(space.agreements).friendly.find(params[:id])
-      else
+      elsif params[:agreement]
         space.agreements.new(agreement_params)
+      else
+        space.agreements.new
       end.tap { |agreement| authorize(agreement) }
     end
 

--- a/app/controllers/space/agreements_controller.rb
+++ b/app/controllers/space/agreements_controller.rb
@@ -1,11 +1,28 @@
 class Space
   class AgreementsController < ApplicationController
     def show
-      authorize(agreement)
+    end
+
+    def create
+      agreement.save
+
+      if agreement.errors.present?
+        render :new, status: :unprocessable_entity
+      else
+        redirect_to space.location(:edit), notice: t(".success", name: agreement.name)
+      end
     end
 
     helper_method def agreement
-      @agreement ||= policy_scope(space.agreements).friendly.find(params[:id])
+      @agreement ||= if params[:id]
+        policy_scope(space.agreements).friendly.find(params[:id])
+      else
+        space.agreements.new(agreement_params)
+      end.tap { |agreement| authorize(agreement) }
+    end
+
+    def agreement_params
+      policy(Agreement).permit(params.require(:agreement))
     end
 
     def space

--- a/app/lib/space_routes.rb
+++ b/app/lib/space_routes.rb
@@ -1,6 +1,6 @@
 module SpaceRoutes
   def self.append_routes(router)
-    router.resources :agreements, only: %i[show create], controller: "space/agreements"
+    router.resources :agreements, only: %i[show new create], controller: "space/agreements"
     router.resource :authenticated_session, only: %i[new create update destroy show]
     router.resources :invitations, only: %i[create destroy index] do
       router.resource :rsvp, only: %i[show update]

--- a/app/lib/space_routes.rb
+++ b/app/lib/space_routes.rb
@@ -1,6 +1,6 @@
 module SpaceRoutes
   def self.append_routes(router)
-    router.resources :agreements, only: %i[show], controller: "space/agreements"
+    router.resources :agreements, only: %i[show create], controller: "space/agreements"
     router.resource :authenticated_session, only: %i[new create update destroy show]
     router.resources :invitations, only: %i[create destroy index] do
       router.resource :rsvp, only: %i[show update]

--- a/app/policies/space/agreement_policy.rb
+++ b/app/policies/space/agreement_policy.rb
@@ -1,7 +1,17 @@
 class Space
   class AgreementPolicy < ApplicationPolicy
+    alias_method :agreement, :object
+
     def show?
       true
+    end
+
+    def create?
+      person&.operator? || person&.member_of?(agreement.space)
+    end
+
+    def permitted_attributes(_)
+      %i[name body]
     end
 
     class Scope < ::ApplicationScope

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,6 +43,7 @@
       <%- if current_space&.agreements&.present? %>
         <div class="text-xs mt-2 w-full flex flex-wrap justify-center">
           <%- current_space.agreements.each do |agreement| %>
+            <%- next unless agreement.persisted? %>
             <%= link_to(agreement.name, agreement.location, class: "px-4 py-2") %>
           <%- end %>
         </div>

--- a/app/views/space/agreements/new.html.erb
+++ b/app/views/space/agreements/new.html.erb
@@ -1,0 +1,8 @@
+<%- breadcrumb :new_space_agreement, agreement %>
+
+<%= form_with(model: agreement.location) do |agreement_form| %>
+  <%= render "text_field", attribute: :name,  form: agreement_form%>
+  <%= render "text_area", attribute: :body,  form: agreement_form%>
+
+  <%= agreement_form.submit %>
+<%- end %>

--- a/app/views/spaces/edit.html.erb
+++ b/app/views/spaces/edit.html.erb
@@ -76,7 +76,7 @@
   <p><%= link_to t('utilities.new.link_to'), space.location(:new, child: :utility) %></p>
 </fieldset>
 
-<fieldset>
+<%= render CardComponent.new do %>
   <header>
     <h3><%= t('space.agreements.index.link_to') %></h3>
     <p class="text-sm italic"><%= t('space.agreements.help_text') %></p>
@@ -88,4 +88,15 @@
       </span>
     <%- end %>
   <div>
-</fieldset>
+  <footer class="mt-4 text-center">
+    <%- new_agreement = space.agreements.build %>
+    <%- if policy(new_agreement).create? %>
+      <%= render ButtonComponent.new(
+        label: "#{t('space.agreements.new.link_to')} #{t('icons.new')}",
+        title: t('space.agreements.new.link_to'),
+        href: space.location(:new, child: :agreement),
+        method: :get,
+        scheme: :secondary) %>
+    <%- end %>
+  </footer>
+<%- end %>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -18,6 +18,11 @@ crumb :show_space_agreement do |agreement|
   link t("show.link_to", name: agreement.name)
 end
 
+crumb :new_space_agreement do |agreement|
+  parent :edit_space, agreement.space
+  link t("space.agreements.new.link_to")
+end
+
 crumb :memberships do |space|
   link "Members", [space, :memberships]
   if policy(space).edit?

--- a/config/locales/agreement/en.yml
+++ b/config/locales/agreement/en.yml
@@ -4,3 +4,5 @@ en:
       help_text: Such as Privacy Policies, Content Policies, Terms of Service, etc.
       index:
         link_to: "Agreements"
+      create:
+        success: "Added Agreement %{name}"

--- a/config/locales/agreement/en.yml
+++ b/config/locales/agreement/en.yml
@@ -4,5 +4,7 @@ en:
       help_text: Such as Privacy Policies, Content Policies, Terms of Service, etc.
       index:
         link_to: "Agreements"
+      new:
+        link_to: "Add Agreement"
       create:
         success: "Added Agreement %{name}"

--- a/spec/requests/space/agreements_controller_request_spec.rb
+++ b/spec/requests/space/agreements_controller_request_spec.rb
@@ -15,6 +15,27 @@ RSpec.describe Space::AgreementsController do
     it { is_expected.to render_template(:show) }
   end
 
+  describe "#new" do
+    subject(:perform_request) do
+      get polymorphic_path(space.location(:new, child: :agreement))
+      response
+    end
+
+    it { is_expected.to be_not_found }
+
+    context "when signed in as a member" do
+      before { sign_in(space, member) }
+
+      it { is_expected.to render_template(:new) }
+
+      specify do
+        perform_request
+        assert_select('input[type="text"][name="agreement[name]"]')
+        assert_select('textarea[name="agreement[body]"]')
+      end
+    end
+  end
+
   describe "#create" do
     subject(:perform_request) do
       post polymorphic_path(space.location(child: :agreements)), params: {agreement: agreement_params}

--- a/spec/requests/space/agreements_controller_request_spec.rb
+++ b/spec/requests/space/agreements_controller_request_spec.rb
@@ -1,15 +1,50 @@
 require "rails_helper"
 
 RSpec.describe Space::AgreementsController do
+  let(:space) { create(:space) }
+  let(:member) { create(:membership, space: space).member }
+
   describe "#show" do
     subject(:perform_request) do
       get polymorphic_path([space, agreement])
       response
     end
 
-    let(:space) { agreement.space }
-    let(:agreement) { create(:space_agreement) }
+    let(:agreement) { create(:space_agreement, space: space) }
 
     it { is_expected.to render_template(:show) }
+  end
+
+  describe "#create" do
+    subject(:perform_request) do
+      post polymorphic_path(space.location(child: :agreements)), params: {agreement: agreement_params}
+      response
+    end
+
+    let(:agreement_params) { attributes_for(:space_agreement) }
+
+    it { is_expected.to be_not_found }
+
+    context "when signed in as a member" do
+      before { sign_in(space, member) }
+
+      specify do
+        perform_request
+        expect(space.reload.agreements).to exist(name: agreement_params[:name], body: agreement_params[:body])
+      end
+
+      it { is_expected.to redirect_to(space.location(:edit)) }
+    end
+
+    context "when the agreement is invalid" do
+      before { sign_in(space, member) }
+
+      let(:agreement_params) { attributes_for(:space_agreement, name: nil) }
+
+      it { is_expected.to render_template(:new) }
+
+      it { is_expected.to be_unprocessable }
+      specify { expect { perform_request }.not_to change { space.agreements.reload.count } }
+    end
   end
 end


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1364

This is only for the classic HTML Request <=> Response Cycle. I realized I probably want to do the `#index` Routes before `#create`, or at least get started on the bits to expose adding an `Agreement` in the `Spaces#edit` page.