### PR TITLE
🥗🥔✨ `Agreement`: Expose path to `AgreementsController#new`

### DIFF
--- a/app/controllers/space/agreements_controller.rb
+++ b/app/controllers/space/agreements_controller.rb
@@ -3,6 +3,10 @@ class Space
     def show
     end
 
+    def new
+      agreement
+    end
+
     def create
       agreement.save
 
@@ -16,8 +20,10 @@ class Space
     helper_method def agreement
       @agreement ||= if params[:id]
         policy_scope(space.agreements).friendly.find(params[:id])
-      else
+      elsif params[:agreement]
         space.agreements.new(agreement_params)
+      else
+        space.agreements.new
       end.tap { |agreement| authorize(agreement) }
     end
 

--- a/app/lib/space_routes.rb
+++ b/app/lib/space_routes.rb
@@ -1,6 +1,6 @@
 module SpaceRoutes
   def self.append_routes(router)
-    router.resources :agreements, only: %i[show create], controller: "space/agreements"
+    router.resources :agreements, only: %i[show new create], controller: "space/agreements"
     router.resource :authenticated_session, only: %i[new create update destroy show]
     router.resources :invitations, only: %i[create destroy index] do
       router.resource :rsvp, only: %i[show update]

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,6 +43,7 @@
       <%- if current_space&.agreements&.present? %>
         <div class="text-xs mt-2 w-full flex flex-wrap justify-center">
           <%- current_space.agreements.each do |agreement| %>
+            <%- next unless agreement.persisted? %>
             <%= link_to(agreement.name, agreement.location, class: "px-4 py-2") %>
           <%- end %>
         </div>

--- a/app/views/space/agreements/new.html.erb
+++ b/app/views/space/agreements/new.html.erb
@@ -1,0 +1,8 @@
+<%- breadcrumb :new_space_agreement, agreement %>
+
+<%= form_with(model: agreement.location) do |agreement_form| %>
+  <%= render "text_field", attribute: :name,  form: agreement_form%>
+  <%= render "text_area", attribute: :body,  form: agreement_form%>
+
+  <%= agreement_form.submit %>
+<%- end %>

--- a/app/views/spaces/edit.html.erb
+++ b/app/views/spaces/edit.html.erb
@@ -76,7 +76,7 @@
   <p><%= link_to t('utilities.new.link_to'), space.location(:new, child: :utility) %></p>
 </fieldset>
 
-<fieldset>
+<%= render CardComponent.new do %>
   <header>
     <h3><%= t('space.agreements.index.link_to') %></h3>
     <p class="text-sm italic"><%= t('space.agreements.help_text') %></p>
@@ -88,4 +88,15 @@
       </span>
     <%- end %>
   <div>
-</fieldset>
+  <footer class="mt-4 text-center">
+    <%- new_agreement = space.agreements.build %>
+    <%- if policy(new_agreement).create? %>
+      <%= render ButtonComponent.new(
+        label: "#{t('space.agreements.new.link_to')} #{t('icons.new')}",
+        title: t('space.agreements.new.link_to'),
+        href: space.location(:new, child: :agreement),
+        method: :get,
+        scheme: :secondary) %>
+    <%- end %>
+  </footer>
+<%- end %>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -18,6 +18,11 @@ crumb :show_space_agreement do |agreement|
   link t("show.link_to", name: agreement.name)
 end
 
+crumb :new_space_agreement do |agreement|
+  parent :edit_space, agreement.space
+  link t("space.agreements.new.link_to")
+end
+
 crumb :memberships do |space|
   link "Members", [space, :memberships]
   if policy(space).edit?

--- a/config/locales/agreement/en.yml
+++ b/config/locales/agreement/en.yml
@@ -4,5 +4,7 @@ en:
       help_text: Such as Privacy Policies, Content Policies, Terms of Service, etc.
       index:
         link_to: "Agreements"
+      new:
+        link_to: "Add Agreement"
       create:
         success: "Added Agreement %{name}"

--- a/spec/requests/space/agreements_controller_request_spec.rb
+++ b/spec/requests/space/agreements_controller_request_spec.rb
@@ -15,6 +15,27 @@ RSpec.describe Space::AgreementsController do
     it { is_expected.to render_template(:show) }
   end
 
+  describe "#new" do
+    subject(:perform_request) do
+      get polymorphic_path(space.location(:new, child: :agreement))
+      response
+    end
+
+    it { is_expected.to be_not_found }
+
+    context "when signed in as a member" do
+      before { sign_in(space, member) }
+
+      it { is_expected.to render_template(:new) }
+
+      specify do
+        perform_request
+        assert_select('input[type="text"][name="agreement[name]"]')
+        assert_select('textarea[name="agreement[body]"]')
+      end
+    end
+  end
+
   describe "#create" do
     subject(:perform_request) do
       post polymorphic_path(space.location(child: :agreements)), params: {agreement: agreement_params}


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1364

This builds on the `Agreements#create` PR by exposing a UI for hitting that endpoint via a Browser.

Note: I updated the footer because `space.agreements.new` creates an un-persisted instance in the `space.agreements` collection.

<img width="383" alt="Screenshot 2023-04-16 at 1 07 22 PM" src="https://user-images.githubusercontent.com/50284/232339286-6b00afd0-4957-4853-81f9-ef65f90dafa9.png">
<img width="382" alt="Screenshot 2023-04-16 at 1 07 06 PM" src="https://user-images.githubusercontent.com/50284/232339287-6792f77e-3499-42d2-836e-5632ecd110e3.png">
<img width="374" alt="Screenshot 2023-04-16 at 1 06 56 PM" src="https://user-images.githubusercontent.com/50284/232339289-f908f140-49d1-40cc-857b-f9ded82ecdfa.png">
<img width="377" alt="Screenshot 2023-04-16 at 1 06 51 PM" src="https://user-images.githubusercontent.com/50284/232339290-37517536-8412-4929-b0ad-707e56c6f708.png">
