### PR TITLE
✨ `Marketplace`: ask for missing delivery details to proceed to checkout

### DIFF
--- a/app/furniture/marketplace/cart.rb
+++ b/app/furniture/marketplace/cart.rb
@@ -43,12 +43,8 @@ class Marketplace
       product_total + delivery_fee + tax_total
     end
 
-    def ready_for_shopping?
-      (delivery_address.present? && contact_phone_number.present? && delivery_window.present?)
-    end
-
     def ready_for_checkout?
-      ready_for_shopping? && cart_products.present? && cart_products.all?(&:valid?)
+      delivery.details_filled_in? && cart_products.present? && cart_products.all?(&:valid?)
     end
   end
 end

--- a/app/furniture/marketplace/cart/deliveries/_delivery.html.erb
+++ b/app/furniture/marketplace/cart/deliveries/_delivery.html.erb
@@ -1,14 +1,27 @@
 <div id="<%=dom_id(delivery) %>" class="flex flex-wrap items-center justify-between text-sm mt-1 sm:mt-2">
-  <span>
-    <span class="font-bold">Delivering to:</span>
-    <%= render(delivery.delivery_area) if delivery.delivery_area.present? %>
-  </span>
+    <span>
+      <% if delivery.details_filled_in? || delivery.delivery_area.present? %>
+        <span class="font-bold">Delivering to:</span>
+          <%= delivery.delivery_address if delivery.delivery_address.present? %>
+          <%= render(delivery.delivery_area) if delivery.delivery_area.present? %>
+      <% end %>
+    </span>
 
-  <%= render ButtonComponent.new(
-        label: t("marketplace.cart.deliveries.edit.link_to"),
+  <% if delivery.details_filled_in? %>
+    <%= render ButtonComponent.new(
+          label: t("marketplace.cart.deliveries.edit.link_to"),
+          href: delivery.location(:edit),
+          method: :get,
+          turbo_stream: true,
+          scheme: :secondary,
+        ) %>
+  <% else %>
+    <%= render ButtonComponent.new(
+        label: t("marketplace.cart.deliveries.edit.details_missing"),
         href: delivery.location(:edit),
         method: :get,
         turbo_stream: true,
-        scheme: :secondary,
+        scheme: :primary,
       ) %>
+  <% end %>
 </div>

--- a/app/furniture/marketplace/cart/deliveries/_form.html.erb
+++ b/app/furniture/marketplace/cart/deliveries/_form.html.erb
@@ -1,4 +1,7 @@
-<div id="<%= dom_id(delivery) %>">
+<%= render CardComponent.new(dom_id: dom_id(delivery), classes: "text-left") do %>
+  <h3>
+    <%= t("marketplace.cart.deliveries.edit.header") %>
+  </h3>
   <%= form_with model: delivery.location do |delivery_form| %>
     <%= render "text_field", attribute: :delivery_address, form: delivery_form %>
     <%= render "window_field", attribute: :delivery_window, form: delivery_form %>
@@ -7,4 +10,4 @@
     <%= render "text_field", attribute: :contact_phone_number, form: delivery_form %>
     <%= delivery_form.submit %>
   <%- end %>
-</div>
+<% end %>

--- a/app/furniture/marketplace/cart/deliveries_controller.rb
+++ b/app/furniture/marketplace/cart/deliveries_controller.rb
@@ -12,12 +12,22 @@ class Marketplace
         if delivery.errors.present?
           render turbo_stream: [turbo_stream.replace(delivery, partial: "form")]
         else
-          render turbo_stream: [turbo_stream.replace(delivery)]
+          # Replace the entire cart footer so that the "Checkout" button updates as well
+          render turbo_stream: [
+            turbo_stream.replace("cart-footer-#{cart.id}",
+              partial: "marketplace/carts/footer", locals: {cart: cart})
+          ]
         end
       end
 
       helper_method def delivery
-        @delivery ||= policy_scope(marketplace.carts).find(params[:cart_id]).delivery
+        @delivery ||= cart.delivery
+      end
+
+      private
+
+      def cart
+        @cart ||= policy_scope(marketplace.carts).find(params[:cart_id])
       end
 
       def delivery_params

--- a/app/furniture/marketplace/carts/_footer.html.erb
+++ b/app/furniture/marketplace/carts/_footer.html.erb
@@ -6,11 +6,16 @@
 
 <tfoot id="cart-footer-<%= cart.id%>" class="bg-gray-50">
   <tr>
-    <td class="text-left px-3 py-3.5 text-right" colspan="8">
+    <td class="px-3 py-3.5 text-right" colspan="8">
       <%= render "marketplace/carts/total", cart: cart %>
       <%- if cart.ready_for_checkout? %>
         <%= button_to("Checkout", cart.location(child: :checkout), data: { turbo: false }) %>
       <%- end %>
+    </td>
+  </tr>
+  <tr>
+    <td class="px-3 pb-3.5 text-right" colspan="8">
+      <%= render cart.delivery %>
     </td>
   </tr>
 </tfoot>

--- a/app/furniture/marketplace/delivery.rb
+++ b/app/furniture/marketplace/delivery.rb
@@ -18,5 +18,9 @@ class Marketplace
     def fee
       delivery_area&.price.presence || marketplace&.delivery_fee.presence
     end
+
+    def details_filled_in?
+      delivery_address.present? && contact_phone_number.present? && delivery_window.present?
+    end
   end
 end

--- a/app/furniture/marketplace/locales/en.yml
+++ b/app/furniture/marketplace/locales/en.yml
@@ -11,7 +11,9 @@ en:
     cart:
       deliveries:
         edit:
-          link_to: "Change Delivery Details"
+          header: "Delivery Details"
+          link_to: "Change delivery details"
+          details_missing: "Add delivery details to checkout"
     delivery_areas:
       index:
         link_to: "Delivery Areas"

--- a/app/furniture/marketplace/marketplaces/_marketplace.html.erb
+++ b/app/furniture/marketplace/marketplaces/_marketplace.html.erb
@@ -6,7 +6,6 @@ end %>
 
 <%- cart = marketplace.carts.create_with(contact_email: shopper.person&.email, delivery_window: marketplace.delivery_window).find_or_create_by(shopper: shopper, status: :pre_checkout) %>
 
-<%= render cart.delivery %>
 <%= render cart %>
 
 <div class="my-2 text-right">

--- a/spec/furniture/marketplace/cart/deliveries_controller_request_spec.rb
+++ b/spec/furniture/marketplace/cart/deliveries_controller_request_spec.rb
@@ -29,7 +29,12 @@ RSpec.describe Marketplace::Cart::DeliveriesController, type: :request do
     context "when a `Guest`" do
       let(:person) { nil }
 
-      it { is_expected.to have_rendered_turbo_stream(:replace, delivery) }
+      it "replaces the cart footer" do
+        perform_request
+        expect(response.parsed_body).to include(
+          "<turbo-stream action=\"replace\" target=\"cart-footer-#{cart.id}\""
+        )
+      end
 
       specify do
         expect { perform_request }
@@ -46,7 +51,12 @@ RSpec.describe Marketplace::Cart::DeliveriesController, type: :request do
 
       before { sign_in(space, person) }
 
-      it { is_expected.to have_rendered_turbo_stream(:replace, delivery) }
+      it "replaces the cart footer" do
+        perform_request
+        expect(response.parsed_body).to include(
+          "<turbo-stream action=\"replace\" target=\"cart-footer-#{cart.id}\""
+        )
+      end
 
       specify do
         expect { perform_request }


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1326

This can use a lot more UI / visual love, but at least it is a sketch of a slightly improved experience: when we are missing delivery details, instead of just hiding the "Checkout" button, show a primary button asking for the delivery details.

### With this change
https://user-images.githubusercontent.com/6729309/233237901-3c4f0bf9-1c56-417b-9be0-8c53686ac1a3.mp4

