### PR TITLE
`Components`: Isolate why Lookbook is sad sometimes

### DIFF
--- a/spec/components/previews/button_component_preview.rb
+++ b/spec/components/previews/button_component_preview.rb
@@ -1,10 +1,11 @@
 class ButtonComponentPreview < ViewComponent::Preview
-  def default
+  # @param classes
+  def default(classes: "font-bold bg-rose-500 text-white hover:text-red-50 p-5 no-underline")
     render(ButtonComponent.new(
       label: "I'm a basic button with custom classes",
       title: "gaaa!",
       href: "#",
-      classes: "font-bold bg-rose-500 text-white hover:text-red-50 p-5 no-underline"
+      classes: classes
     ))
   end
 

--- a/spec/components/previews/marketplace/product_component_preview.rb
+++ b/spec/components/previews/marketplace/product_component_preview.rb
@@ -2,8 +2,8 @@ class Marketplace
   class ProductComponentPreview < ViewComponent::Preview
     # @param name
     # @param price
-    def card(name: "Fancy Pants", price: 8.5)
-      render(ProductComponent.new(product: Product.new(name: name, price: price)))
+    def card(name: "Grampy Tamps", price: 8.5)
+      render(::Marketplace::ProductComponent.new(product: ::Marketplace::Product.new(name: name, price: price)))
     end
   end
 end

--- a/spec/components/previews/marketplace/tax_rate_component_preview.rb
+++ b/spec/components/previews/marketplace/tax_rate_component_preview.rb
@@ -3,7 +3,7 @@ class Marketplace
     # @param label
     # @param tax_rate
     def card(label: "Sales Tax", tax_rate: 8.5)
-      render(TaxRateComponent.new(tax_rate: TaxRate.new(label: label, tax_rate: tax_rate)))
+      render(::Marketplace::TaxRateComponent.new(tax_rate: ::Marketplace::TaxRate.new(label: label, tax_rate: tax_rate)))
     end
   end
 end


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1187

OK, so from what I can tell, it is related to nested constants. LookBook (or maybe ViewComponent?!) does not appear to follow the Zeitwerk-style constant auto-loading rules; and rather depends on it's own internal system for detecting changes to files and reloading the Ruby AST.

When you change a ComponentPreview that is not namespaced, it happily reloads and everything is great. When you change a ComponentPreview that *is* namespaced it throws a giant fit.

I have not yet created an isolated reproduction (Fresh Rails 7, Ruby 3.1, ViewComponent, etc) but I figured I would push up at least the changes I fiddled with to figure that out last Wednesday.