### PR TITLE
🧹 `Marketplace`: Rename `marketplace_cart#delivery_window` to `delivery_notes`

### DIFF
--- a/app/furniture/marketplace/cart.rb
+++ b/app/furniture/marketplace/cart.rb
@@ -17,7 +17,6 @@ class Marketplace
 
     # this feels like it is starting to want to be it's own model...
     has_encrypted :delivery_address
-    attribute :delivery_window, ::Marketplace::Delivery::WindowType.new
     has_encrypted :contact_phone_number
     has_encrypted :contact_email
     def contact_email
@@ -36,7 +35,7 @@ class Marketplace
     def delivery
       @delivery ||= becomes(Delivery)
     end
-    delegate :fee, to: :delivery, prefix: true
+    delegate :fee, :window, to: :delivery, prefix: true
 
     def tax_total
       cart_products.sum(0, &:tax_amount)

--- a/app/furniture/marketplace/cart/deliveries/_form.html.erb
+++ b/app/furniture/marketplace/cart/deliveries/_form.html.erb
@@ -4,7 +4,7 @@
   </h3>
   <%= form_with model: delivery.location do |delivery_form| %>
     <%= render "text_field", attribute: :delivery_address, form: delivery_form %>
-    <%= render "window_field", attribute: :delivery_window, form: delivery_form %>
+    <%= render "text_field", attribute: :delivery_notes, form: delivery_form %>
     <%= render "select", options: delivery.marketplace.delivery_areas.pluck(:label, :id), include_blank: true, attribute: :delivery_area_id, form: delivery_form %>
     <%= render "email_field", attribute: :contact_email, form: delivery_form %>
     <%= render "text_field", attribute: :contact_phone_number, form: delivery_form %>

--- a/app/furniture/marketplace/cart/delivery.rb
+++ b/app/furniture/marketplace/cart/delivery.rb
@@ -7,7 +7,6 @@ class Marketplace
       validates :contact_email, presence: true
       validates :contact_phone_number, presence: true
       validates :delivery_address, presence: true
-      validates :delivery_window, presence: true
 
       def cart
         @cart ||= becomes(Cart)

--- a/app/furniture/marketplace/cart/delivery_policy.rb
+++ b/app/furniture/marketplace/cart/delivery_policy.rb
@@ -5,7 +5,7 @@ class Marketplace
     class DeliveryPolicy < Policy
       alias_method :delivery, :object
       def permitted_attributes(_params = nil)
-        %i[delivery_address contact_email contact_phone_number delivery_window delivery_area_id]
+        %i[delivery_address contact_email contact_phone_number delivery_notes delivery_area_id]
       end
 
       class Scope < ApplicationScope

--- a/app/furniture/marketplace/delivery.rb
+++ b/app/furniture/marketplace/delivery.rb
@@ -7,20 +7,20 @@ class Marketplace
     belongs_to :delivery_area
 
     has_encrypted :delivery_address
-    attribute :delivery_window, WindowType.new
     has_encrypted :contact_phone_number
     has_encrypted :contact_email
 
-    def window
-      delivery_window
+    def delivery_window
+      delivery_area&.delivery_window
     end
+    alias_method :window, :delivery_window
 
     def fee
       delivery_area&.price.presence || marketplace&.delivery_fee.presence
     end
 
     def details_filled_in?
-      delivery_address.present? && contact_phone_number.present? && delivery_window.present?
+      delivery_address.present? && contact_phone_number.present? && delivery_area.present?
     end
   end
 end

--- a/app/furniture/marketplace/delivery_area.rb
+++ b/app/furniture/marketplace/delivery_area.rb
@@ -7,6 +7,7 @@ class Marketplace
     has_many :orders, inverse_of: :delivery_area
     has_many :deliveries, inverse_of: :delivery_area
 
+    attribute :delivery_window, ::Marketplace::Delivery::WindowType.new
     monetize :price_cents
   end
 end

--- a/app/furniture/marketplace/marketplaces/_marketplace.html.erb
+++ b/app/furniture/marketplace/marketplaces/_marketplace.html.erb
@@ -4,7 +4,7 @@
     Marketplace::Shopper.find_or_create_by(person: current_person)
 end %>
 
-<%- cart = marketplace.carts.create_with(contact_email: shopper.person&.email, delivery_window: marketplace.delivery_window).find_or_create_by(shopper: shopper, status: :pre_checkout) %>
+<%- cart = marketplace.carts.create_with(contact_email: shopper.person&.email).find_or_create_by(shopper: shopper, status: :pre_checkout) %>
 
 <%= render cart %>
 

--- a/app/furniture/marketplace/order.rb
+++ b/app/furniture/marketplace/order.rb
@@ -14,7 +14,6 @@ class Marketplace
     has_many :products, through: :ordered_products, inverse_of: :orders
 
     has_encrypted :delivery_address
-    attribute :delivery_window, ::Marketplace::Delivery::WindowType.new
     has_encrypted :contact_phone_number
     has_encrypted :contact_email
 
@@ -36,6 +35,7 @@ class Marketplace
     end
 
     delegate :delivery_fee, to: :marketplace
+    delegate :delivery_window, to: :delivery_area, allow_nil: true
 
     def marketplace_name
       marketplace.room.name

--- a/app/furniture/marketplace/order/email_receipt_component.html.erb
+++ b/app/furniture/marketplace/order/email_receipt_component.html.erb
@@ -48,10 +48,14 @@
 <tfoot>
 <tr><th colspan="3">Delivery Details</th></tr>
 <tr>
-  <td class="text-right">Delivery Schedule:</td>
-  <td><%= render(order.delivery_window) %></td>
+  <td class="text-right">Delivery Notes</td>
+  <td><%= order.delivery_notes %></td>
 </tr>
 <%- if order.delivery_area.present? %>
+  <tr>
+    <td class="text-right">Delivery Schedule:</td>
+    <td><%= render(order.delivery_area.delivery_window) %></td>
+  </tr>
   <tr>
     <td class="text-right">Delivering In:</td>
     <td><%= order.delivery_area.label %></td>

--- a/db/migrate/20230427003441_rename_marketplace_orders_delivery_window.rb
+++ b/db/migrate/20230427003441_rename_marketplace_orders_delivery_window.rb
@@ -1,0 +1,7 @@
+class RenameMarketplaceOrdersDeliveryWindow < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      rename_column :marketplace_orders, :delivery_window, :delivery_notes
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_16_172045) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_27_003441) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -149,7 +149,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_16_172045) do
     t.text "delivery_address_ciphertext"
     t.string "contact_phone_number_ciphertext"
     t.datetime "placed_at"
-    t.string "delivery_window"
+    t.string "delivery_notes"
     t.string "contact_email_ciphertext"
     t.uuid "delivery_area_id"
     t.index ["delivery_area_id"], name: "index_marketplace_orders_on_delivery_area_id"

--- a/spec/factories/furniture/marketplace.rb
+++ b/spec/factories/furniture/marketplace.rb
@@ -38,6 +38,13 @@ FactoryBot.define do
 
       delivery_areas { Array.new(delivery_area_quantity) { association(:marketplace_delivery_area, marketplace: instance) } }
     end
+
+    trait :full do
+      with_tax_rates
+      with_delivery_areas
+      with_delivery_fees
+      with_notify_emails
+    end
   end
 
   factory :marketplace_product, class: "Marketplace::Product" do
@@ -112,9 +119,9 @@ FactoryBot.define do
         product_count { (1..5).to_a.sample }
       end
 
-      marketplace { association(:marketplace, :with_tax_rates, :with_delivery_areas, :with_delivery_fees, :with_notify_emails) }
+      marketplace { association(:marketplace, :full) }
 
-      delivery_window { 1.hour.from_now }
+      delivery_notes { Faker::Movies::HitchhikersGuideToTheGalaxy.marvin_quote }
       delivery_area { marketplace.delivery_areas.sample }
       placed_at { 5.minutes.ago }
       delivery_address { Faker::Address.full_address }
@@ -155,7 +162,7 @@ FactoryBot.define do
     delivery_address { Faker::Address.full_address }
     contact_phone_number { Faker::PhoneNumber.phone_number }
     contact_email { Faker::Internet.safe_email }
-    delivery_window { Marketplace::Delivery::Window.new(value: Faker::Time.forward(days: 1, period: :evening).to_s) }
+    delivery_notes { Faker::Quote.famous_last_words }
     delivery_area { marketplace.delivery_areas.sample }
     delivery_area_id { delivery_area.id }
   end

--- a/spec/furniture/marketplace/cart/deliveries_controller_request_spec.rb
+++ b/spec/furniture/marketplace/cart/deliveries_controller_request_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Marketplace::Cart::DeliveriesController, type: :request do
         expect { perform_request }
           .to change(delivery, :contact_email).to(delivery_attributes[:contact_email])
           .and change(delivery, :contact_phone_number).to(delivery_attributes[:contact_phone_number])
-          .and change(delivery, :delivery_window).to(delivery_attributes[:delivery_window])
+          .and change(delivery, :delivery_window).to(Marketplace::Delivery::Window.new(delivery_attributes[:delivery_window]))
           .and change(delivery, :delivery_address).to(delivery_attributes[:delivery_address])
           .and change(delivery, :delivery_area_id).to(delivery_attributes[:delivery_area].id)
       end
@@ -62,7 +62,7 @@ RSpec.describe Marketplace::Cart::DeliveriesController, type: :request do
         expect { perform_request }
           .to change(delivery, :contact_email).to(delivery_attributes[:contact_email])
           .and change(delivery, :contact_phone_number).to(delivery_attributes[:contact_phone_number])
-          .and change(delivery, :delivery_window).to(delivery_attributes[:delivery_window])
+          .and change(delivery, :delivery_window).to(Marketplace::Delivery::Window.new(delivery_attributes[:delivery_window]))
           .and change(delivery, :delivery_address).to(delivery_attributes[:delivery_address])
           .and change(delivery, :delivery_area_id).to(delivery_attributes[:delivery_area].id)
       end

--- a/spec/furniture/marketplace/cart/delivery_expectations_component_spec.rb
+++ b/spec/furniture/marketplace/cart/delivery_expectations_component_spec.rb
@@ -9,12 +9,12 @@ RSpec.describe Marketplace::Cart::DeliveryExpectationsComponent, type: :componen
   let(:marketplace) { build(:marketplace) }
 
   context "when the cart does not have a `delivery_area`" do
-    let(:cart) { build(:marketplace_cart, marketplace: marketplace, delivery_window: 1.hour.from_now) }
+    let(:cart) { build(:marketplace_cart, marketplace: marketplace) }
 
     context "when the `marketplace` has an `order_by` without a `delivery_window`" do
       let(:marketplace) { build(:marketplace, order_by: "by 8AM") }
 
-      it { is_expected.to have_content("to ensure an on-time delivery for #{I18n.l(1.hour.from_now, format: :day_month_date_hour_minute)}", normalize_ws: true) }
+      it { is_expected.to have_content("Order by 8AM") }
     end
 
     context "when the `marketplace` has a `delivery_window` without an `order_by`" do
@@ -33,8 +33,7 @@ RSpec.describe Marketplace::Cart::DeliveryExpectationsComponent, type: :componen
       let(:marketplace) { build(:marketplace) }
 
       it {
-        expect(output).to have_content("Delivering at #{I18n.l(1.hour.from_now, format: :day_month_date_hour_minute)}",
-          normalize_ws: true)
+        expect(output).to have_content("Delivers at your chosen time")
       }
     end
   end

--- a/spec/furniture/marketplace/cart/delivery_policy_spec.rb
+++ b/spec/furniture/marketplace/cart/delivery_policy_spec.rb
@@ -13,6 +13,6 @@ RSpec.describe Marketplace::Cart::DeliveryPolicy, type: :policy do
     it { is_expected.to include(:contact_phone_number) }
     it { is_expected.to include(:contact_email) }
     it { is_expected.to include(:delivery_address) }
-    it { is_expected.to include(:delivery_window) }
+    it { is_expected.to include(:delivery_notes) }
   end
 end

--- a/spec/furniture/marketplace/cart/delivery_spec.rb
+++ b/spec/furniture/marketplace/cart/delivery_spec.rb
@@ -15,8 +15,4 @@ RSpec.describe Marketplace::Cart::Delivery, type: :model do
   describe "#delivery_address" do
     it { is_expected.to validate_presence_of(:delivery_address) }
   end
-
-  describe "#delivery_window" do
-    it { is_expected.to validate_presence_of(:delivery_window) }
-  end
 end

--- a/spec/furniture/marketplace/delivery_areas_controller_request_spec.rb
+++ b/spec/furniture/marketplace/delivery_areas_controller_request_spec.rb
@@ -64,7 +64,9 @@ RSpec.describe Marketplace::DeliveryAreasController, type: :request do
       expect { result }.to change(delivery_area, :label).to("Dog")
         .and(change(delivery_area, :price).to(Money.new(60_00)))
         .and(change(delivery_area, :order_by).to("3PM"))
-        .and(change(delivery_area, :delivery_window).to("6pm Same Day"))
+        .and(change(delivery_area, :delivery_window).to(
+          ::Marketplace::Delivery::Window.new(value: "6pm Same Day")
+        ))
     end
   end
 

--- a/spec/furniture/marketplace/delivery_spec.rb
+++ b/spec/furniture/marketplace/delivery_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Marketplace::Delivery, type: :model do
   subject(:delivery) { build(:marketplace_delivery, marketplace: marketplace, delivery_area: delivery_area) }
 
   let(:marketplace) { build(:marketplace) }
-  let(:delivery_area) { nil }
+  let(:delivery_area) { build(:marketplace_delivery_area, marketplace: marketplace) }
 
   it { is_expected.to belong_to(:marketplace) }
   it { is_expected.to belong_to(:shopper) }
@@ -20,6 +20,8 @@ RSpec.describe Marketplace::Delivery, type: :model do
     subject(:fee) { delivery.fee }
 
     context "when there is not a marketplace delivery fee or a delivery area delivery fee" do
+      let(:delivery_area) { build(:marketplace_delivery_area, price_cents: nil, marketplace: marketplace) }
+
       it { is_expected.to eq(0) }
     end
 
@@ -41,6 +43,6 @@ RSpec.describe Marketplace::Delivery, type: :model do
   describe "#window" do
     subject(:window) { delivery.window }
 
-    it { is_expected.to eql(delivery.delivery_window) }
+    it { is_expected.to eql(delivery.delivery_area.delivery_window) }
   end
 end

--- a/spec/furniture/marketplace/order/email_receipt_component_spec.rb
+++ b/spec/furniture/marketplace/order/email_receipt_component_spec.rb
@@ -4,16 +4,19 @@ RSpec.describe Marketplace::Order::EmailReceiptComponent, type: :component do
   subject(:content) { render_inline(component) }
 
   let(:component) { described_class.new(order) }
-  let(:order) { build(:marketplace_order, :full) }
+  let(:marketplace) { build(:marketplace, :full) }
+  let(:order) { build(:marketplace_order, :full, marketplace: marketplace) }
 
   context "when the order has a particular time to be delivered" do
-    let(:order) { build(:marketplace_order, delivery_window: 3.hours.from_now) }
+    let(:delivery_area) { build(:marketplace_delivery_area, marketplace: marketplace, delivery_window: 3.hours.from_now) }
+    let(:order) { build(:marketplace_order, delivery_area: delivery_area) }
 
     it { is_expected.to have_content(I18n.l(order.delivery_window.value, format: :day_month_date_hour_minute)) }
   end
 
   context "when the order has some words for when it is delivered" do
-    let(:order) { build(:marketplace_order, delivery_window: "3pm on Sunday") }
+    let(:delivery_area) { build(:marketplace_delivery_area, marketplace: marketplace, delivery_window: "3pm on Sunday") }
+    let(:order) { build(:marketplace_order, delivery_area: delivery_area) }
 
     it { is_expected.to have_content("3pm on Sunday") }
   end


### PR DESCRIPTION
* https://github.com/zinc-collective/convene/issues/1185

First step of several towards simplifying how we store and handle the "delivery window" on a Marketplace Order.

### Screenshots

#### Delivery details edit form
![image](https://user-images.githubusercontent.com/6729309/234742930-d48319ba-500f-4f61-a191-d230173812b9.png)

#### Order receipt email with notes

![image](https://user-images.githubusercontent.com/6729309/234743668-0c4621bd-9628-4eee-b175-5b11ac572e9b.png)

