### PR TITLE
✨ `Marketplace`: Don't show to `Shopper`s unless it's ready

### DIFF
--- a/app/furniture/marketplace/marketplace.rb
+++ b/app/furniture/marketplace/marketplace.rb
@@ -22,6 +22,10 @@ class Marketplace
       true
     end
 
+    def ready_for_shopping?
+      products.present? && stripe_api_key? && delivery_areas.present? && stripe_account_connected?
+    end
+
     # The Secret Stripe API key belonging to the owner of the Marketplace
     def stripe_api_key
       space.utilities.find_by!(utility_slug: :stripe).utility.api_token

--- a/app/furniture/marketplace/marketplaces/_marketplace.html.erb
+++ b/app/furniture/marketplace/marketplaces/_marketplace.html.erb
@@ -1,12 +1,14 @@
-<%- shopper = if current_person.is_a?(Guest)
-     Marketplace::Shopper.find_or_create_by(id: session[:guest_shopper_id] ||= SecureRandom.uuid)
-  else
-    Marketplace::Shopper.find_or_create_by(person: current_person)
-end %>
+<%- if marketplace.ready_for_shopping? %>
+  <%- shopper = if current_person.is_a?(Guest)
+      Marketplace::Shopper.find_or_create_by(id: session[:guest_shopper_id] ||= SecureRandom.uuid)
+    else
+      Marketplace::Shopper.find_or_create_by(person: current_person)
+  end %>
 
-<%- cart = marketplace.carts.create_with(contact_email: shopper.person&.email).find_or_create_by(shopper: shopper, status: :pre_checkout) %>
+  <%- cart = marketplace.carts.create_with(contact_email: shopper.person&.email).find_or_create_by(shopper: shopper, status: :pre_checkout) %>
 
-<%= render cart %>
+  <%= render cart %>
+<%- end %>
 
 <div class="my-2 text-right">
   <%- if policy(marketplace).edit? %>

--- a/spec/factories/furniture/marketplace.rb
+++ b/spec/factories/furniture/marketplace.rb
@@ -35,6 +35,20 @@ FactoryBot.define do
       delivery_areas { Array.new(delivery_area_quantity) { association(:marketplace_delivery_area, marketplace: instance) } }
     end
 
+    trait :with_products do
+      transient do
+        product_quantity { 1 }
+      end
+
+      products { Array.new(product_quantity) { association(:marketplace_product, marketplace: instance) } }
+    end
+
+    trait :with_stripe_account do
+      stripe_account { "act_#{SecureRandom.hex(8)}" }
+      stripe_webhook_endpoint { "http://act_#{stripe_account}.example.com/" }
+      stripe_webhook_endpoint_secret { "SECRET_#{SecureRandom.hex(8)}" }
+    end
+
     trait :full do
       with_tax_rates
       with_delivery_areas

--- a/spec/furniture/marketplace/marketplace_spec.rb
+++ b/spec/furniture/marketplace/marketplace_spec.rb
@@ -30,31 +30,31 @@ RSpec.describe Marketplace::Marketplace, type: :model do
   describe "#ready_for_shopping?" do
     subject(:ready_for_shopping?) { marketplace.ready_for_shopping? }
 
-    context "when there is a stripe utility, products, and delivery areas" do
+    context "when there is a stripe utility, product, delivery area, and stripe account" do
       let(:marketplace) { create(:marketplace, :with_stripe_utility, :with_products, :with_delivery_areas, :with_stripe_account) }
 
       it { is_expected.to be_truthy }
     end
 
-    context "when there is a stripe account, products and a delivery area but no stripe utility" do
+    context "when there is a stripe account, product, and delivery area but no stripe utility" do
       let(:marketplace) { create(:marketplace, :with_products, :with_delivery_areas, :with_stripe_account) }
 
       it { is_expected.to be_falsey }
     end
 
-    context "when there is a stripe uility, stripe account, and products but no delivery area" do
+    context "when there is a stripe utility, stripe account, and products but no delivery area" do
       let(:marketplace) { create(:marketplace, :with_stripe_utility, :with_products, :with_stripe_account) }
 
       it { is_expected.to be_falsey }
     end
 
-    context "when there is a stripe utility, stirpe account and delivery area but no products" do
+    context "when there is a stripe utility, stripe account, and delivery area but no products" do
       let(:marketplace) { create(:marketplace, :with_stripe_utility, :with_delivery_areas, :with_stripe_account) }
 
       it { is_expected.to be_falsey }
     end
 
-    context "when there is a stripe utility, delivery area, and products but no stripe account" do
+    context "when there is a stripe utility, delivery area, and product but no stripe account" do
       let(:marketplace) { create(:marketplace, :with_products, :with_stripe_utility, :with_delivery_areas) }
 
       it { is_expected.to be_falsey }

--- a/spec/furniture/marketplace/marketplace_spec.rb
+++ b/spec/furniture/marketplace/marketplace_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Marketplace::Marketplace, type: :model do
       it { is_expected.to be_falsey }
     end
 
-    context "when there is a stripe utility, stripe account, and products but no delivery area" do
+    context "when there is a stripe utility, stripe account, and product but no delivery area" do
       let(:marketplace) { create(:marketplace, :with_stripe_utility, :with_products, :with_stripe_account) }
 
       it { is_expected.to be_falsey }

--- a/spec/furniture/marketplace/marketplace_spec.rb
+++ b/spec/furniture/marketplace/marketplace_spec.rb
@@ -26,4 +26,38 @@ RSpec.describe Marketplace::Marketplace, type: :model do
     it { is_expected.not_to include(non_marketplace_furniture) }
     it { is_expected.to include(marketplace_furniture) }
   end
+
+  describe "#ready_for_shopping?" do
+    subject(:ready_for_shopping?) { marketplace.ready_for_shopping? }
+
+    context "when there is a stripe utility, products, and delivery areas" do
+      let(:marketplace) { create(:marketplace, :with_stripe_utility, :with_products, :with_delivery_areas, :with_stripe_account) }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "when there is a stripe account, products and a delivery area but no stripe utility" do
+      let(:marketplace) { create(:marketplace, :with_products, :with_delivery_areas, :with_stripe_account) }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context "when there is a stripe uility, stripe account, and products but no delivery area" do
+      let(:marketplace) { create(:marketplace, :with_stripe_utility, :with_products, :with_stripe_account) }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context "when there is a stripe utility, stirpe account and delivery area but no products" do
+      let(:marketplace) { create(:marketplace, :with_stripe_utility, :with_delivery_areas, :with_stripe_account) }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context "when there is a stripe utility, delivery area, and products but no stripe account" do
+      let(:marketplace) { create(:marketplace, :with_products, :with_stripe_utility, :with_delivery_areas) }
+
+      it { is_expected.to be_falsey }
+    end
+  end
 end


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/831

We could probably include better messaging, but for now `Marketplace`'s don't show up until they are configured enough to actually take orders.

## After

![Screenshot 2023-05-03 at 6 27 43 PM](https://user-images.githubusercontent.com/50284/236088201-1687856d-7fca-4292-92ec-aa8b8f57f416.png)
![Screenshot 2023-05-03 at 6 27 34 PM](https://user-images.githubusercontent.com/50284/236088205-d684a492-8bd9-4492-b75c-23effe00e152.png)
