### PR TITLE
🐞 `Marketplace`: Don't explode on `Checkout`

### DIFF
--- a/app/furniture/marketplace/cart.rb
+++ b/app/furniture/marketplace/cart.rb
@@ -40,7 +40,7 @@ class Marketplace
     delegate :fee, :window, to: :delivery, prefix: true
 
     def tax_total
-      cart_products.sum(0, &:tax_amount)
+      Money.new(cart_products.sum(0, &:tax_amount))
     end
 
     def price_total

--- a/app/furniture/marketplace/checkout.rb
+++ b/app/furniture/marketplace/checkout.rb
@@ -36,7 +36,7 @@ class Marketplace
         {
           price_data: {
             currency: "USD",
-            unit_amount: cart_product.product.price_cents,
+            unit_amount: cart_product.product.price.cents,
             product_data: {name: cart_product.product.name}
           },
           quantity: cart_product.quantity
@@ -49,7 +49,7 @@ class Marketplace
         {quantity: 1,
          price_data: {
            currency: "USD",
-           unit_amount: delivery_fee,
+           unit_amount: delivery_fee.cents,
            product_data: {name: "Delivery"}
          }}
       ]

--- a/app/furniture/marketplace/delivery.rb
+++ b/app/furniture/marketplace/delivery.rb
@@ -16,7 +16,7 @@ class Marketplace
     alias_method :window, :delivery_window
 
     def fee
-      delivery_area&.price.presence || 0
+      delivery_area&.price.presence || Money.new(0)
     end
 
     def details_filled_in?

--- a/spec/furniture/marketplace/checkout_spec.rb
+++ b/spec/furniture/marketplace/checkout_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe Marketplace::Checkout do
+  describe "#create_stripe_session" do
+    it "creates a line item for the delivery fee" do
+      allow(Stripe::Checkout::Session).to receive(:create)
+      delivery_area = create(:marketplace_delivery_area)
+      cart = build(:marketplace_cart, delivery_area: delivery_area, marketplace: delivery_area.marketplace)
+      checkout = described_class.new(cart: cart)
+
+      allow(cart.marketplace).to receive(:stripe_api_key).and_return("FAKE_KEY_1234")
+      checkout.create_stripe_session(success_url: "", cancel_url: "")
+
+      # @todo there is probably some way to actually use the `hash_including` and `array_including` matchers
+      # But I couldnt' figure that out as easily as... uhhh.. reaching deep into the internals of rspec to get the stub
+      # proxy.
+      arguments = RSpec::Mocks.space.proxy_for(Stripe::Checkout::Session).messages_arg_list[0][0]
+
+      expect(arguments[:line_items]).to include(quantity: 1,
+        price_data: {currency: "USD", unit_amount: cart.delivery_area.price.cents,
+                     product_data: {name: "Delivery"}})
+    end
+  end
+end


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1326
- https://github.com/zinc-collective/convene/issues/1324

This is wildly insufficient, but it gets us to the point where we're able to test that the way we're calling `Stripe::Checkout::Session.create` is at least *close* to what it's supposed to be called with.

It would be far better to get a `spec/furniture/marketplace/system` that actually hits Stripe...