### PR TITLE
`Marketplace`: Further limit display size of `Product` photos

### DIFF
--- a/app/furniture/marketplace/cart_products/_cart_product.html.erb
+++ b/app/furniture/marketplace/cart_products/_cart_product.html.erb
@@ -4,7 +4,7 @@
   <td class="w-full max-w-0 py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:w-auto sm:max-w-none sm:pl-6">
     <%- if product.photo.present? %>
       <figure>
-        <%= image_tag product.photo.variant(resize_to_limit: [550, 550]).processed.url, class: "rounded-lg"
+        <%= image_tag product.photo.variant(resize_to_limit: [150, 150]).processed.url, class: "rounded-lg"
  %>
         <figcaption class="text-center py-2">
           <%=product.name%>

--- a/app/furniture/marketplace/product_component.html.erb
+++ b/app/furniture/marketplace/product_component.html.erb
@@ -6,7 +6,7 @@
   <div class="grow flex flex-col justify-between">
     <% if product.photo.present? %>
       <div>
-        <%= image_tag product.photo %>
+        <%= image_tag product.photo.variant(resize_to_limit: [150, 150]) %>
       </div>
     <% end %>
     <div class="text-sm italic">

--- a/app/furniture/marketplace/products/_form.html.erb
+++ b/app/furniture/marketplace/products/_form.html.erb
@@ -6,7 +6,7 @@
     <%= render "collection_check_boxes", { attribute: :tax_rate_ids, collection: marketplace.tax_rates, value_method: :id, text_method: :label, form: f} %>
     <%- if product.photo.present? %>
       <div>
-        <%= image_tag product.photo, class: "rounded-lg" %>
+        <%= image_tag product.photo.variant(resize_to_limit: [150, 150]), class: "rounded-lg" %>
       </div>
     <%- end %>
     <%= render "file_field", { attribute: :photo, form: f} %>


### PR DESCRIPTION
* https://github.com/zinc-collective/convene/issues/1428


I feel like 500x500 can easily overwhelm the page, so I'm limiting the display size further. I picked this size based on some comparisons for other similar apps:

Yelp:
![image](https://github.com/zinc-collective/convene/assets/6729309/8dfb6b52-4444-499f-9a90-9b5ed5ba6a77)

Instacart:
![image](https://github.com/zinc-collective/convene/assets/6729309/be095158-3435-4f67-a548-60ba550938f9)

![image](https://github.com/zinc-collective/convene/assets/6729309/c035e282-4e12-4d35-93e7-da3a7bd9a6a5)


### Screentshots
#### Before

![image](https://github.com/zinc-collective/convene/assets/6729309/ca732da3-af07-49e7-995f-78bdf192de15)

![image](https://github.com/zinc-collective/convene/assets/6729309/32504fe7-3aed-4ca6-a3eb-4801b3ae6ecb)


![image](https://github.com/zinc-collective/convene/assets/6729309/0470dfe5-43f0-4fef-8f06-c03da26ea8ed)


#### After
![image](https://github.com/zinc-collective/convene/assets/6729309/2d4b3355-8631-4146-8bd5-8d09848b801c)

![image](https://github.com/zinc-collective/convene/assets/6729309/cf12626c-ab62-403d-a4e9-49c159797c51)

![image](https://github.com/zinc-collective/convene/assets/6729309/b1d3364e-05cb-40dd-9120-d37fc0399ada)

![image](https://github.com/zinc-collective/convene/assets/6729309/327509ec-e176-4136-8964-7fee59af5176)

![Uploading image.png…]()

