### PR TITLE
🌸 `Spaces`: Prevent Add `Agreement` button from overlapping

### DIFF
--- a/app/assets/stylesheets/base/typography.scss
+++ b/app/assets/stylesheets/base/typography.scss
@@ -33,7 +33,7 @@
     @apply mb-2;
 
     &:last-of-type {
-      @apply mb-0;
+      @apply mb-2;
     }
   }
 


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1364

Fix the "Add Agreement +" button overlapping agreement text on the `Spaces` edit page.

space.agreements.help_text on the `Spaces` `edit` page.

⚠️ **Warning**: This change could the layout of other elements on other pages that CSS &:last-of-type also applies too. But it's such a small change, it might not have a detrimental affect.

**Before**
![before](https://github.com/zinc-collective/convene/assets/16140873/5dda8735-0157-405f-856b-122b78ed85be)

**After**
![after](https://github.com/zinc-collective/convene/assets/16140873/b4a4a565-45e5-4bbb-90e8-e11bcc0dee09)