### PR TITLE
[#1472] Replace "Room" with "Section"

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,7 +29,7 @@
 
       <div>
         <%- if current_room && policy(current_room).edit? %>
-          <%= link_to t('icons.edit'), [:edit, current_space, current_room], class: 'no-underline', aria: { label: "Configure Room"} %>
+          <%= link_to t('icons.edit'), [:edit, current_space, current_room], class: 'no-underline', aria: { label: "Configure Section"} %>
         <%- end %>
         <%= link_to "Convene", root_url %>: Space to Work, Play, or Simply Be
       </div>

--- a/app/views/spaces/edit.html.erb
+++ b/app/views/spaces/edit.html.erb
@@ -10,7 +10,7 @@
 
 <fieldset>
   <header>
-    <h3>Rooms</h3>
+    <h3>Sections</h3>
   </header>
 
   <div>
@@ -27,7 +27,7 @@
 
   <footer>
     <%= link_to [:new, space, :room] do %>
-      <span class="icon --add" role="img" aria-label="Add"></span>Add New Room
+      <span class="icon --add" role="img" aria-label="Add"></span>Add New Section
     <% end %>
   </footer>
 </fieldset>

--- a/config/locales/room/en.yml
+++ b/config/locales/room/en.yml
@@ -3,16 +3,16 @@ en:
     no_furniture_notice: 'No furniture yet! Deck out your space and add some Furniture! 🛋️'
     place_furniture_heading: 'Add Furniture 🛋️'
     create:
-      success: You've created Room '%{room_name}' successfully! 🎉
+      success: You've created Section '%{room_name}' successfully! 🎉
     update:
-      success: You've updated Room '%{room_name}' successfully! 🎉
+      success: You've updated Section '%{room_name}' successfully! 🎉
     destroy:
-      success: You've removed Room '%{room_name}' successfully! 🎉
-      failure: We couldn't remove Room '%{room_name}'.
+      success: You've removed Section '%{room_name}' successfully! 🎉
+      failure: We couldn't remove Section '%{room_name}'.
     form:
-      destroy: "Remove Room 🗑️"
+      destroy: "Remove Section 🗑️"
   helpers:
     submit:
       room:
-        create: Add Room ➕
+        create: Add Section ➕
         edit: ⚙️ Configure '%{room_name}'


### PR DESCRIPTION
https://github.com/zinc-collective/convene/issues/1472

Replace "Room" with "Section" in customer facing UI.

**Rooms List Page**
![Rooms List Page](https://github.com/zinc-collective/convene/assets/16140873/af856146-e69f-4a0f-8210-165387a3ce79)

**create room form**
![create room form](https://github.com/zinc-collective/convene/assets/16140873/577366ac-7636-484d-b776-0eb4f09bb007)

**edit room form**
![edit room form](https://github.com/zinc-collective/convene/assets/16140873/f8e29e73-500c-4a86-b1ee-36c02a94fa19)

# Tests
Confirmed pages render on local with text changes.
Can create and edit a room/section.
🐛 cannot Delete a room/section

