### PR TITLE
Replace `Furniture` with `Gizmo`

### DIFF
--- a/app/views/rooms/edit.html.erb
+++ b/app/views/rooms/edit.html.erb
@@ -5,7 +5,7 @@
 <%= render partial: 'form', locals: { room: room } %>
 
 <section id="furnitures" class="overflow-hidden rounded-lg bg-white shadow p-3 mt-3">
-  <h2>Furniture</h2>
+  <h2>Gizmos</h2>
   <%= render room.furnitures.rank(:slot), editing: true %>
 </section>
 

--- a/config/locales/furniture/en.yml
+++ b/config/locales/furniture/en.yml
@@ -1,18 +1,18 @@
 en:
   furnitures:
     update:
-      success: Furniture '%{name}' successfully updated! 🎉
+      success: Gizmo '%{name}' successfully updated! 🎉
     create:
-      success: Furniture '%{name}' successfully placed! 🎉
+      success: Gizmo '%{name}' successfully placed! 🎉
     destroy:
-      success: Furniture '%{name}' successfully removed! 🎉
+      success: Gizmo '%{name}' successfully removed! 🎉
     form:
-      destroy: "Remove Furniture 🗑️"
+      destroy: "Remove Gizmo 🗑️"
     furniture:
       edit_title: "Configure %{name}"
       remove_title: "Remove %{name}"
-      confirm_destroy: "This Removes the Furniture and all its Data"
+      confirm_destroy: "This Removes the Gizmo and all its Data"
   helpers:
     submit:
       furniture:
-        create: Add Furniture ➕
+        create: Add Gizmo ➕

--- a/config/locales/room/en.yml
+++ b/config/locales/room/en.yml
@@ -1,7 +1,7 @@
 en:
   rooms:
-    no_furniture_notice: 'No furniture yet! Deck out your space and add some Furniture! 🛋️'
-    place_furniture_heading: 'Add Furniture 🛋️'
+    no_furniture_notice: 'No gizmos yet! Deck out your space and add some Gizmos! 🛋️'
+    place_furniture_heading: 'Add Gizmo 🛋️'
     create:
       success: You've created Room '%{room_name}' successfully! 🎉
     update:


### PR DESCRIPTION
https://github.com/zinc-collective/convene/issues/1472

Replace `Furniture` with `Gizmo` and `Gizmos` in customer facing UI.

**furniture list page**
![furniture list page](https://github.com/zinc-collective/convene/assets/16140873/c8534a8d-9bc9-4ab8-a8a1-c052b3d9ad4c)

**update message**
![update message](https://github.com/zinc-collective/convene/assets/16140873/64469590-e78b-4fb4-8938-4d8d63b71ad2)


**remove button**
![remove button](https://github.com/zinc-collective/convene/assets/16140873/67a1b023-d3e3-4226-aa21-4c2797d50a77)

**delete prompt modal**
![delete prompt modal](https://github.com/zinc-collective/convene/assets/16140873/20866bde-59fc-4970-ae95-ec44c25f5e3d)

# Tests
Confirmed pages render on local with text changes.
Can create, edit and delete Furniture.