### PR TITLE
`Invitation`: Update the spec to reflect the email subject change

### DIFF
--- a/features/lib/Invitation.js
+++ b/features/lib/Invitation.js
@@ -68,7 +68,7 @@ class Invitation {
   emails() {
     return this.emailServer().emailsWhere({
       to: this.emailAddress,
-      text: (text) => /You've been invited/.test(text),
+      text: (text) => /invited you to/.test(text),
     });
   }
   /**


### PR DESCRIPTION
We currently look for the RSVP Link in our system tests by matching against the subject line of the email. Which works! However, we don't do much with our system tests so it's easy to forget.