### PR TITLE
`Marketplace`: Don't need `TaxRate` onto Bazaar every deploy

### DIFF
--- a/lib/tasks/release.rake
+++ b/lib/tasks/release.rake
@@ -3,13 +3,6 @@
 namespace :release do
   desc "Ensures any post-release / pre-deploy behavior has occurred"
   task after_build: [:environment, "db:prepare"] do
-    Marketplace::TaxRate.all.find_each do |tax_rate|
-      if tax_rate.marketplace.blank?
-        Marketplace::ProductTaxRate.where(tax_rate: tax_rate).each(&:destroy!)
-        tax_rate.destroy!
-        next
-      end
-      tax_rate.update!(bazaar: tax_rate.marketplace.bazaar)
-    end
+    # Put code you want to execute after migrations but before release here
   end
 end


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1137

Since they're all attached and will be into the future we don't need to migrate
them on every deploy anymore.