### PR TITLE
🧹 `Marketplace`: `CartProduct`s know their location

### DIFF
--- a/app/furniture/marketplace/cart_product.rb
+++ b/app/furniture/marketplace/cart_product.rb
@@ -3,6 +3,7 @@
 class Marketplace
   class CartProduct < Record
     self.table_name = "marketplace_cart_products"
+    self.location_parent = :cart
 
     belongs_to :cart, inverse_of: :cart_products
     delegate :shopper, to: :cart

--- a/app/furniture/marketplace/cart_products/_cart_product.html.erb
+++ b/app/furniture/marketplace/cart_products/_cart_product.html.erb
@@ -33,14 +33,14 @@
       <%# TODO: Extract minus and plus buttons into components %>
       <%- minus_quantity = [cart_product.quantity - 1, 0].max %>
       <%- minus_method = minus_quantity.zero? ? :delete : :put %>
-      <%= render "buttons/minus", disabled: cart_product.quantity.zero?, method: minus_method, title: t('.remove'), disabled: cart_product.quantity.zero?, href: [cart.space, cart.room, cart.marketplace, cart, cart_product, { cart_product: { quantity: minus_quantity, product_id: product.id} }] %>
+      <%= render "buttons/minus", disabled: cart_product.quantity.zero?, method: minus_method, title: t('.remove'), disabled: cart_product.quantity.zero?, href: cart_product.location(query_params: { cart_product: { quantity: minus_quantity, product_id: product.id} }) %>
 
 
       <span class="py-2 px-2 my-1 text-lg"><%= cart_product.quantity %></span>
 
       <%- add_quantity = cart_product.quantity + 1 %>
       <%- add_method = add_quantity == 1 ? :post : :put %>
-      <%= render "buttons/plus", method: add_method, title: t('.add'), href: [cart.space, cart.room, cart.marketplace, cart, cart_product, { cart_product: {quantity: add_quantity, product_id: product.id} }] %>
+      <%= render "buttons/plus", method: add_method, title: t('.add'), href: cart_product.location(query_params: { cart_product: {quantity: add_quantity, product_id: product.id} }) %>
     </div>
   </td>
 </tr>

--- a/app/models/within_location.rb
+++ b/app/models/within_location.rb
@@ -19,7 +19,7 @@ module WithinLocation
     location_parent.location(*args, **kwargs)
   end
 
-  def location(action = :show, child: nil)
+  def location(action = :show, child: nil, query_params: nil)
     root = case action
     when :new, :edit
       if routed_as == :resource
@@ -30,7 +30,8 @@ module WithinLocation
     else
       parent_location + [self]
     end
-    (root + [child]).compact
+
+    (root + [child, query_params]).compact
   end
 
   module ClassMethods

--- a/spec/furniture/marketplace/cart_product_spec.rb
+++ b/spec/furniture/marketplace/cart_product_spec.rb
@@ -17,4 +17,18 @@ RSpec.describe Marketplace::CartProduct, type: :model do
       expect { cart.cart_products.first.update!(quantity: 17) }.to raise_error(ActiveRecord::RecordInvalid)
     end
   end
+
+  describe "#location" do
+    subject(:location) { cart_product.location }
+
+    let(:cart_product) { create(:marketplace_cart_product, marketplace: create(:marketplace)) }
+
+    it { is_expected.to eq(cart_product.cart.location(child: cart_product)) }
+
+    context "with query params" do
+      subject(:location) { cart_product.location(query_params: {cart_product: {quantity: 3, product_id: "a-fake-product-id"}}) }
+
+      it { is_expected.to end_with({cart_product: {quantity: 3, product_id: "a-fake-product-id"}}) }
+    end
+  end
 end


### PR DESCRIPTION
This isn't super-critical; but when fixing the bug with adding and removing items from the Cart I noticed that we were building the URLs manually

Now a `location` call can accept `query_params`, which will make using it with `button_to` and `link_to` a bit easier.