### PR TITLE
🥗 `Marketplace`: Quick spec for the `Marketplaces#show` endpoint

### DIFF
--- a/app/furniture/marketplace/marketplaces/show.html.erb
+++ b/app/furniture/marketplace/marketplaces/show.html.erb
@@ -1,2 +1,2 @@
 <%- breadcrumb :marketplace, marketplace %>
-<%= render Marketplace::Component.new(marketplace: marketplace) %>
+<%= render Marketplace::MarketplaceComponent.new(marketplace: marketplace) %>

--- a/spec/furniture/marketplace/marketplaces_controller_request_spec.rb
+++ b/spec/furniture/marketplace/marketplaces_controller_request_spec.rb
@@ -33,4 +33,13 @@ RSpec.describe Marketplace::MarketplacesController, type: :request do
       expect(marketplace.notify_emails).to eq(marketplace_attributes[:notify_emails])
     end
   end
+
+  describe "#show" do
+    it "does not show guests the edit button" do
+      get polymorphic_path(marketplace.location)
+
+      expect(response.body).not_to include(I18n.t("marketplace.marketplace.edit"))
+      expect(response).to be_ok
+    end
+  end
 end


### PR DESCRIPTION
- Pulled out of https://github.com/zinc-collective/convene/pull/1487
- https://github.com/zinc-collective/convene/issues/831

Missed a bit in my rename; so I added some tests to the endpoint to catch it
in the future.

