### PR TITLE
`Marketplace`: Assert the `CartProduct` shows the `Product::Photo`

### DIFF
--- a/spec/furniture/marketplace/cart_product_component_spec.rb
+++ b/spec/furniture/marketplace/cart_product_component_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Marketplace::CartProductComponent, type: :component do
   it { is_expected.to have_content(helpers.humanized_money_with_symbol(product.price)) }
   it { is_expected.to have_link(I18n.t("marketplace.cart_product_component.add")) }
   it { is_expected.to have_link(I18n.t("marketplace.cart_product_component.remove")) }
-  it { puts product.photo.filename; puts product.photo.variant(resize_to_limit: [150, 150]).processed.url; is_expected.to have_selector("img[src$='#{product.photo.filename}']") }
+  it { is_expected.to have_selector("img[src*='#{product.photo.filename}']") }
 
   context "when the product is not yet in the cart" do
     let(:cart_product) { build(:marketplace_cart_product, cart: cart, product: product, quantity: 0) }

--- a/spec/furniture/marketplace/cart_product_component_spec.rb
+++ b/spec/furniture/marketplace/cart_product_component_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Marketplace::CartProductComponent, type: :component do
   it { is_expected.to have_content(helpers.humanized_money_with_symbol(product.price)) }
   it { is_expected.to have_link(I18n.t("marketplace.cart_product_component.add")) }
   it { is_expected.to have_link(I18n.t("marketplace.cart_product_component.remove")) }
+  it { is_expected.to have_selector("img[src$='#{product.photo.filename}']") }
 
   context "when the product is not yet in the cart" do
     let(:cart_product) { build(:marketplace_cart_product, cart: cart, product: product, quantity: 0) }

--- a/spec/furniture/marketplace/cart_product_component_spec.rb
+++ b/spec/furniture/marketplace/cart_product_component_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Marketplace::CartProductComponent, type: :component do
   it { is_expected.to have_content(helpers.humanized_money_with_symbol(product.price)) }
   it { is_expected.to have_link(I18n.t("marketplace.cart_product_component.add")) }
   it { is_expected.to have_link(I18n.t("marketplace.cart_product_component.remove")) }
-  it { is_expected.to have_selector("img[src$='#{product.photo.filename}']") }
+  it { puts product.photo.filename; is_expected.to have_selector("img[src$='#{product.photo.filename}']") }
 
   context "when the product is not yet in the cart" do
     let(:cart_product) { build(:marketplace_cart_product, cart: cart, product: product, quantity: 0) }

--- a/spec/furniture/marketplace/cart_product_component_spec.rb
+++ b/spec/furniture/marketplace/cart_product_component_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Marketplace::CartProductComponent, type: :component do
   it { is_expected.to have_content(helpers.humanized_money_with_symbol(product.price)) }
   it { is_expected.to have_link(I18n.t("marketplace.cart_product_component.add")) }
   it { is_expected.to have_link(I18n.t("marketplace.cart_product_component.remove")) }
-  it { puts product.photo.filename; is_expected.to have_selector("img[src$='#{product.photo.filename}']") }
+  it { puts product.photo.filename; puts product.photo.variant(resize_to_limit: [150, 150]).processed.url; is_expected.to have_selector("img[src$='#{product.photo.filename}']") }
 
   context "when the product is not yet in the cart" do
     let(:cart_product) { build(:marketplace_cart_product, cart: cart, product: product, quantity: 0) }


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1430
- https://github.com/zinc-collective/convene/issues/1428

- Pulled from https://github.com/libvips/ruby-vips/blob/master/.github/workflows/test.yml

I'm not particularly pleased with this, but I didn't find a github action; and I'm not entirely sure why the test passes locally but not on CI.