### PR TITLE
Improve "Gizmos" section of the Section (aka `room`) configuration view

### DIFF
--- a/app/controllers/furnitures_controller.rb
+++ b/app/controllers/furnitures_controller.rb
@@ -7,8 +7,8 @@ class FurnituresController < ApplicationController
   end
 
   def create
-    respond_to do |format|
-      if furniture.save!
+    if furniture.save
+      respond_to do |format|
         format.html do
           redirect_to(
             [furniture.room.space, furniture.room],
@@ -17,6 +17,12 @@ class FurnituresController < ApplicationController
         end
         format.turbo_stream
       end
+    else
+      redirect_to(
+        [furniture.room.space, furniture.room],
+        alert: t(".failure", errors: furniture.errors.full_messages.join(", ")),
+        status: :unprocessable_entity
+      )
     end
   end
 

--- a/app/models/furniture.rb
+++ b/app/models/furniture.rb
@@ -22,6 +22,8 @@ class Furniture < ApplicationRecord
 
   delegate :attributes=, to: :furniture, prefix: true
 
+  validates :furniture_kind, presence: true
+
   def furniture
     @furniture ||= Furniture.from_placement(self)
   end

--- a/app/views/furnitures/_new.html.erb
+++ b/app/views/furnitures/_new.html.erb
@@ -1,10 +1,11 @@
 <div id="new_furniture">
   <h3><%= t('rooms.place_furniture_heading') %></h3>
-  <%= form_with model: furniture.location do | placement_form | %>
-    <%= placement_form.hidden_field :slot, value: furniture.room.furnitures.count %>
-    <%= placement_form.select :furniture_kind, Furniture.registry.keys.map { |k| [k.to_s.titleize, k] } %>
+  <%= form_with model: furniture.location do | form | %>
+    <%= form.hidden_field :slot, value: furniture.room.furnitures.count %>
+    <%= render "select", attribute: :furniture_kind, options: Furniture.registry.keys.map { |k| [k.to_s.titleize, k] },
+        form: form, prompt: "-- Pick a type of gizmo --", include_blank: false %>
     <footer>
-      <%= placement_form.submit %>
+      <%= form.submit %>
     </footer>
   <%- end %>
 </div>

--- a/app/views/furnitures/_new.html.erb
+++ b/app/views/furnitures/_new.html.erb
@@ -1,4 +1,4 @@
-<fieldset id="new_furniture">
+<div id="new_furniture">
   <h3><%= t('rooms.place_furniture_heading') %></h3>
   <%= form_with model: furniture.location do | placement_form | %>
     <%= placement_form.hidden_field :slot, value: furniture.room.furnitures.count %>
@@ -7,4 +7,4 @@
       <%= placement_form.submit %>
     </footer>
   <%- end %>
-</fieldset>
+</div>

--- a/app/views/rooms/edit.html.erb
+++ b/app/views/rooms/edit.html.erb
@@ -4,12 +4,19 @@
 
 <%= render partial: 'form', locals: { room: room } %>
 
-<section id="furnitures" class="overflow-hidden rounded-lg bg-white shadow p-3 mt-3">
+<%= render CardComponent.new(classes: "mt-3 gap-y-3") do %>
   <h2>Gizmos</h2>
-  <%= render room.furnitures.rank(:slot), editing: true %>
-</section>
 
-<%- new_furniture = room.furnitures.new %>
-<%- if policy(new_furniture).new? %>
-  <%= render "furnitures/new", furniture: new_furniture %>
-<%- end %>
+  <div id="furnitures">
+    <% if room.furnitures.present? %>
+      <%= render room.furnitures.rank(:slot), editing: true %>
+    <% else %>
+      <p class="text-gray-500"><%= t('rooms.no_furniture_notice') %></p>
+    <% end %>
+  </div>
+
+  <%- new_furniture = room.furnitures.new %>
+  <%- if policy(new_furniture).new? %>
+    <%= render "furnitures/new", furniture: new_furniture %>
+  <%- end %>
+<% end %>

--- a/config/locales/furniture/en.yml
+++ b/config/locales/furniture/en.yml
@@ -1,4 +1,8 @@
 en:
+  activerecord:
+    attributes:
+      furniture:
+        furniture_kind: Type of gizmo
   furnitures:
     update:
       success: Gizmo '%{name}' successfully updated! 🎉

--- a/config/locales/furniture/en.yml
+++ b/config/locales/furniture/en.yml
@@ -8,6 +8,7 @@ en:
       success: Gizmo '%{name}' successfully updated! 🎉
     create:
       success: Gizmo '%{name}' successfully placed! 🎉
+      failure: "Could not add gizmo: %{errors}"
     destroy:
       success: Gizmo '%{name}' successfully removed! 🎉
     form:

--- a/config/locales/room/en.yml
+++ b/config/locales/room/en.yml
@@ -1,7 +1,7 @@
 en:
   rooms:
-    no_furniture_notice: 'No gizmos yet! Deck out your space and add some Gizmos! 🛋️'
-    place_furniture_heading: 'Add Gizmo 🛋️'
+    no_furniture_notice: 'No gizmos yet. Deck out this section by adding some gizmos!'
+    place_furniture_heading: 'Add a new gizmo'
     create:
       success: You've created Section '%{room_name}' successfully! 🎉
     update:

--- a/spec/factories/furniture/journal.rb
+++ b/spec/factories/furniture/journal.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :journal, class: "Journal::Journal" do
     room
+    furniture_kind { :journal }
   end
 
   factory :journal_entry, class: "Journal::Entry" do


### PR DESCRIPTION
* https://github.com/zinc-collective/convene/issues/1155

This PR:
* unifies the Gizmos section into one card
* changes the dropdown to require people to select a furniture kind, so that they don't add things by accident
* enforces that a `furniture_kind` value is set, and shows the error in the UI if there is one

It would be nice to improve this further so that it is not possible to submit the "add new" form without a valid type selected.

### Before
![image](https://github.com/zinc-collective/convene/assets/6729309/9aa1e862-32fb-4cb7-a9db-6911689c1704)

### After 
![image](https://github.com/zinc-collective/convene/assets/6729309/c1580bd2-6fc3-4e55-b697-a7887da8ddc0)

#### Error message on failed "add gizmo" action
![image](https://github.com/zinc-collective/convene/assets/6729309/7f4b4ddf-2000-4932-b262-82f5ab9271f1)