### PR TITLE
🔨🐞 `Invitations`: are deliverable again since they come from a valid Email Address

### DIFF
--- a/app/mailers/space_invitation_mailer.rb
+++ b/app/mailers/space_invitation_mailer.rb
@@ -4,7 +4,7 @@ class SpaceInvitationMailer < ApplicationMailer
     @space = invitation.space
     mail(
       to: @invitation.email,
-      from: "#{@invitation.invitor_display_name} (via #{@space.name})",
+      from: "#{@invitation.invitor_display_name} (via #{@space.name}) #{ENV.fetch("EMAIL_DEFAULT_FROM")}",
       subject: "#{@invitation.invitor_display_name} invited you to #{@space.name}"
     )
   end

--- a/spec/mailers/space_invitation_mailer_spec.rb
+++ b/spec/mailers/space_invitation_mailer_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe SpaceInvitationMailer do
+  describe "#space_invitation_email" do
+    it "is from the support email" do
+      stub_const("ENV", {"EMAIL_DEFAULT_FROM" => "Convene Support <convene-support@example.com>"})
+      invitation = create(:invitation, invitor: create(:person, name: "Zee"), space: create(:space, name: "Hackertown"))
+      mail = described_class.space_invitation_email(invitation)
+
+      # @todo I couldn't figure out how to actually test that it had all the information in the from
+      # and I am giving up so I can get chocolate
+      expect(mail.from).to eq(["convene-support@example.com"])
+    end
+  end
+end


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1515

Turns out, when I had suggested we drop the Convene bits from the email I did not think about what that would mean from the email address perspective.

While I don't have a Github issue yet for Space's being able to send email from their domain; I think that would be a good thing for us to support at some point so our clients branding stays front and center and we stay in the background.

In the meantime, since it's coming from a convene domain, we should probably include the convene support name as well.

## After
<img width="1475" alt="Screenshot 2023-05-26 at 7 42 32 PM" src="https://github.com/zinc-collective/convene/assets/50284/760a2c6e-45ea-4b0b-86fb-775123759b2f">

## Before
<img width="1520" alt="Screenshot 2023-05-26 at 7 43 03 PM" src="https://github.com/zinc-collective/convene/assets/50284/e3ed5f43-eea9-44a9-8392-4f465dd60cf7">


