### PR TITLE
🥗🔨🐞 `Neighborhood`: Footer links to the Neighborhood URL

### DIFF
--- a/app/components/neighborhood/link_component.rb
+++ b/app/components/neighborhood/link_component.rb
@@ -1,0 +1,13 @@
+class Neighborhood::LinkComponent < ApplicationComponent
+  include ViewComponent::InlineTemplate
+
+  erb_template <<~ERB
+    <%= link_to name, url %>: <%= tagline %>
+  ERB
+
+  def neighborhood
+    @neighborhood ||= Neighborhood.new
+  end
+
+  delegate :name, :url, :tagline, to: :neighborhood
+end

--- a/app/models/neighborhood.rb
+++ b/app/models/neighborhood.rb
@@ -19,6 +19,18 @@ class Neighborhood
     Person.where(operator: true)
   end
 
+  def url
+    ENV.fetch("APP_ROOT_URL")
+  end
+
+  def name
+    ENV.fetch("NEIGHBORHOOD_NAME", "Convene")
+  end
+
+  def tagline
+    ENV.fetch("NEIGHBORHOOD_TAGLINE", "Space to Work, Play, or Simply Be")
+  end
+
   def email_configuration
     {
       address: ENV["SMTP_ADDRESS"],

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,7 +31,7 @@
         <%- if current_room && policy(current_room).edit? %>
           <%= link_to t('icons.edit'), [:edit, current_space, current_room], class: 'no-underline', aria: { label: "Configure Section"} %>
         <%- end %>
-        <%= link_to "Convene", root_url %>: Space to Work, Play, or Simply Be
+        <%= render Neighborhood::LinkComponent.new %>
       </div>
       <div>
         💾&nbsp;

--- a/spec/components/neighborhood/link_component_spec.rb
+++ b/spec/components/neighborhood/link_component_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Neighborhood::LinkComponent, type: :component do
+  subject(:output) { render_inline(component) }
+
+  let(:component) { described_class.new }
+
+  it { is_expected.to have_link("Convene", href: ENV.fetch("APP_ROOT_URL")) }
+  it { is_expected.to have_content("Space to Work, Play, or Simply Be") }
+
+  context "when an Operator has set custom values" do
+    before do
+      stub_const("ENV", "NEIGHBORHOOD_NAME" => "Parsley's Persimmons Cooperative", "NEIGHBORHOOD_TAGLINE" => "The Place for Persimmon People", "APP_ROOT_URL" => "https://parsleys-persimmons-coop.example.com")
+    end
+
+    it { is_expected.to have_link("Parsley's Persimmons Cooperative", href: "https://parsleys-persimmons-coop.example.com") }
+    it { is_expected.to have_content("The Place for Persimmon People") }
+  end
+end


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/892
- https://github.com/zinc-collective/convene/issues/74

I noticed that the `Convene` link in the footer was always to the current `root_url`, which will be the `Space` when visiting the `Space` via a `Domain`.

This shifts it to use the `APP_ROOT_URL`, and allows `Operator`s to configure the Neighborhood name and Tagline.