### PR TITLE
🧹 Eliminate `dependent: :destroy_async`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -37,7 +37,6 @@ RSpec/DescribeClass:
 RSpec/ExampleLength:
   Exclude:
     - 'spec/models/membership_spec.rb'
-    - 'spec/models/room_spec.rb'
     - 'spec/policies/room_policy_spec.rb'
     - 'spec/requests/rsvps_controller_request_spec.rb'
     - 'spec/requests/spaces_controller_request_spec.rb'
@@ -68,7 +67,6 @@ RSpec/NamedSubject:
     - 'spec/models/authentication_method_spec.rb'
     - 'spec/models/invitation_spec.rb'
     - 'spec/models/membership_spec.rb'
-    - 'spec/models/space_spec.rb'
 
 # Offense count: 6
 # Configuration parameters: Database, Include.
@@ -108,7 +106,6 @@ Rails/FilePath:
 Rails/HasManyOrHasOneDependent:
   Exclude:
     - 'app/models/invitation.rb'
-    - 'app/models/person.rb'
 
 # Offense count: 2
 Rails/I18nLocaleTexts:

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -5,17 +5,17 @@ class Person < ApplicationRecord
   validates :email, presence: true, uniqueness: {case_sensitive: false}
 
   # Ways for the person to sign in
-  has_many :authentication_methods, inverse_of: :person, dependent: :destroy_async
+  has_many :authentication_methods, inverse_of: :person, dependent: :destroy
 
   # Joins the person to the spaces they are part of
-  has_many :memberships, inverse_of: :member, foreign_key: :member_id, dependent: :destroy_async
-  has_many :active_memberships, -> { active }, class_name: :Membership, inverse_of: :member, foreign_key: :member_id
+  has_many :memberships, inverse_of: :member, foreign_key: :member_id, dependent: :destroy
+  has_many :active_memberships, -> { active }, class_name: :Membership, inverse_of: :member, foreign_key: :member_id, dependent: :destroy
 
   # The Spaces the Person is part of
   has_many :spaces, through: :active_memberships
   has_many :rooms, through: :spaces
 
-  has_many :invitations, inverse_of: :invitor, foreign_key: :invitor_id
+  has_many :invitations, inverse_of: :invitor, foreign_key: :invitor_id, dependent: :destroy
 
   def member_of?(space)
     spaces.include?(space)

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -34,7 +34,7 @@ class Room < ApplicationRecord
   }
   validates :publicity_level, presence: true
 
-  has_many :furnitures, dependent: :destroy_async, inverse_of: :room
+  has_many :furnitures, dependent: :destroy, inverse_of: :room
   accepts_nested_attributes_for :furnitures
 
   def full_slug

--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -25,16 +25,16 @@ class Space < ApplicationRecord
 
   # Joins People to spaces for permissioning and
   # other purposes
-  has_many :memberships, inverse_of: :space, dependent: :destroy_async
+  has_many :memberships, inverse_of: :space, dependent: :destroy
 
   # The People with permissions for the Space
   has_many :members, through: :memberships
 
   # Inviting new members
-  has_many :invitations, inverse_of: :space, dependent: :destroy_async
+  has_many :invitations, inverse_of: :space, dependent: :destroy
 
   # The Rooms within this Space
-  has_many :rooms, inverse_of: :space, dependent: :destroy_async
+  has_many :rooms, inverse_of: :space, dependent: :destroy
   has_many :furnitures, through: :rooms, inverse_of: :space
 
   has_many :agreements, inverse_of: :space, dependent: :destroy
@@ -43,7 +43,7 @@ class Space < ApplicationRecord
 
   # @see {Utility}
   # @returns {ActiveRecord::Relation<Utilities>}
-  has_many :utilities, dependent: :destroy_async
+  has_many :utilities, inverse_of: :space, dependent: :destroy
 
   def parent_location
     []

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -4,8 +4,9 @@ require "rails_helper"
 
 RSpec.describe Person do
   it { is_expected.to have_many(:invitations).inverse_of(:invitor).with_foreign_key(:invitor_id) }
-  it { is_expected.to have_many(:authentication_methods).inverse_of(:person).dependent(:destroy_async) }
-  it { is_expected.to have_many(:memberships).inverse_of(:member).dependent(:destroy_async) }
+  it { is_expected.to have_many(:authentication_methods).inverse_of(:person).dependent(:destroy) }
+  it { is_expected.to have_many(:memberships).inverse_of(:member).dependent(:destroy) }
+  it { is_expected.to have_many(:active_memberships).inverse_of(:member).dependent(:destroy) }
 
   describe "#display_name" do
     it "is blank when `name` and `email` are blank" do

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Room do
   let(:space) { Space.new }
 
-  it { is_expected.to have_many(:furnitures).inverse_of(:room) }
+  it { is_expected.to have_many(:furnitures).inverse_of(:room).dependent(:destroy) }
   it { is_expected.to belong_to(:space).inverse_of(:rooms) }
 
   describe ".slug" do

--- a/spec/models/space_spec.rb
+++ b/spec/models/space_spec.rb
@@ -3,17 +3,21 @@
 require "rails_helper"
 
 RSpec.describe Space do
-  it { is_expected.to have_many(:rooms) }
+  subject(:space) { described_class.new }
+
+  it { is_expected.to have_many(:rooms).dependent(:destroy) }
   it { is_expected.to have_many(:furnitures).through(:rooms).inverse_of(:space) }
+  it { is_expected.to have_many(:utilities).inverse_of(:space).dependent(:destroy) }
 
   it { is_expected.to have_many(:agreements).inverse_of(:space).dependent(:destroy) }
 
   it do
-    expect(subject).to belong_to(:entrance).class_name("Room")
+    expect(space).to belong_to(:entrance).class_name("Room")
       .optional(true).dependent(false)
   end
 
-  it { is_expected.to have_many(:invitations).inverse_of(:space) }
+  it { is_expected.to have_many(:memberships).inverse_of(:space).dependent(:destroy) }
+  it { is_expected.to have_many(:invitations).inverse_of(:space).dependent(:destroy) }
 
   describe "#name" do
     it { is_expected.to validate_presence_of(:name) }


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1536
- https://zinc-collective.sentry.io/issues/4200863641/?project=6052513&referrer=github_integration

`destroy_async` and foreign keys don't play particularly well together, it appears.

This should make it so if we can't destroy a particular `Space`, `Room`, `Person`, etc. it will at least tell us sooner rather than later.

I took the time to bundle in some linter fixes with the files I changed to prevent the error from re-occuring.