### PR TITLE
🛠️ `Neighborhood`: Raise exceptions on email delivery errors

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,5 +1,7 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: ENV.fetch("EMAIL_DEFAULT_FROM", "from@example.com")
+  DEFAULT_FROM = ENV.fetch("EMAIL_DEFAULT_FROM", "convene-support@example.com")
+
+  default from: DEFAULT_FROM
   prepend_view_path "app/furniture"
 
   layout "mailer"

--- a/app/mailers/space_invitation_mailer.rb
+++ b/app/mailers/space_invitation_mailer.rb
@@ -4,7 +4,7 @@ class SpaceInvitationMailer < ApplicationMailer
     @space = invitation.space
     mail(
       to: @invitation.email,
-      from: "#{@invitation.invitor_display_name} (via #{@space.name}) #{ENV.fetch("EMAIL_DEFAULT_FROM")}",
+      from: "#{@invitation.invitor_display_name} (via #{@space.name}) #{DEFAULT_FROM}",
       subject: "#{@invitation.invitor_display_name} invited you to #{@space.name}"
     )
   end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -66,7 +66,7 @@ Rails.application.configure do
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/spec/mailers/space_invitation_mailer_spec.rb
+++ b/spec/mailers/space_invitation_mailer_spec.rb
@@ -7,9 +7,8 @@ RSpec.describe SpaceInvitationMailer do
       invitation = create(:invitation, invitor: create(:person, name: "Zee"), space: create(:space, name: "Hackertown"))
       mail = described_class.space_invitation_email(invitation)
 
-      # @todo I couldn't figure out how to actually test that it had all the information in the from
-      # and I am giving up so I can get chocolate
       expect(mail.from).to eq(["convene-support@example.com"])
+      expect(mail.header[:from].value).to include("Zee (via Hackertown)")
     end
   end
 end

--- a/spec/mailers/space_invitation_mailer_spec.rb
+++ b/spec/mailers/space_invitation_mailer_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe SpaceInvitationMailer do
   describe "#space_invitation_email" do
     it "is from the support email" do
-      stub_const("ENV", {"EMAIL_DEFAULT_FROM" => "Convene Support <convene-support@example.com>"})
+      stub_const("ApplicationMailer::DEFAULT_FROM", "Convene Support <convene-support@example.com>")
       invitation = create(:invitation, invitor: create(:person, name: "Zee"), space: create(:space, name: "Hackertown"))
       mail = described_class.space_invitation_email(invitation)
 


### PR DESCRIPTION
* https://github.com/zinc-collective/convene/issues/1518

Also tightened up an email spec and unified reading the `EMAIL_DEFAULT_FROM` env varialbe to one location.

I am not 100% certain of the behavior of `raise_delivery_errors`, but if it gets noisy (e.g. if it ends up throwing exceptions for all undeliverable addresses), we can refine this by adding a `rescue_from` to `ApplicationMailer` to report to Sentry only the errors that we can do something about.