### PR TITLE
docs: add note about renames of Room and Furniture

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,7 @@ Stakeholders for `Convene` fall into one or more of the following categories:
 - [`Operators`], who steward the [`Neighborhood`: Infrastructure], [`Neighborhood`: Trust & Safety], and [`Client`: Support] responsibilities
 - [`Contributors`] and [`Maintainers`], who design and build [`Furniture`].
 
+Note: `Furniture` has been renamed to `Gizmo/Gizmos`.
 
 ### 1.3 Specific Dependencies
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ with _Furniture_ to meet their collective digital needs. For example:
 - A Farmer's Market could provide professionally designed websites and social media presences for their vendors.
 - A Co-operative Startup Incubator could keep capitalization tables, Patronage Records and other logistical records.
 
+Note: `Furniture` has been renamed to `Gizmo/Gizmos`.
+
 You can see more in the [Zinc neighborhood](https://convene.zinc.coop).
 
 We have two milestones we are working towards:

--- a/features/boops.feature
+++ b/features/boops.feature
@@ -1,4 +1,7 @@
 Feature: Boops
+
+  Note: `Furniture` has been renamed to `Gizmo/Gizmos`.
+
   In order to equitably invoice for the costs incurred in providing co-owned digital infrastucture
   Operators want a way to account for costs of interactions/behaviors/etc.
 

--- a/features/furniture.feature
+++ b/features/furniture.feature
@@ -1,3 +1,5 @@
+# Note: `Furniture` has been renamed to `Gizmo/Gizmos`.
+
 Feature: Furniture
   In order to customize Rooms to fit their purpose,
   I would like to place Furniture in the Room.

--- a/features/furniture/spotlight.feature.md
+++ b/features/furniture/spotlight.feature.md
@@ -1,5 +1,9 @@
 # Furniture: Spotlight!
 
+Note: `Room/Rooms` has been renamed to `Section/Sections`.
+
+Note: `Furniture` has been renamed to `Gizmo/Gizmos`.
+
 Instagram and Signal have Stories, eCommerce sites have "Featured Items", Product Landing Pages have
 "Highlighted Value Propositions." Each of these "Spotlight" something on the Web, and bring it to the
 front of a Visitors attention.

--- a/features/membership-and-ownership.feature
+++ b/features/membership-and-ownership.feature
@@ -1,3 +1,6 @@
+# Note: `Room/Rooms` has been renamed to `Section/Sections`.
+# Note: `Furniture` has been renamed to `Gizmo/Gizmos`.
+
 Feature: Membership and Ownership
   In order to build a cohesive, multi-occupant Space
   I want to grant People Membership in my Space
@@ -15,6 +18,8 @@ Feature: Membership and Ownership
 
   Furniture may also expose different Features based upon Membership. For example,
   Members may be able to include Images in Chat, while Guests may not.
+
+  Note: `Furniture` has been renamed to `Gizmo/Gizmos`.
 
   @unstarted
   Scenario: Removing a Member

--- a/features/navigate-between-convene-and-other-systems.feature
+++ b/features/navigate-between-convene-and-other-systems.feature
@@ -1,3 +1,5 @@
+# Note: `Room/Rooms` has been renamed to `Section/Sections`.
+
 Feature: Navigate Between Convene and other Systems
   In order to build confidence that Convene plays well with others
   We want to hold the affordances people use to switch between Convene and other systems with a degree of care and intentionality.

--- a/features/rooms.feature
+++ b/features/rooms.feature
@@ -1,6 +1,8 @@
 Feature: Rooms
   # Rooms organize the information and functionality of a Space.
 
+  # Note: `Room/Rooms` has been renamed to `Section/Sections`.
+
   # Adding a Room is done through the Space Edit page
   @built @unimplemented-steps @andromeda
   Scenario: Adding a Room

--- a/features/support/parameter-types/README.md
+++ b/features/support/parameter-types/README.md
@@ -27,6 +27,10 @@ The core nouns in Convene are:
    purposes.
 4. [Furniture] for human/computer interaction within a space.
 
+Note: `Room/Rooms` has been renamed to `Section/Sections`.
+
+Note: `Furniture` has been renamed to `Gizmo/Gizmos`.
+
 [actors]: ./actors.js
 [rooms]: ./rooms.js
 [spaces]: ./spaces.js

--- a/features/utilities.feature
+++ b/features/utilities.feature
@@ -1,4 +1,7 @@
 Feature: Utilities
+
+# Note: `Furniture` has been renamed to `Gizmo/Gizmos`.
+
 # Utilities connect a Space to the broader Internet, and allow Furniture
 # within the Space to leverage other Services or Websites. A Space connects
 # to Utilities via a Utility; which can be used by Furniture or


### PR DESCRIPTION
Change Ana [reccomended](https://github.com/zinc-collective/convene/issues/1472#issuecomment-1595647326) for [discussion](https://github.com/zinc-collective/convene/issues/1472#issuecomment-1595616304)  

- add note at the top of each doc mentioning that `Furniture` has been renamed to `Gizmo`
-  add note at the top mentioning that `Room` has been renamed to `Section`

<img width="670" alt="Screenshot 2023-06-18 at 8 01 26 AM" src="https://github.com/zinc-collective/convene/assets/16140873/1e964790-7700-4010-89b2-bb9e2d2dbb03">
<img width="711" alt="Screenshot 2023-06-18 at 8 02 11 AM" src="https://github.com/zinc-collective/convene/assets/16140873/be356830-a608-4cc1-b0eb-e28426c8a4d6">
<img width="784" alt="Screenshot 2023-06-18 at 8 04 23 AM" src="https://github.com/zinc-collective/convene/assets/16140873/3cc37c09-e9cb-4aba-8125-22e681adfb9e">
<img width="792" alt="Screenshot 2023-06-18 at 8 05 40 AM" src="https://github.com/zinc-collective/convene/assets/16140873/1e5747de-b419-4556-9e31-33d1fa63e279">


