### PR TITLE
✨ Space config displays help text

### DIFF
--- a/app/views/spaces/edit.html.erb
+++ b/app/views/spaces/edit.html.erb
@@ -1,5 +1,32 @@
 <% breadcrumb :edit_space, space %>
 
+<% if space.entrance_id.blank? || space.rooms.blank? || space.members.blank? %>
+  <%= render AlertComponent.new(scheme: :warning, icon: :exclamation_triangle,
+    title: t('spaces.edit.config_missing_title')) do %>
+    <%= t('spaces.edit.config_missing_explainer_html' ) %>
+
+    <ul>
+      <% if space.rooms.blank? %>
+        <li>
+          <%= t('spaces.edit.config_missing_sections_text_html' ) %>
+        </li>
+      <% end %>
+
+      <% if space.entrance_id.blank? %>
+        <li>
+          <%= t('spaces.edit.config_missing_entrance_text_html' ) %>
+        </li>
+      <% end %>
+
+      <% if space.members.blank? %>
+        <li>
+          <%= t('spaces.edit.config_missing_members_text_html' ) %>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+<% end %>
+
 <%= render "people", space: space %>
 <%= render "sections", space: space %>
 <%= render "utilities", space: space %>

--- a/config/locales/space/en.yml
+++ b/config/locales/space/en.yml
@@ -1,5 +1,15 @@
 en:
   spaces:
+    edit:
+      config_missing_title: Space configuration missing 🛠️
+      config_missing_explainer_html: |
+        Don't forget to finish setting up this Space!
+      config_missing_entrance_text_html: |
+        Select a Section in the Entrance field below, to set a Section as the Space's Entrance.
+      config_missing_sections_text_html: |
+        Click the 'Add New Section' link below to add at least one Section to this Space.
+      config_missing_members_text_html: |
+        Click the 'Invitations' link below to invite people to the join this Space.
     update:
       success: Space successfully updated 🎉
       error: Something went wrong with the update 💔


### PR DESCRIPTION
- For https://github.com/zinc-collective/convene/issues/1585

# Changes
- Add help text to the Space config page when a Space is missing sections, an entrance and memberships.

<img width="1530" alt="Screenshot 2023-06-21 at 6 44 21 PM" src="https://github.com/zinc-collective/convene/assets/16140873/831aa993-4168-47cc-9390-cafb8e7c8e95">
