### PR TITLE
🥗 `Gizmo`: System Spec to Add and Remove Gizmo

### DIFF
--- a/app/assets/stylesheets/components/button.scss
+++ b/app/assets/stylesheets/components/button.scss
@@ -1,10 +1,11 @@
+/* @todo DELETE ME */
 @layer components {
   [type="reset"],
   [type="button"],
   [type="submit"],
   button,
   .button {
-    @apply font-bold py-2 px-4 my-1 rounded bg-primary-500 text-white text-center transition ease-in-out duration-150;
+    @apply font-bold py-2 px-4 rounded bg-primary-500 text-white text-center transition ease-in-out duration-150;
 
     &:hover {
       @apply bg-primary-700;

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -36,6 +36,7 @@ class Room < ApplicationRecord
 
   has_many :furnitures, dependent: :destroy, inverse_of: :room
   accepts_nested_attributes_for :furnitures
+  alias_method :gizmos, :furnitures
 
   def full_slug
     "#{space.slug}--#{slug}"

--- a/app/views/furnitures/_form.html.erb
+++ b/app/views/furnitures/_form.html.erb
@@ -1,14 +1,17 @@
 <section id="<%= dom_id(furniture) %>">
   <%- if policy(furniture).edit? %>
-    <%= form_with(model: [furniture.room.space, furniture.room, furniture], local: true) do |form| %>
+    <%= form_with(model: [furniture.room.space, furniture.room, furniture]) do |form| %>
       <div>
         <%= render partial: furniture.furniture.form_template, locals: { form: form } %>
       </div>
       <footer>
         <%- if policy(furniture).destroy? %>
-          <%= form.button name: "_method", value: "delete", class: "--danger" do %>
-            <%=t('.destroy')%>
-          <%- end %>
+          <%= render ButtonComponent.new(
+                      label: t('.destroy', name: furniture.furniture.model_name.human.titleize),
+                      href: [furniture.room.space, furniture.room, furniture],
+                      title: t('.destroy', name: furniture.furniture.model_name.human.titleize),
+                      method: :delete,
+                      scheme: :danger) %>
         <%- end %>
 
         <%- if furniture.furniture.attribute_names.present? %>

--- a/app/views/furnitures/_furniture.html.erb
+++ b/app/views/furnitures/_furniture.html.erb
@@ -12,6 +12,7 @@
                         label: t('icons.edit'),
                         href: edit_href,
                         method: :get,
+                        turbo_stream: true,
                         title: t('.edit_title', name: furniture.furniture.model_name.human.titleize),
                         scheme: :secondary) %>
         <%- end %>

--- a/spec/factories/space.rb
+++ b/spec/factories/space.rb
@@ -4,6 +4,10 @@ FactoryBot.define do
   factory :space do
     sequence(:name) { |n| "#{Faker::Book.title} #{n}" }
 
+    trait :with_entrance do
+      entrance { association(:room, space: instance) }
+    end
+
     trait :with_members do
       transient do
         member_count { 4 }

--- a/spec/system/furniture_spec.rb
+++ b/spec/system/furniture_spec.rb
@@ -5,7 +5,6 @@ describe "Furniture" do
   include ActiveJob::TestHelper
   it "Managing Furniture" do
     space = create(:space, :with_entrance, :with_members, member_count: 1)
-    # Sign in to the Space
     sign_in(space.members.first, space)
 
     add_gizmo("Markdown Text Block", room: space.entrance)

--- a/spec/system/furniture_spec.rb
+++ b/spec/system/furniture_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+# @see https://github.com/zinc-collective/convene/issues/709
+describe "Furniture" do
+  include ActiveJob::TestHelper
+  it "Managing Furniture" do
+    space = create(:space, :with_entrance, :with_members, member_count: 1)
+    # Sign in to the Space
+    sign_in(space.members.first, space)
+
+    add_gizmo("Markdown Text Block", room: space.entrance)
+    remove_gizmo("Markdown Text Block", room: space.entrance)
+
+    visit(polymorphic_path(space.entrance.location(:edit)))
+    expect(page).to have_text("No gizmos yet.")
+  end
+
+  def sign_in(user, space)
+    visit(polymorphic_path(space.location))
+    click_link_or_button("Sign in")
+    fill_in("authenticated_session[contact_location]", with: user.email)
+    find('input[type="submit"]').click
+    perform_enqueued_jobs
+
+    visit(URI.parse(URI.extract(ActionMailer::Base.deliveries.first.body.to_s)[1]).request_uri)
+  end
+
+  def add_gizmo(type, room:)
+    visit(polymorphic_path(room.location(:edit)))
+    select(type, from: "Type of gizmo")
+    click_link_or_button("Add Gizmo")
+  end
+
+  def remove_gizmo(type, room:)
+    visit(polymorphic_path(room.location(:edit)))
+    expect(page).to have_text("Markdown Text Block")
+    within("##{ActionView::RecordIdentifier.dom_id(room.gizmos.first)}") do
+      click_link_or_button "Configure Markdown Text Block"
+    end
+    click_link_or_button "Remove Gizmo"
+  end
+end


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1565
- https://github.com/zinc-collective/convene/issues/1472

For some reason the automated check doesn't *FAIL* despite it failing when we manually execute it!


The "cause" is that the gizmo form has two `_method` fields, one is the hidden `_method` field that is automatically inserted by `form_with` when the `model` is `persisted?`; the other is added by a `button` that sets the `_method` to delete so that it can be removed.

In the system spec; the driven `firefox` takes the `_method` set by the clicked `button`. In the user-land; it sends *both* methods; and Rails picks the first one.

The "solution" will be to ditch the second `_method` (possibly even removing the ability to Remove a Gizmo from the `update` form.)