### PR TITLE
`Contributor`: override .env.development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *secrets.tfvars
 .env
 .env.production
+.env.development
 
 tmp/*
 node_modules/


### PR DESCRIPTION
I realized that `.env` is used in every environment (`production`, `test` and `development`); which means that the ActionMailer test deliveries ... actually go all the way through to maildev!

Which was not ideal.