### PR TITLE
🥔✨ `Space`: `Member` may set `Domain`

### DIFF
--- a/app/controllers/spaces_controller.rb
+++ b/app/controllers/spaces_controller.rb
@@ -42,7 +42,7 @@ class SpacesController < ApplicationController
   def update
     if space.update(space_params)
       flash[:notice] = t(".success")
-      redirect_to space
+      redirect_to space, allow_other_host: true
     else
       flash.now[:alert] = t(".error")
       render :edit

--- a/app/controllers/spaces_controller.rb
+++ b/app/controllers/spaces_controller.rb
@@ -42,7 +42,7 @@ class SpacesController < ApplicationController
   def update
     if space.update(space_params)
       flash[:notice] = t(".success")
-      redirect_to space, allow_other_host: true
+      redirect_to space.location(:edit), allow_other_host: true
     else
       flash.now[:alert] = t(".error")
       render :edit

--- a/app/policies/space_policy.rb
+++ b/app/policies/space_policy.rb
@@ -23,7 +23,7 @@ class SpacePolicy < ApplicationPolicy
   alias_method :create?, :destroy?
 
   def permitted_attributes(_params)
-    [:name, :slug, :entrance_id, :blueprint, :enforce_ssl]
+    [:name, :slug, :entrance_id, :blueprint, :enforce_ssl, :branded_domain]
   end
 
   class Scope < ApplicationScope

--- a/app/views/spaces/_website_settings.html.erb
+++ b/app/views/spaces/_website_settings.html.erb
@@ -12,6 +12,10 @@
   <% end %>
 
   <%= form_with model: space.location do | web_settings_form | %>
+    <%= web_settings_form.label :branded_domain %>
+    <%= space.branded_domain %>
+    <%= web_settings_form.text_field :branded_domain %>
+
     <%= web_settings_form.label :enforce_ssl do %>
       <%= web_settings_form.check_box :enforce_ssl %>
         Enforce SSL - Automatically redirects all Visitor traffic to this Space to https.

--- a/app/views/spaces/_website_settings.html.erb
+++ b/app/views/spaces/_website_settings.html.erb
@@ -4,17 +4,8 @@
     <p class="text-sm italic"><%= t('website_settings.help_text') %></p>
   </header>
 
-  <h4 class="text-base"> Domain </h4>
-  <% if space.branded_domain.present? %>
-    <p class="text-sm"><%=  space.branded_domain.presence || "No Domain" %></p>
-  <% else %>
-    <p class="text-sm"> No domain </p>
-  <% end %>
-
-  <%= form_with model: space.location do | web_settings_form | %>
-    <%= web_settings_form.label :branded_domain %>
-    <%= space.branded_domain %>
-    <%= web_settings_form.text_field :branded_domain %>
+  <%= form_with model: space.location, data: { turbo: false } do | web_settings_form | %>
+    <%= render "text_field", attribute: :branded_domain, form: web_settings_form %>
 
     <%= web_settings_form.label :enforce_ssl do %>
       <%= web_settings_form.check_box :enforce_ssl %>

--- a/spec/requests/spaces_controller_request_spec.rb
+++ b/spec/requests/spaces_controller_request_spec.rb
@@ -126,10 +126,14 @@ RSpec.describe SpacesController do
 
       it "updates the Space" do
         new_entrance = space.rooms.sample
-        put polymorphic_path(space), params: {space: {entrance_id: new_entrance.id, enforce_ssl: 1}}
+        put polymorphic_path(space), params: {space: {entrance_id: new_entrance.id, enforce_ssl: true, branded_domain: "zeespencer.com"}}
 
-        expect(space.reload.entrance).to eql(new_entrance)
-        expect(space.reload.enforce_ssl).to be true
+        space.reload
+
+        expect(space.entrance).to eql(new_entrance)
+        expect(space.enforce_ssl).to be true
+        expect(space.branded_domain).to eql("zeespencer.com")
+        expect(response).to redirect_to("http://zeespencer.com/edit")
         expect(flash[:notice]).to include("successfully updated")
       end
     end


### PR DESCRIPTION
- For https://github.com/zinc-collective/convene/issues/1513

After setting a domain on Space configure page, the Space#update will redirect to that new domain and encounter the issue below. Thus users cannot load the Space configure page to see the domain setting on their space.

e.g. in below example, space.branded_domain = "games.local"

<img width="1680" alt="Screenshot 2023-06-25 at 11 45 48 AM" src="https://github.com/zinc-collective/convene/assets/16140873/6746ba89-7a81-4410-8dad-8f4c854f8ea7">


https://github.com/zinc-collective/convene/assets/50284/9945c53e-24cb-4331-a8a2-45ec13569584


