### PR TITLE
✨🥔 `Components`: Expose `ButtonComponent#danger` variant

### DIFF
--- a/app/components/button_component.rb
+++ b/app/components/button_component.rb
@@ -82,7 +82,12 @@ class ButtonComponent < ApplicationComponent
   end
 
   def danger_classes
-    ["bg-danger-500 hover:bg-danger-700 active:bg-danger-200 text-white"]
+    [
+      "bg-danger-500",
+      "hover:bg-danger-700",
+      "active:bg-danger-200",
+      "text-white"
+    ]
   end
 
   def primary_classes

--- a/app/components/button_component.rb
+++ b/app/components/button_component.rb
@@ -3,7 +3,8 @@
 class ButtonComponent < ApplicationComponent
   SCHEME_MAPPINGS = {
     primary: :primary_classes,
-    secondary: :secondary_classes
+    secondary: :secondary_classes,
+    danger: :danger_classes
   }.with_indifferent_access.freeze
 
   def initialize(
@@ -61,6 +62,7 @@ class ButtonComponent < ApplicationComponent
       "shadow-sm",
       "ring-1",
       "ring-inset",
+      "text-center",
       "no-underline",
       "focus-visible:outline",
       "focus-visible:outline-2",
@@ -77,6 +79,10 @@ class ButtonComponent < ApplicationComponent
       "hover:bg-purple-100",
       "hover:text-purple-700"
     ]
+  end
+
+  def danger_classes
+    ["bg-danger-500 hover:bg-danger-700 active:bg-danger-200 text-white"]
   end
 
   def primary_classes

--- a/spec/components/button_component_spec.rb
+++ b/spec/components/button_component_spec.rb
@@ -49,5 +49,11 @@ RSpec.describe ButtonComponent, type: :component do
         expect(output.at_css("span").text).to eq("Some label")
       end
     end
+
+    context "when the scheme is `:danger`" do
+      let(:component) { described_class.new(**params.merge({scheme: :danger})) }
+
+      it { expect(output.at_css(".bg-danger-500")).to be_present }
+    end
   end
 end


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1187

As part of https://github.com/zinc-collective/convene/pull/1592 I needed a Button that used the `dange` variant and all the turbo-y goodness.

So I pulled a variant into the `ButtonComponent`; and then we can search for `--danger` and purge them.