### PR TITLE
🧹 `Gizmo`: Access a `Room`'s Gizmos via `.gizmos`

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -139,7 +139,7 @@ class ApplicationController < ActionController::Base
   end
 
   def space_repository
-    policy_scope(Space.includes(:rooms, entrance: [:furnitures]))
+    policy_scope(Space.includes(:rooms, entrance: [:gizmos]))
   end
 
   # Retrieves the room based upon the current_space and params

--- a/app/controllers/furnitures_controller.rb
+++ b/app/controllers/furnitures_controller.rb
@@ -62,9 +62,9 @@ class FurnituresController < ApplicationController
   end
 
   def find_or_build
-    return current_room.furnitures.find(params[:id]) if params[:id]
+    return current_room.gizmos.find(params[:id]) if params[:id]
 
-    current_room.furnitures.new(furniture_params)
+    current_room.gizmos.new(furniture_params)
   end
 
   def furniture_params

--- a/app/furniture/embedded_forms/_form.html.erb
+++ b/app/furniture/embedded_forms/_form.html.erb
@@ -2,6 +2,6 @@
 # @todo expect a `form` that is already using the fields for,
 # so we don't do it every time
 %>
-<%= form.fields_for(:furniture) do |furniture_fields| %>
+<%= form.fields_for(:gizmo) do |furniture_fields| %>
   <%= render "url_field", attribute: :form_url, form: furniture_fields %>
 <%- end %>

--- a/app/furniture/livestreams/_form.html.erb
+++ b/app/furniture/livestreams/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form.fields_for(:furniture) do |furniture_fields| %>
+<%= form.fields_for(:gizmo) do |furniture_fields| %>
   <%= render "text_field", form: furniture_fields, attribute: :channel %>
   <%= render "select", form: furniture_fields, attribute: :layout, options: ['video', 'video_with_chat'], include_blank: false %>
 

--- a/app/furniture/markdown_text_blocks/_form.html.erb
+++ b/app/furniture/markdown_text_blocks/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form.fields_for(:furniture) do |furniture_fields| %>
+<%= form.fields_for(:gizmo) do |furniture_fields| %>
   <%= furniture_fields.label :content %>
   <%= furniture_fields.text_area :content %>
   <%= render partial: "error", locals: { model: furniture_fields.object, attribute: :content } %>

--- a/app/furniture/marketplace/bazaar.rb
+++ b/app/furniture/marketplace/bazaar.rb
@@ -2,7 +2,7 @@ class Marketplace
   # Serves as a connection point for cross-marketplace functionality, like
   # {TaxRate} and {Shopper}.
   class Bazaar < ::Space
-    has_many :marketplaces, through: :rooms, source: :furnitures, inverse_of: :bazaar, class_name: "Marketplace"
+    has_many :marketplaces, through: :rooms, source: :gizmos, inverse_of: :bazaar, class_name: "Marketplace"
     has_many :tax_rates, inverse_of: :bazaar, dependent: :destroy
 
     def space

--- a/app/furniture/marketplace/marketplace.rb
+++ b/app/furniture/marketplace/marketplace.rb
@@ -5,7 +5,7 @@ class Marketplace
     location(parent: :room)
     default_scope { where(furniture_kind: "marketplace") }
 
-    has_one :bazaar, through: :room, inverse_of: :furnitures, source: :space, class_name: "Bazaar"
+    has_one :bazaar, through: :room, inverse_of: :gizmos, source: :space, class_name: "Bazaar"
     # @todo replace with through :bazaar
     has_many :tax_rates, inverse_of: :marketplace
 

--- a/app/models/blueprint.rb
+++ b/app/models/blueprint.rb
@@ -34,7 +34,7 @@ class Blueprint
   def add_furniture(room, room_attributes)
     furnitures = room_attributes.fetch(:furnitures, {})
     furnitures.each.with_index do |(furniture_kind, settings), slot|
-      furniture = room.furnitures
+      furniture = room.gizmos
         .find_or_initialize_by(slot: slot)
       furniture
         .update!(settings: merge_non_empty(settings, furniture.settings),

--- a/app/models/furniture.rb
+++ b/app/models/furniture.rb
@@ -10,8 +10,8 @@ class Furniture < ApplicationRecord
 
   ranks :slot, with_same: [:room_id]
 
-  belongs_to :room, inverse_of: :furnitures
-  has_one :space, through: :room, inverse_of: :furnitures
+  belongs_to :room, inverse_of: :gizmos
+  has_one :space, through: :room, inverse_of: :gizmos
 
   attribute :furniture_kind, :string
 
@@ -20,16 +20,17 @@ class Furniture < ApplicationRecord
   # The order in which {Furniture} is rendered in a Room. Lower is higher.
   attribute :slot, :integer
 
-  delegate :attributes=, to: :furniture, prefix: true
+  delegate :attributes=, to: :gizmo, prefix: true
 
   validates :furniture_kind, presence: true
 
-  def furniture
-    @furniture ||= Furniture.from_placement(self)
+  def gizmo
+    @gizmo ||= Furniture.from_placement(self)
   end
+  alias_method :furniture, :gizmo
 
   def title
-    furniture.model_name.human.titleize
+    gizmo.model_name.human.titleize
   end
 
   delegate :utilities, to: :space

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -34,9 +34,7 @@ class Room < ApplicationRecord
   }
   validates :publicity_level, presence: true
 
-  has_many :furnitures, dependent: :destroy, inverse_of: :room
-  accepts_nested_attributes_for :furnitures
-  alias_method :gizmos, :furnitures
+  has_many :gizmos, dependent: :destroy, inverse_of: :room, class_name: :Furniture
 
   def full_slug
     "#{space.slug}--#{slug}"

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -35,6 +35,7 @@ class Room < ApplicationRecord
   validates :publicity_level, presence: true
 
   has_many :gizmos, dependent: :destroy, inverse_of: :room, class_name: :Furniture
+  accepts_nested_attributes_for :gizmos
 
   def full_slug
     "#{space.slug}--#{slug}"

--- a/app/models/room/serializer.rb
+++ b/app/models/room/serializer.rb
@@ -11,7 +11,7 @@ class Room::Serializer < ApplicationSerializer
         id: room.id,
         slug: room.slug,
         name: room.name,
-        furnitures: room.furnitures.map(&Furniture::Serializer.method(:new)).map(&:to_json)
+        furnitures: room.gizmos.map(&Furniture::Serializer.method(:new)).map(&:to_json)
       }
     )
   end

--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -50,7 +50,7 @@ class Space < ApplicationRecord
   end
 
   def configured?(current_space)
-    current_space.rooms.blank? || current_space.entrance_id.blank? || current_space.members.blank? || current_space.entrance&.furnitures.blank?
+    current_space.rooms.blank? || current_space.entrance_id.blank? || current_space.members.blank? || current_space.entrance&.gizmos.blank?
   end
 
   attr_accessor :blueprint

--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -35,7 +35,7 @@ class Space < ApplicationRecord
 
   # The Rooms within this Space
   has_many :rooms, inverse_of: :space, dependent: :destroy
-  has_many :furnitures, through: :rooms, inverse_of: :space
+  has_many :gizmos, through: :rooms, inverse_of: :space
 
   has_many :agreements, inverse_of: :space, dependent: :destroy
 

--- a/app/policies/furniture_policy.rb
+++ b/app/policies/furniture_policy.rb
@@ -25,7 +25,7 @@ class FurniturePolicy < ApplicationPolicy
   alias_method :destroy?, :update?
 
   def permitted_attributes(_params)
-    [:furniture_kind, :slot, furniture_attributes: furniture_params]
+    [:furniture_kind, :slot, gizmo_attributes: furniture_params]
   end
 
   def furniture_params

--- a/app/policies/room_policy.rb
+++ b/app/policies/room_policy.rb
@@ -20,7 +20,7 @@ class RoomPolicy < ApplicationPolicy
 
   def permitted_attributes(params)
     [:access_level, :name, :slug, :publicity_level,
-      furnitures_attributes:
+      gizmos_attributes:
        policy(Furniture).permitted_attributes(params)]
   end
 

--- a/app/views/furnitures/_new.html.erb
+++ b/app/views/furnitures/_new.html.erb
@@ -1,7 +1,7 @@
 <div id="new_furniture">
   <h3><%= t('rooms.place_furniture_heading') %></h3>
   <%= form_with model: furniture.location do | form | %>
-    <%= form.hidden_field :slot, value: furniture.room.furnitures.count %>
+    <%= form.hidden_field :slot, value: furniture.room.gizmos.count %>
     <%= render "select", attribute: :furniture_kind, options: Furniture.registry.keys.map { |k| [k.to_s.titleize, k] },
         form: form, prompt: "-- Pick a type of gizmo --", include_blank: false %>
     <footer>

--- a/app/views/furnitures/create.turbo_stream.erb
+++ b/app/views/furnitures/create.turbo_stream.erb
@@ -3,4 +3,4 @@
   <%= render(furniture, { editing: true }) %>
 <%- end %>
 
-<%= turbo_stream.replace(:new_furniture, partial: 'furnitures/new', locals: { furniture: current_room.furnitures.new }) %>
+<%= turbo_stream.replace(:new_furniture, partial: 'furnitures/new', locals: { furniture: current_room.gizmos.new }) %>

--- a/app/views/rooms/_room.html.erb
+++ b/app/views/rooms/_room.html.erb
@@ -1,7 +1,7 @@
 <div class="flex flex-col content-between justify-end mx-auto max-w-7xl sm:px-6 lg:px-8">
   <div class="grow mx-auto w-full">
     <section id="furnitures">
-      <%= render room.furnitures.rank(:slot) %>
+      <%= render room.gizmos.rank(:slot) %>
     </section>
   </div>
 

--- a/app/views/rooms/edit.html.erb
+++ b/app/views/rooms/edit.html.erb
@@ -8,14 +8,14 @@
   <h2>Gizmos</h2>
 
   <div id="furnitures">
-    <% if room.furnitures.present? %>
-      <%= render room.furnitures.rank(:slot), editing: true %>
+    <% if room.gizmos.present? %>
+      <%= render room.gizmos.rank(:slot), editing: true %>
     <% else %>
       <p class="text-gray-500"><%= t('rooms.no_furniture_notice') %></p>
     <% end %>
   </div>
 
-  <%- new_furniture = room.furnitures.new %>
+  <%- new_furniture = room.gizmos.new %>
   <%- if policy(new_furniture).new? %>
     <%= render "furnitures/new", furniture: new_furniture %>
   <%- end %>

--- a/app/views/spaces/edit.html.erb
+++ b/app/views/spaces/edit.html.erb
@@ -24,7 +24,7 @@
         </li>
       <% end %>
 
-      <% if space.entrance_id.present? && space.entrance&.furnitures&.blank? %>
+      <% if space.entrance_id.present? && space.entrance&.gizmos&.blank? %>
         <li>
           <%= t('spaces.edit.config_missing_entrance_furniture_text_html', room_name: link_to(space.entrance.name, space.entrance.location(:edit) )) %>
         </li>

--- a/features/lib/Room.js
+++ b/features/lib/Room.js
@@ -26,7 +26,7 @@ class Room extends Model {
       room: {
         name: this.name,
         slug: this.slug,
-        furnituresAttributes: this.furnituresAttributes,
+        gizmosAttributes: this.gizmosAttributes,
       },
     };
   }

--- a/features/steps/furniture_steps.js
+++ b/features/steps/furniture_steps.js
@@ -27,9 +27,7 @@ Given(
       },
     ];
 
-    return this.api()
-      .rooms(space)
-      .update(room.assign({ gizmosAttributes }));
+    return this.api().rooms(space).update(room.assign({ gizmosAttributes }));
   }
 );
 Then(

--- a/features/steps/furniture_steps.js
+++ b/features/steps/furniture_steps.js
@@ -20,7 +20,7 @@ Given(
    * @param {DataTable} dataTable
    */
   function (_a, furniture, _a2, room, space, dataTable) {
-    const furnituresAttributes = [
+    const gizmosAttributes = [
       {
         furnitureKind: furniture.type.toLowerCase(),
         furnitureAttributes: dataTableToHash(dataTable),
@@ -29,7 +29,7 @@ Given(
 
     return this.api()
       .rooms(space)
-      .update(room.assign({ furnituresAttributes }));
+      .update(room.assign({ gizmosAttributes }));
   }
 );
 Then(

--- a/features/steps/furniture_steps.js
+++ b/features/steps/furniture_steps.js
@@ -23,7 +23,7 @@ Given(
     const gizmosAttributes = [
       {
         furnitureKind: furniture.type.toLowerCase(),
-        furnitureAttributes: dataTableToHash(dataTable),
+        gizmoAttributes: dataTableToHash(dataTable),
       },
     ];
 

--- a/spec/models/blueprint_spec.rb
+++ b/spec/models/blueprint_spec.rb
@@ -23,13 +23,13 @@ RSpec.describe Blueprint do
 
       # @todo add other examples of changing data after the
       # blueprint has been applied
-      space.rooms.first.furnitures.first.update(furniture_attributes: {content: "Hey there!"})
+      space.rooms.first.gizmos.first.update(gizmo_attributes: {content: "Hey there!"})
 
       described_class.new(EXAMPLE_CONFIG).find_or_create!
 
       # @todo add other examples of confirming the changes
       # were not overwritten
-      expect(space.rooms.first.furnitures.first.furniture.content).to eql("Hey there!")
+      expect(space.rooms.first.gizmos.first.gizmo.content).to eql("Hey there!")
     end
 
     it "Updates a given space" do

--- a/spec/models/furniture_spec.rb
+++ b/spec/models/furniture_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Furniture do
-  it { is_expected.to belong_to(:room).inverse_of(:furnitures) }
-  it { is_expected.to have_one(:space).through(:room).inverse_of(:furnitures) }
+  it { is_expected.to belong_to(:room).inverse_of(:gizmos) }
+  it { is_expected.to have_one(:space).through(:room).inverse_of(:gizmos) }
 
   describe "#furniture" do
     it "returns the configured piece of furniture" do

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Room do
   let(:space) { Space.new }
 
-  it { is_expected.to have_many(:furnitures).inverse_of(:room).dependent(:destroy) }
+  it { is_expected.to have_many(:gizmos).inverse_of(:room).dependent(:destroy) }
   it { is_expected.to belong_to(:space).inverse_of(:rooms) }
 
   describe ".slug" do

--- a/spec/models/space_spec.rb
+++ b/spec/models/space_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Space do
   subject(:space) { described_class.new }
 
   it { is_expected.to have_many(:rooms).dependent(:destroy) }
-  it { is_expected.to have_many(:furnitures).through(:rooms).inverse_of(:space) }
+  it { is_expected.to have_many(:gizmos).through(:rooms).inverse_of(:space) }
   it { is_expected.to have_many(:utilities).inverse_of(:space).dependent(:destroy) }
 
   it { is_expected.to have_many(:agreements).inverse_of(:space).dependent(:destroy) }

--- a/spec/requests/furnitures_controller_request_spec.rb
+++ b/spec/requests/furnitures_controller_request_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe FurnituresController do
 
     context "when the person is a guest" do
       it "does not allow updating placements" do
-        patch placement_path, params: {furniture: {furniture_attributes: {content: "updated content"}}}
+        patch placement_path, params: {furniture: {gizmo_attributes: {content: "updated content"}}}
         expect(response).not_to have_http_status(:success)
       end
     end
@@ -43,7 +43,7 @@ RSpec.describe FurnituresController do
       before { sign_in(space, person) }
 
       it "allows updating a placement" do
-        patch placement_path, params: {furniture: {furniture_attributes: {content: "updated content"}}}
+        patch placement_path, params: {furniture: {gizmo_attributes: {content: "updated content"}}}
         expect(response).to have_http_status(:found)
         expect(placement.reload.settings["content"]).to eq("updated content")
       end

--- a/spec/requests/furnitures_controller_request_spec.rb
+++ b/spec/requests/furnitures_controller_request_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe FurnituresController do
 
     before { sign_in(space, person) }
 
-    specify { expect { perform_request }.to change { room.furnitures.count }.by(1) }
+    specify { expect { perform_request }.to change { room.gizmos.count }.by(1) }
 
     it "creates a furniture placement of the kind of furniture provided within the room" do
       perform_request
-      placement = room.furnitures.last
+      placement = room.gizmos.last
       expect(placement.furniture).to be_a(MarkdownTextBlock)
       expect(placement.slot).to be(0)
       expect(response).to redirect_to([space, room])

--- a/spec/requests/rooms_request_spec.rb
+++ b/spec/requests/rooms_request_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "/spaces/:space_slug/rooms/" do # rubocop:disable RSpec/DescribeC
       response "200", "Room retrieved" do
         run_test! do |response|
           data = response_data(response)
-          furniture_data = room.furnitures
+          furniture_data = room.gizmos
             .map(&Furniture::Serializer.method(:new))
             .map(&:to_json)
           expect(data[:room]).to eq(id: room.id, name: room.name,
@@ -52,7 +52,7 @@ RSpec.describe "/spaces/:space_slug/rooms/" do # rubocop:disable RSpec/DescribeC
             properties: {
               name: {type: :string, example: "Fancy Room"},
               slug: {type: :string, example: "fancy-room"},
-              furnitures_attributes: {
+              gizmos_attributes: {
                 type: :array,
                 items: {
                   type: :object,
@@ -70,7 +70,7 @@ RSpec.describe "/spaces/:space_slug/rooms/" do # rubocop:disable RSpec/DescribeC
       response "200", "Room updated with furniture" do
         let(:room) { create(:room, space: space) }
         let(:attributes) do
-          {name: "A new name", furnitures_attributes: [attributes_for(:furniture)]}
+          {name: "A new name", gizmos_attributes: [attributes_for(:furniture)]}
         end
 
         run_test! do


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1472
- https://github.com/zinc-collective/convene/issues/709
- https://github.com/zinc-collective/convene/issues/1155

Theoretically, this will get us a bit closer to Gizmofication...

I'm available to do a big-bang rename; but I figured starting with replacing where we call `.furniture` and `.furnitures` with `.gizmo` and `.gizmos` would be a smaller step; but it also is a bit scatter-shot.

I *think* it should be possible to rename the `Furniture` class (and it's related `Controller`, `Policy`, and `Views`) but I got skeered.