### PR TITLE
🧹 `Neighborhood`: update CI pipeline names

### DIFF
--- a/.github/workflows/test-convene-web.yml
+++ b/.github/workflows/test-convene-web.yml
@@ -53,7 +53,7 @@ jobs:
         run: yarn install
 
   test-rspec:
-    name: Run tests
+    name: Run Rspec tests
     runs-on: ubuntu-latest
     needs: [setup]
 
@@ -119,7 +119,7 @@ jobs:
       - name: Setup rails
         run: bin/setup-rails && bin/rails assets:precompile
 
-      - name: Run Tests
+      - name: Run tests
         env:
           HEADLESS: true
         run: bundle exec rspec
@@ -131,7 +131,7 @@ jobs:
           path: tmp/capybara/*.png
 
   test-features:
-    name: Run browser tests
+    name: Run Cucumber feature tests
     runs-on: ubuntu-latest
     needs: [setup]
 

--- a/.github/workflows/test-convene-web.yml
+++ b/.github/workflows/test-convene-web.yml
@@ -131,7 +131,7 @@ jobs:
           path: tmp/capybara/*.png
 
   test-features:
-    name: Run Cucumber feature tests
+    name: Run Cucumber tests
     runs-on: ubuntu-latest
     needs: [setup]
 

--- a/.github/workflows/test-convene-web.yml
+++ b/.github/workflows/test-convene-web.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Setup rails
         run: bin/setup-rails && bin/rails assets:precompile
 
-      - name: Run tests
+      - name: Run Tests
         env:
           HEADLESS: true
         run: bundle exec rspec


### PR DESCRIPTION
Update test pipeline names to add clarity.

- change `Run tests` ➡️  `Run Rspec tests` because the pipe runs Rspec Unit tests and now, the new System test `spec/system/furniture_spec.rb` (added in https://github.com/zinc-collective/convene/pull/1588) which also includes some browser testing.

- change `Run browser tests`  ➡️ `Run Cucumber tests` because the pipe not no longer the only pipe that runs browser tests.

![chagnes 1](https://github.com/zinc-collective/convene/assets/16140873/3bf69d89-76d9-4713-be3d-6e114bdbd696)
![chagnes 2](https://github.com/zinc-collective/convene/assets/16140873/81b83bf8-30e8-4ba5-b753-bd556a8918d1)


