### PR TITLE
🐞🔨 `Space`: When the `entrance` is missing, it explodes

### DIFF
--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -49,5 +49,9 @@ class Space < ApplicationRecord
     []
   end
 
+  def configured?(current_space)
+    current_space.rooms.blank? || current_space.entrance_id.blank? || current_space.members.blank? || current_space.entrance&.furnitures.blank?
+  end
+
   attr_accessor :blueprint
 end

--- a/app/views/spaces/edit.html.erb
+++ b/app/views/spaces/edit.html.erb
@@ -1,6 +1,6 @@
 <% breadcrumb :edit_space, space %>
 
-<% if space.entrance_id.blank? || space.rooms.blank? || space.members.blank? %>
+<% if space.rooms.blank? || space.entrance_id.blank? || space.members.blank? || space.entrance.furnitures.blank? %>
   <%= render AlertComponent.new(scheme: :warning, icon: :exclamation_triangle,
     title: t('spaces.edit.config_missing_title')) do %>
     <%= t('spaces.edit.config_missing_explainer_html' ) %>

--- a/app/views/spaces/edit.html.erb
+++ b/app/views/spaces/edit.html.erb
@@ -24,7 +24,7 @@
         </li>
       <% end %>
 
-      <% if space.entrance&.furnitures.blank? %>
+      <% if space.entrance_id.present? && space.entrance&.furnitures.blank? %>
         <li>
           <%= t('spaces.edit.config_missing_entrance_furniture_text_html', room_name: link_to(space.entrance.name, space.entrance.location(:edit) )) %>
         </li>

--- a/app/views/spaces/edit.html.erb
+++ b/app/views/spaces/edit.html.erb
@@ -1,6 +1,6 @@
 <% breadcrumb :edit_space, space %>
 
-<% if space.rooms.blank? || space.entrance_id.blank? || space.members.blank? || space.entrance&.furnitures.blank? %>
+<% if space.configured?(space) %>
   <%= render AlertComponent.new(scheme: :warning, icon: :exclamation_triangle,
     title: t('spaces.edit.config_missing_title')) do %>
     <%= t('spaces.edit.config_missing_explainer_html' ) %>

--- a/app/views/spaces/edit.html.erb
+++ b/app/views/spaces/edit.html.erb
@@ -24,7 +24,7 @@
         </li>
       <% end %>
 
-      <% if space.entrance_id.present? && space.entrance&.furnitures.blank? %>
+      <% if space.entrance_id.present? && space.entrance&.furnitures&.blank? %>
         <li>
           <%= t('spaces.edit.config_missing_entrance_furniture_text_html', room_name: link_to(space.entrance.name, space.entrance.location(:edit) )) %>
         </li>

--- a/app/views/spaces/edit.html.erb
+++ b/app/views/spaces/edit.html.erb
@@ -24,7 +24,7 @@
         </li>
       <% end %>
 
-      <% if space.entrance.furnitures.blank? %>
+      <% if space.entrance&.furnitures.blank? %>
         <li>
           <%= t('spaces.edit.config_missing_entrance_furniture_text_html', room_name: link_to(space.entrance.name, space.entrance.location(:edit) )) %>
         </li>

--- a/app/views/spaces/edit.html.erb
+++ b/app/views/spaces/edit.html.erb
@@ -1,6 +1,6 @@
 <% breadcrumb :edit_space, space %>
 
-<% if space.rooms.blank? || space.entrance_id.blank? || space.members.blank? || space.entrance.furnitures.blank? %>
+<% if space.rooms.blank? || space.entrance_id.blank? || space.members.blank? || space.entrance&.furnitures.blank? %>
   <%= render AlertComponent.new(scheme: :warning, icon: :exclamation_triangle,
     title: t('spaces.edit.config_missing_title')) do %>
     <%= t('spaces.edit.config_missing_explainer_html' ) %>


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1585

Trying to fix an issue @daltonrpruitt  found in https://github.com/zinc-collective/convene/issues/1565#issuecomment-1606496774 and add a missing condition to an if statement that got forgotten when https://github.com/zinc-collective/convene/pull/1593 was built


**prompts that display, if no section, no entrance and no entrance gizmos exist**
<img width="880" alt="prompts that display when no section nor entrance nor gizmos" src="https://github.com/zinc-collective/convene/assets/16140873/cb2f3ad9-f3b9-4da9-8f08-dd482d7ba7c2">

**prompts that display, if 1 section exists, but no entrance is set**
<img width="883" alt="when 1 section:room exists" src="https://github.com/zinc-collective/convene/assets/16140873/cdd7c577-69be-4770-a8c1-05b682b25442">


**prompts that display, if 1 section exists, it is set as entrance, but entrance has no gizmo**
<img width="887" alt="when 1 section exist and is set as entrance but no gizmos" src="https://github.com/zinc-collective/convene/assets/16140873/94965f9e-a782-4011-a290-6fe8d15d8031">

**prompts that display, if section entrance has gizmo**
<img width="696" alt="when section entrance has gizmo" src="https://github.com/zinc-collective/convene/assets/16140873/52051eae-4bdd-48d5-909e-beb8269fc309">
