### PR TITLE
`Marketplace`: Updates warning message to reflect requirements

### DIFF
--- a/app/furniture/marketplace/locales/en.yml
+++ b/app/furniture/marketplace/locales/en.yml
@@ -39,8 +39,7 @@ en:
       edit: "Manage Marketplace"
       config_missing_title: "Marketplace configuration missing"
       config_missing_explainer_html: |
-        This marketplace is not ready for shopping, and is not visible to the public.
-        Add missing configuration by going to %{edit_link}.
+        This marketplace is not ready for shopping. You must connect Stripe and add at least one product and one delivery area. You can add missing configuration by going to %{edit_link}.
     marketplaces:
       edit:
         missing_stripe_api_key: "Add a Stripe API key to %{space_name}"


### PR DESCRIPTION
While learning my way through Marketplace app setup I was surprised to discover I missed adding a Delivery Area until I snooped around the code to debug the warning toast: 

> Marketplace configuration missing
>
> This marketplace is not ready for shopping, and is not visible to the public. Add missing configuration by going to Manage Marketplace.