### PR TITLE
🧹🏡 Remove `cssbundling` and `jsbundling` gems, which we aren't using

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,8 +20,6 @@ gem "rails", "~> 7.0"
 gem "puma", "~> 6.3"
 
 # Browser Layer
-gem "cssbundling-rails"
-gem "jsbundling-rails"
 gem "sprockets-rails"
 # Turbo lets us swap chunks of HTML without page reloads: https://github.com/hotwired/turbo-rails
 gem "stimulus-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,8 +131,6 @@ GEM
     crass (1.0.6)
     css_parser (1.14.0)
       addressable
-    cssbundling-rails (1.1.2)
-      railties (>= 6.0.0)
     date (3.3.3)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
@@ -171,8 +169,6 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     jmespath (1.6.2)
-    jsbundling-rails (1.1.2)
-      railties (>= 6.0.0)
     json (2.6.3)
     json-schema (3.0.0)
       addressable (>= 2.8)
@@ -476,7 +472,6 @@ DEPENDENCIES
   binding_of_caller
   bootsnap (~> 1.16)
   capybara
-  cssbundling-rails
   dotenv-rails
   factory_bot_rails
   faker
@@ -484,7 +479,6 @@ DEPENDENCIES
   gretel (~> 4.5)
   image_processing
   jbuilder (~> 2.11)
-  jsbundling-rails
   listen (~> 3.8)
   lockbox (= 1.2.0)
   lookbook (>= 2.0.0.beta.4)


### PR DESCRIPTION
Simplifying our Gemfile a bit.