### PR TITLE
🏠 `Neighborhood`: Consolidate default setup of `.env*` files

### DIFF
--- a/.devcontainer/startup.bash
+++ b/.devcontainer/startup.bash
@@ -89,14 +89,8 @@ fi
 
 Xvfb $DISPLAY -ac &> .devcontainer/output/Xvfb.out &
 
-if [ ! -f .env ]; then
-    cp .env.example .env
-    sed -i "/^# PG/s/^# //g" .env
-fi
-
-if [ ! -f .env.development ]; then
-  cp .env.development.example .env.development
-fi
+bin/copy-example-envs
+sed -i "/^# PG/s/^# //g" .env # Make sure postgres env vars aren't commented out
 
 # if [ ${data_files_existed} != 0 ]; then
     setup_out='.devcontainer/output/bin_setup.out'

--- a/bin/copy-example-envs
+++ b/bin/copy-example-envs
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if test -f ".env"; then
+  echo "Found .env, leaving it in place!"
+else
+  echo "Copying .env.example to .env"
+  cp .env.example .env
+fi
+
+if test -f ".env.development"; then
+  echo "Found .env.development, leaving it in place!"
+else
+  echo "Copying .env.development.example to .env.development"
+  cp .env.development.example .env
+fi

--- a/bin/copy-example-envs
+++ b/bin/copy-example-envs
@@ -11,5 +11,5 @@ if test -f ".env.development"; then
   echo "Found .env.development, leaving it in place!"
 else
   echo "Copying .env.development.example to .env.development"
-  cp .env.development.example .env
+  cp .env.development.example .env.development
 fi

--- a/bin/setup
+++ b/bin/setup
@@ -41,19 +41,7 @@ setup_package "vips"  # for image processing by Active Storage
 brew install --cask firefox
 yarn global add maildev
 
-if test -f ".env"; then
-  echo "Found .env, leaving it in place!"
-else
-  echo "Copying .env.example to .env"
-  cp .env.example .env
-fi
-
-if test -f ".env.development"; then
-  echo "Found .env.development, leaving it in place!"
-else
-  echo "Copying .env.development.example to .env.development"
-  cp .env.development.example .env
-fi
+bin/copy-example-envs
 
 # TODO: Figure out how to lock node version, asset building depends on min nodejs version of 12.20.0
 # see https://github.com/postcss/postcss-cli/issues/404 for details

--- a/bin/setup-rails
+++ b/bin/setup-rails
@@ -21,13 +21,7 @@ FileUtils.chdir APP_ROOT do
   system!('bin/yarn')
 
   puts "\n== Copying sample files =="
-  unless File.exist?('.env')
-    FileUtils.cp '.env.example', '.env'
-  end
-
-  unless File.exist?('.env.development')
-    FileUtils.cp '.env.development.example', '.env.development'
-  end
+  system!('bin/copy-example-envs')
 
   puts "\n== Preparing development database =="
   system! 'bin/rails db:prepare'


### PR DESCRIPTION
We were performing the same actions in three different places. 
This consolidates those into one single script.
This also fixes a bug in copying the `.env.development.example` file over the `.env` file, which was only being done in the `.devcontainer/startup.bash` script.

Co-authored-by: Zee Spencer <zspencer@users.noreply.github.com>
Co-authored-by: Ana <anaulin@users.noreply.github.com>
Co-authored-by: Kelly Hong <KellyAH@users.noreply.github.com>