### PR TITLE
🧹 Eliminate duplication in `Marketplace::ManagementComponent`

### DIFF
--- a/app/furniture/marketplace/breadcrumbs.rb
+++ b/app/furniture/marketplace/breadcrumbs.rb
@@ -9,7 +9,7 @@ end
 
 crumb :edit_marketplace do |marketplace|
   parent :room, marketplace.room
-  link t("marketplace.marketplace.edit"), marketplace.location(:edit)
+  link t("marketplace.marketplace.edit.link_to"), marketplace.location(:edit)
 end
 
 crumb :marketplace_checkout do |checkout|

--- a/app/furniture/marketplace/locales/en.yml
+++ b/app/furniture/marketplace/locales/en.yml
@@ -36,7 +36,8 @@ en:
     marketplace:
       manage_header: "Marketplace"
       configuration_menu: "Configuration"
-      edit: "Manage Marketplace"
+      edit:
+        link_to: "Manage Marketplace"
       config_missing_title: "Marketplace configuration missing"
       config_missing_explainer_html: |
         This marketplace is not ready for shopping. You must connect Stripe and add at least one product and one delivery area. You can add missing configuration by going to %{edit_link}.

--- a/app/furniture/marketplace/management_component.html.erb
+++ b/app/furniture/marketplace/management_component.html.erb
@@ -10,41 +10,12 @@
   <%= content %>
 
   <% card.with_footer do %>
-    <nav class="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 gap-3">
-      <%= render ButtonComponent.new(
-        label: t('marketplace.marketplace.configuration_menu'),
-        icon: :gear,
-        href: marketplace.location(:edit),
-        turbo_stream: false, method: :get, scheme: :secondary
-      ) if policy(marketplace).edit? %>
-
-      <%= render ButtonComponent.new(
-        label: t('marketplace.products.index.link_to'),
-        icon: :tag,
-        href: marketplace.location(child: :products),
-        turbo_stream: false, method: :get, scheme: :secondary
-      ) if policy(marketplace).edit? %>
-
-      <%= render ButtonComponent.new(
-        label: t('marketplace.delivery_areas.index.link_to'),
-        icon: :map,
-        href: marketplace.location(child: :delivery_areas),
-        turbo_stream: false, method: :get, scheme: :secondary
-      ) if policy(marketplace.delivery_areas.new).create? %>
-
-      <%= render ButtonComponent.new(
-        label: t('marketplace.tax_rates.index.link_to'),
-        icon: :receipt_percent,
-        href: marketplace.location(child: :tax_rates),
-        turbo_stream: false, method: :get, scheme: :secondary
-      ) if policy(marketplace.bazaar.tax_rates.new(marketplace: marketplace)).create? %>
-
-      <%= render ButtonComponent.new(
-        label: t('marketplace.orders.index.link_to'),
-        icon: :cart,
-        href: marketplace.location(child: :orders),
-        turbo_stream: false, method: :get, scheme: :secondary
-      ) if policy(marketplace.orders).index? %>
+    <nav class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3">
+      <%= render button_to(:edit, icon: :gear) if policy(marketplace).edit? %>
+      <%= render button_to({child: :products}, icon: :tag)  if policy(marketplace.products).index? %>
+      <%= render button_to({child: :delivery_areas}, icon: :map)  if policy(marketplace.delivery_areas).index? %>
+      <%= render button_to({child: :tax_rates}, icon: :receipt_percent)  if policy(marketplace.tax_rates).index? %>
+      <%= render button_to({child: :orders}, icon: :cart)  if policy(marketplace.orders).index? %>
     </nav>
   <% end %>
 <% end %>

--- a/app/furniture/marketplace/management_component.html.erb
+++ b/app/furniture/marketplace/management_component.html.erb
@@ -11,11 +11,11 @@
 
   <% card.with_footer do %>
     <nav class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3">
-      <%= render button_to(:edit, icon: :gear) if policy(marketplace).edit? %>
-      <%= render button_to({child: :products}, icon: :tag)  if policy(marketplace.products).index? %>
-      <%= render button_to({child: :delivery_areas}, icon: :map)  if policy(marketplace.delivery_areas).index? %>
-      <%= render button_to({child: :tax_rates}, icon: :receipt_percent)  if policy(marketplace.tax_rates).index? %>
-      <%= render button_to({child: :orders}, icon: :cart)  if policy(marketplace.orders).index? %>
+      <%= render button(:edit, icon: :gear) if policy(marketplace).edit? %>
+      <%= render button({child: :products}, icon: :tag)  if policy(marketplace.products).index? %>
+      <%= render button({child: :delivery_areas}, icon: :map)  if policy(marketplace.delivery_areas).index? %>
+      <%= render button({child: :tax_rates}, icon: :receipt_percent)  if policy(marketplace.tax_rates).index? %>
+      <%= render button({child: :orders}, icon: :cart)  if policy(marketplace.orders).index? %>
     </nav>
   <% end %>
 <% end %>

--- a/app/furniture/marketplace/management_component.rb
+++ b/app/furniture/marketplace/management_component.rb
@@ -7,5 +7,17 @@ class Marketplace
 
       self.marketplace = marketplace
     end
+
+    def button_to(location, icon:)
+      label, href = if location.is_a?(Symbol)
+        [t("marketplace.marketplace.#{location}.link_to"),
+          marketplace.location(location)]
+      else
+        [t("marketplace.#{location[:child]}.index.link_to"),
+          marketplace.location(**location)]
+      end
+
+      ButtonComponent.new(label: label, icon: icon, href: href, turbo_stream: false, method: :get, scheme: :secondary)
+    end
   end
 end

--- a/app/furniture/marketplace/management_component.rb
+++ b/app/furniture/marketplace/management_component.rb
@@ -8,7 +8,7 @@ class Marketplace
       self.marketplace = marketplace
     end
 
-    def button_to(location, icon:)
+    def button(location, icon:)
       label, href = if location.is_a?(Symbol)
         [t("marketplace.marketplace.#{location}.link_to"),
           marketplace.location(location)]

--- a/app/furniture/marketplace/marketplace_component.html.erb
+++ b/app/furniture/marketplace/marketplace_component.html.erb
@@ -2,7 +2,7 @@
   <%= render AlertComponent.new(scheme: :warning, icon: :exclamation_triangle,
                                 title: t('marketplace.marketplace.config_missing_title')) do %>
     <%= t('marketplace.marketplace.config_missing_explainer_html',
-          edit_link: link_to(t('marketplace.marketplace.edit'), location(:edit)) ) %>
+          edit_link: link_to(t('marketplace.marketplace.edit.link_to'), location(:edit)) ) %>
   <% end %>
 <% end %>
 
@@ -10,7 +10,7 @@
 
 <%- if policy(marketplace).edit? %>
   <div class="my-2 text-right">
-    <%= render ButtonComponent.new(scheme: :secondary, label: t('marketplace.marketplace.edit'),
+    <%= render ButtonComponent.new(scheme: :secondary, label: t('marketplace.marketplace.edit.link_to'),
                                    href: location(:edit), method: :get) %>
   </div>
 <%- end %>

--- a/spec/furniture/marketplace/marketplace_component_spec.rb
+++ b/spec/furniture/marketplace/marketplace_component_spec.rb
@@ -11,17 +11,17 @@ RSpec.describe Marketplace::MarketplaceComponent, type: :component do
     let(:current_person) { create(:person, operator: true) }
 
     it { is_expected.not_to have_content(I18n.t("marketplace.marketplace.config_missing_explainer_html")) }
-    it { is_expected.to have_link(I18n.t("marketplace.marketplace.edit"), href: polymorphic_path(marketplace.location(:edit))) }
+    it { is_expected.to have_link(I18n.t("marketplace.marketplace.edit.link_to"), href: polymorphic_path(marketplace.location(:edit))) }
 
     context "when the marketplace is not fully configured" do
       let(:marketplace) { create(:marketplace) }
 
-      it { is_expected.to have_content(I18n.t("marketplace.marketplace.config_missing_explainer_html", edit_link: I18n.t("marketplace.marketplace.edit"))) }
+      it { is_expected.to have_content(I18n.t("marketplace.marketplace.config_missing_explainer_html", edit_link: I18n.t("marketplace.marketplace.edit.link_to"))) }
     end
   end
 
   context "when the current person cannot edit the marketplace" do
-    it { is_expected.not_to have_link(I18n.t("marketplace.marketplace.edit"), href: polymorphic_path(marketplace.location(:edit))) }
+    it { is_expected.not_to have_link(I18n.t("marketplace.marketplace.edit.link_to"), href: polymorphic_path(marketplace.location(:edit))) }
 
     context "when the marketplace is not fully configured" do
       let(:marketplace) { create(:marketplace) }

--- a/spec/furniture/marketplace/marketplaces_controller_request_spec.rb
+++ b/spec/furniture/marketplace/marketplaces_controller_request_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Marketplace::MarketplacesController, type: :request do
     it "does not show guests the edit button" do
       get polymorphic_path(marketplace.location)
 
-      expect(response.body).not_to include(I18n.t("marketplace.marketplace.edit"))
+      expect(response.body).not_to include(I18n.t("marketplace.marketplace.edit.link_to"))
       expect(response).to be_ok
     end
   end


### PR DESCRIPTION
-  https://github.com/zinc-collective/convene/issues/831

Now we have a small set of buttons where the vew code only has the *differences*! yay!