### PR TITLE
🐛 `Invitations` and `People`: strip extra whitespace from emails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,9 @@ gem "lockbox", "1.2.0"
 gem "rotp", "~> 6.2"
 gem "strong_migrations", "~> 1.4"
 
+# ActiveModel extension to remove extra whitespace from attributes
+gem "strip_attributes", "~> 1.13"
+
 # Use postgresql for data persistence
 gem "pg", "~> 1.5"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -429,6 +429,8 @@ GEM
       rubocop-performance (~> 1.18.0)
     stimulus-rails (1.2.1)
       railties (>= 6.0.0)
+    strip_attributes (1.13.0)
+      activemodel (>= 3.0, < 8.0)
     stripe (8.5.0)
     strong_migrations (1.4.4)
       activerecord (>= 5.2)
@@ -518,6 +520,7 @@ DEPENDENCIES
   sprockets-rails
   standard (~> 1.29)
   stimulus-rails
+  strip_attributes (~> 1.13)
   stripe
   strong_migrations (~> 1.4)
   turbo-rails

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -3,6 +3,8 @@
 class Invitation < ApplicationRecord
   location(parent: :space)
 
+  strip_attributes only: [:email]
+
   belongs_to :space, inverse_of: :invitations
 
   belongs_to :invitor, class_name: :Person, inverse_of: :invitations

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -2,6 +2,8 @@
 
 # A representation of a human
 class Person < ApplicationRecord
+  strip_attributes only: [:email]
+
   validates :email, presence: true, uniqueness: {case_sensitive: false}
 
   # Ways for the person to sign in

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -19,6 +19,8 @@ class Person < ApplicationRecord
 
   has_many :invitations, inverse_of: :invitor, foreign_key: :invitor_id, dependent: :destroy
 
+  before_save :downcase_email, if: :email_changed?
+
   def member_of?(space)
     spaces.include?(space)
   end
@@ -31,5 +33,11 @@ class Person < ApplicationRecord
 
   def authenticated?
     true
+  end
+
+  private
+
+  def downcase_email
+    self.email = email&.downcase
   end
 end

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -14,6 +14,11 @@ RSpec.describe Invitation do
       invitation.email = "User@example.Com"
       expect(invitation.email).to eql("user@example.com")
     end
+
+    it "is stripped of whitespace" do
+      invitation = create(:invitation, email: " orca@yachtkillerz.org ")
+      expect(invitation.email).to eql("orca@yachtkillerz.org")
+    end
   end
 
   describe "#invitor_display_name" do

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -32,6 +32,13 @@ RSpec.describe Person do
     end
   end
 
+  describe "#email" do
+    it "automatically removes extra whitespace" do
+      person = create(:person, email: " virgo@oakland.org ")
+      expect(person.email).to eq("virgo@oakland.org")
+    end
+  end
+
   describe "#member_of?" do
     subject(:person) { membership.member }
 

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -33,9 +33,14 @@ RSpec.describe Person do
   end
 
   describe "#email" do
-    it "automatically removes extra whitespace" do
+    it "automatically loses extra whitespace" do
       person = create(:person, email: " virgo@oakland.org ")
       expect(person.email).to eq("virgo@oakland.org")
+    end
+
+    it "is automatically downcased" do
+      person = create(:person, email: "sOlOud@geez.ORG")
+      expect(person.email).to eq("soloud@geez.org")
     end
   end
 


### PR DESCRIPTION
This fixes https://github.com/zinc-collective/convene/issues/1607

I also threw in some downcasing of `Person.email`, to match the downcasing we are already doing on the `Invitation.email`.