### PR TITLE
🧹`Marketplace`: Demonstrate usage of `decent_exposure`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,6 +87,7 @@ gem "bootsnap", "~> 1.16", require: false
 
 # Permissions and policies
 gem "pundit", "~> 2.3"
+gem "decent_exposure", "~> 3.0"
 
 # Utility support
 gem "money-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,6 +135,8 @@ GEM
       railties (>= 6.0.0)
     date (3.3.3)
     debug_inspector (1.1.0)
+    decent_exposure (3.0.4)
+      activesupport (>= 4.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dotenv (2.8.1)
@@ -480,6 +482,7 @@ DEPENDENCIES
   bootsnap (~> 1.16)
   capybara
   cssbundling-rails
+  decent_exposure (~> 3.0)
   dotenv-rails
   factory_bot_rails
   faker

--- a/app/furniture/marketplace/cart_products_controller.rb
+++ b/app/furniture/marketplace/cart_products_controller.rb
@@ -1,8 +1,10 @@
 class Marketplace
   class CartProductsController < Controller
+    expose :cart, scope: -> { policy_scope(marketplace.carts) }, model: Cart
+    expose :cart_product, scope: -> { policy_scope(cart.cart_products) }, model: CartProduct
+
     def create
-      authorize(cart_product)
-      cart_product.save
+      authorize(cart_product).save
 
       respond_to do |format|
         format.html do
@@ -31,8 +33,7 @@ class Marketplace
     end
 
     def update
-      authorize(cart_product)
-      cart_product.update(cart_product_params)
+      authorize(cart_product).update(cart_product_params)
       respond_to do |format|
         format.html do
           if cart_product.errors.empty?
@@ -59,8 +60,7 @@ class Marketplace
     end
 
     def destroy
-      authorize(cart_product)
-      cart_product.destroy
+      authorize(cart_product).destroy
       respond_to do |format|
         format.html do
           if cart_product.destroyed?
@@ -86,20 +86,8 @@ class Marketplace
       end
     end
 
-    def cart_product
-      @cart_product ||= if params[:id]
-        cart.cart_products.find(params[:id])
-      elsif params[:cart_product]
-        cart.cart_products.new(cart_product_params)
-      end
-    end
-
     def cart_product_component
       @cart_product_component ||= CartProductComponent.new(cart_product: cart_product)
-    end
-
-    def cart
-      marketplace.carts.find(params[:cart_id])
     end
 
     def cart_product_params

--- a/app/furniture/marketplace/controller.rb
+++ b/app/furniture/marketplace/controller.rb
@@ -1,9 +1,6 @@
 class Marketplace
   class Controller < FurnitureController
-    helper_method def marketplace
-      @marketplace ||= policy_scope(Marketplace).find(params[:marketplace_id])
-    end
-
+    expose :marketplace, scope: -> { policy_scope(Marketplace) }
     delegate :bazaar, to: :marketplace
     helper_method :bazaar
 

--- a/app/furniture/marketplace/delivery_areas_controller.rb
+++ b/app/furniture/marketplace/delivery_areas_controller.rb
@@ -1,13 +1,18 @@
 class Marketplace
   class DeliveryAreasController < Controller
+    expose :delivery_area, model: DeliveryArea, scope: -> { delivery_areas }
+    expose :delivery_areas, -> { policy_scope(marketplace.delivery_areas) }
+
     def index
+      skip_authorization
     end
 
     def edit
+      authorize(delivery_area)
     end
 
     def create
-      if delivery_area.save
+      if authorize(delivery_area).save
         redirect_to marketplace.location(child: :delivery_areas)
       else
         render :new
@@ -15,23 +20,19 @@ class Marketplace
     end
 
     def new
-      delivery_area
+      authorize(delivery_area)
     end
 
     def update
-      if delivery_area.update(delivery_area_params)
+      if authorize(delivery_area).update(delivery_area_params)
         redirect_to marketplace.location(child: :delivery_areas), notice: t(".success", name: delivery_area.label)
       else
         render :edit
       end
     end
 
-    def delivery_area_params
-      policy(DeliveryArea).permit(params.require(:delivery_area))
-    end
-
     def destroy
-      delivery_area.destroy
+      authorize(delivery_area).destroy
 
       respond_to do |format|
         format.turbo_stream do
@@ -52,20 +53,8 @@ class Marketplace
       end
     end
 
-    helper_method def delivery_area
-      @delivery_area ||= if params[:id]
-        delivery_areas.find(params[:id])
-      elsif params[:delivery_area]
-        delivery_areas.new(delivery_area_params)
-      else
-        delivery_areas.new
-      end.tap do |delivery_area|
-        authorize(delivery_area)
-      end
-    end
-
-    helper_method def delivery_areas
-      @delivery_areas ||= policy_scope(marketplace.delivery_areas)
+    def delivery_area_params
+      policy(DeliveryArea).permit(params.require(:delivery_area))
     end
   end
 end

--- a/app/furniture/marketplace/marketplaces_controller.rb
+++ b/app/furniture/marketplace/marketplaces_controller.rb
@@ -2,15 +2,14 @@
 
 class Marketplace
   class MarketplacesController < FurnitureController
+    expose(:marketplace, model: Marketplace)
+
     def show
+      authorize(marketplace)
     end
 
     def edit
-      marketplace
-    end
-
-    helper_method def marketplace
-      authorize(Marketplace.find(params[:id]))
+      authorize(marketplace)
     end
   end
 end

--- a/app/furniture/marketplace/notification_methods_controller.rb
+++ b/app/furniture/marketplace/notification_methods_controller.rb
@@ -1,15 +1,18 @@
 class Marketplace
   class NotificationMethodsController < Controller
+    expose :notification_method, model: NotificationMethod, scope: -> { notification_methods }
+    expose :notification_methods, -> { policy_scope(marketplace.notification_methods) }
+
     def new
-      notification_method
+      authorize(notification_method)
     end
 
     def edit
-      notification_method
+      authorize(notification_method)
     end
 
     def update
-      if notification_method.update(notification_method_params)
+      if authorize(notification_method).update(notification_method_params)
         redirect_to marketplace.location(child: :notification_methods), notice: t(".success", contact_location: notification_method.contact_location)
       else
         render :edit, status: :unprocessable_entity
@@ -17,7 +20,7 @@ class Marketplace
     end
 
     def create
-      if notification_method.save
+      if authorize(notification_method).save
         redirect_to marketplace.location(child: :notification_methods)
       else
         render :new, status: :unprocessable_entity
@@ -25,25 +28,9 @@ class Marketplace
     end
 
     def destroy
-      notification_method.destroy
+      authorize(notification_method).destroy
 
       redirect_to marketplace.location(child: :notification_methods), notice: t(".success", contact_location: notification_method.contact_location)
-    end
-
-    helper_method def notification_methods
-      @notification_methods ||= marketplace.notification_methods
-    end
-
-    helper_method def notification_method
-      @notification_method ||= if params[:id]
-        notification_methods.find(params[:id])
-      elsif params[:notification_method]
-        notification_methods.new(notification_method_params)
-      else
-        notification_methods.new
-      end.tap do |notification_method|
-        authorize(notification_method)
-      end
     end
 
     def notification_method_params

--- a/app/furniture/marketplace/orders_controller.rb
+++ b/app/furniture/marketplace/orders_controller.rb
@@ -1,18 +1,14 @@
 class Marketplace
   class OrdersController < Controller
+    expose :order, scope: -> { orders }, model: Order
+    expose :orders, -> { policy_scope(marketplace.orders).order(created_at: :desc) }
+
     def show
       authorize(order)
     end
 
     def index
-    end
-
-    helper_method def orders
-      policy_scope(marketplace.orders).order(created_at: :desc)
-    end
-
-    helper_method def order
-      orders.find(params[:id])
+      skip_authorization
     end
   end
 end

--- a/app/furniture/marketplace/tax_rates_controller.rb
+++ b/app/furniture/marketplace/tax_rates_controller.rb
@@ -1,14 +1,18 @@
 class Marketplace
   class TaxRatesController < Controller
+    expose :tax_rate, model: TaxRate, scope: -> { tax_rates }
+    expose :tax_rates, -> { policy_scope(bazaar.tax_rates) }
+
     def new
-      tax_rate
+      authorize(tax_rate)
     end
 
     def index
+      skip_authorization
     end
 
     def create
-      if tax_rate.save
+      if authorize(tax_rate).save
         redirect_to marketplace.location(child: :tax_rates)
       else
         render :new
@@ -16,6 +20,8 @@ class Marketplace
     end
 
     def edit
+      authorize(tax_rate)
+
       respond_to do |format|
         format.turbo_stream do
           render turbo_stream: turbo_stream.replace(tax_rate, partial: "form")
@@ -26,7 +32,7 @@ class Marketplace
     end
 
     def update
-      tax_rate.update(tax_rate_params)
+      authorize(tax_rate).update(tax_rate_params)
 
       respond_to do |format|
         format.turbo_stream do
@@ -48,7 +54,7 @@ class Marketplace
     end
 
     def destroy
-      tax_rate.destroy
+      authorize(tax_rate).destroy
 
       respond_to do |format|
         format.turbo_stream do
@@ -71,22 +77,6 @@ class Marketplace
 
     def tax_rate_params
       policy(TaxRate).permit(params.require(:tax_rate))
-    end
-
-    helper_method def tax_rate
-      @tax_rate ||= if params[:id]
-        tax_rates.find(params[:id])
-      elsif params[:tax_rate]
-        tax_rates.new(tax_rate_params.merge(marketplace: marketplace))
-      else
-        tax_rates.new(marketplace: marketplace)
-      end.tap do |tax_rate|
-        authorize(tax_rate)
-      end
-    end
-
-    helper_method def tax_rates
-      @tax_rates ||= policy_scope(bazaar.tax_rates)
     end
   end
 end

--- a/app/furniture/marketplace/tax_rates_controller.rb
+++ b/app/furniture/marketplace/tax_rates_controller.rb
@@ -1,6 +1,7 @@
 class Marketplace
   class TaxRatesController < Controller
-    expose :tax_rate, model: TaxRate, scope: -> { tax_rates }
+    expose :tax_rate, model: TaxRate, scope: -> { tax_rates },
+      build: ->(params, scope) { scope.new(params.merge(marketplace: marketplace)) }
     expose :tax_rates, -> { policy_scope(bazaar.tax_rates) }
 
     def new

--- a/spec/furniture/marketplace/notification_methods_controller_request_spec.rb
+++ b/spec/furniture/marketplace/notification_methods_controller_request_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Marketplace::NotificationMethodsController, type: :request do
     end
 
     describe "when request is invalid" do
-      let(:notification_method_attributes) { {} }
+      let(:notification_method_attributes) { {contact_method: "email"} }
 
       it { is_expected.to have_rendered(:new) }
     end

--- a/spec/furniture/marketplace/orders_controller_request_spec.rb
+++ b/spec/furniture/marketplace/orders_controller_request_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe Marketplace::OrdersController, type: :request do
+  let(:space) { create(:space, :with_members, member_count: 1) }
+  let(:member) { space.members.first }
+  let(:marketplace) { create(:marketplace, space: space) }
+  let(:order) { create(:marketplace_order, marketplace: marketplace, delivery_address: "123 N West St") }
+
+  describe "#show" do
+    subject(:perform_request) do
+      get polymorphic_path(order.location)
+      response
+    end
+
+    context "when the current person can see the order" do
+      before { sign_in(space, member) }
+
+      it { is_expected.to be_ok }
+
+      specify {
+        perform_request
+        expect(response.body).to include("123 N West St")
+      }
+    end
+
+    context "when the order is not viewable by the current person" do
+      specify { expect { perform_request }.to raise_error(ActiveRecord::RecordNotFound) }
+      # it { is_expected.to be_not_found}
+    end
+  end
+end

--- a/spec/furniture/marketplace/products_controller_request_spec.rb
+++ b/spec/furniture/marketplace/products_controller_request_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Marketplace::ProductsController, type: :request do
     end
 
     describe "when product is invalid" do
-      let(:product_attributes) { {} }
+      let(:product_attributes) { {description: "test"} }
 
       it { is_expected.to have_rendered(:new) }
     end
@@ -44,10 +44,11 @@ RSpec.describe Marketplace::ProductsController, type: :request do
 
   describe "#edit" do
     it "Shows the form to edit a Marketplace Product" do
+      sign_in(space, member)
       product = create(:marketplace_product, marketplace: marketplace)
 
-      get polymorphic_path([:edit, space, room, marketplace, product])
-      expect(response).to render_template(:edit)
+      get polymorphic_path(product.location(:edit))
+      expect(response).to have_rendered(:edit)
     end
   end
 end


### PR DESCRIPTION
This demonstrates how the `decent_exposure` gem reduces LoC-per-Controller. Right now, I've isolated this to the `Marketplace` namespace; since I wasn't sure if this would be received as a useful abstraction or an obstraction...

There's some warts I'm not keen on:

1. It uses `Object.const_get` to try and load a model based upon the name... which isn't the end of the world but it sure as heck doesn't play well with namespaces...
2. It would be nice if we could use a `with: [:policy_scoped]` so we don't have to call `policy_scope` every time; but it didn't look like that was possible straight-off-the-docs so I didn't go down the path of trying to make it work.

Thoughts?

P.s. The majority of the new lines are from the test I wrote to make sure that the `Marketplace::OrdersController` wasn't YOLOed. It's -38+18 if you take that into account, saving -6~7 lines-per-controller.