### PR TITLE
🐞🔨 `Journal`: Show error messages when `Entry` cannot be saved

### DIFF
--- a/app/furniture/journal/entries_controller.rb
+++ b/app/furniture/journal/entries_controller.rb
@@ -6,7 +6,7 @@ class Journal::EntriesController < FurnitureController
     if entry.save
       redirect_to [space, room]
     else
-      render :new
+      render :new, status: :unprocessable_entity
     end
   end
 
@@ -17,7 +17,7 @@ class Journal::EntriesController < FurnitureController
     if entry.update(entry_params)
       redirect_to entry.location
     else
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/furniture/journal/entry.rb
+++ b/app/furniture/journal/entry.rb
@@ -9,6 +9,7 @@ class Journal
     scope :recent, -> { order("published_at DESC NULLS FIRST") }
 
     attribute :headline, :string
+    validates :headline, presence: true
     attribute :body, :string
     validates :body, presence: true
 

--- a/spec/furniture/journal/entry_spec.rb
+++ b/spec/furniture/journal/entry_spec.rb
@@ -1,10 +1,15 @@
 require "rails_helper"
 
-RSpec.describe Journal::Entry do
-  subject(:entry) { build(:journal_entry, body: body) }
+RSpec.describe Journal::Entry, type: :model do
+  subject(:entry) { build(:journal_entry) }
+
+  it { is_expected.to validate_presence_of(:headline) }
+  it { is_expected.to validate_presence_of(:body) }
 
   describe "#to_html" do
     subject(:to_html) { entry.to_html }
+
+    let(:entry) { build(:journal_entry, body: body) }
 
     context "when #body is 'https://www.google.com @zee@weirder.earth'" do
       let(:body) { "https://www.google.com @zee@weirder.earth" }


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1566

Womp womp; apparently I had forgotten to do the `unprocessable_entity`, which meant that `turbo` was failing miserably instead of replacing the form when creating or updating a journal entry.

Well; now it's fixed!