### PR TITLE
🌸 `Journal`: The `Entry#body` form field fills the screen

### DIFF
--- a/app/furniture/journal/entries/_form.html.erb
+++ b/app/furniture/journal/entries/_form.html.erb
@@ -1,6 +1,6 @@
-<%= form_with model: entry.location do |f| %>
+<%= form_with model: entry.location, class: "flex flex-col grow" do |f| %>
     <%= render "text_field", { attribute: :headline, form: f} %>
-    <%= render "text_area", { attribute: :body, form: f} %>
+    <%= render "text_area", { attribute: :body, form: f, field_classes: "grow", container_classes: "grow flex flex-col"} %>
     <%= render "datetime_field", { attribute: :published_at, form: f} %>
 
     <%= f.submit %>

--- a/app/views/application/_text_area.html.erb
+++ b/app/views/application/_text_area.html.erb
@@ -1,5 +1,5 @@
-<div>
+<div class="<%= local_assigns[:container_classes]%>">
   <%= form.label attribute %>
-  <%= form.text_area attribute %>
+  <%= form.text_area attribute, class: local_assigns[:field_classes] %>
   <%= render partial: "error", locals: { model: form.object, attribute: attribute } %>
 </div>


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1566

I was doing some writing and noticed that I tend to drag the text area to make it bigger.

Now I won't have to do that!


## After
<img width="387" alt="Screenshot 2023-07-03 at 9 30 26 PM" src="https://github.com/zinc-collective/convene/assets/50284/509ccac9-bffb-4ce2-ac2b-8941f490d7f9">


## Before
<img width="386" alt="Screenshot 2023-07-03 at 9 30 41 PM" src="https://github.com/zinc-collective/convene/assets/50284/a6ffd36c-4871-4581-85ff-bd5680841ec4">
