### PR TITLE
`Journal`: Strip whitespace from `slug`, `headline`, and `name`

### DIFF
--- a/app/furniture/journal/entry.rb
+++ b/app/furniture/journal/entry.rb
@@ -17,6 +17,8 @@ class Journal
     attribute :slug, :string
     validates :slug, uniqueness: {scope: :journal_id}
 
+    strip_attributes only: [:body, :headline, :slug]
+
     # FriendlyId does the legwork to make the slug uri-friendly
     extend FriendlyId
     friendly_id :headline, use: :scoped, scope: :journal

--- a/spec/furniture/journal/entry_spec.rb
+++ b/spec/furniture/journal/entry_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Journal::Entry, type: :model do
 
   it { is_expected.to validate_presence_of(:headline) }
   it { is_expected.to validate_presence_of(:body) }
+  it { is_expected.to strip_attributes(:slug, :body, :headline) }
 
   describe "#to_html" do
     subject(:to_html) { entry.to_html }

--- a/spec/support/strip_attributes.rb
+++ b/spec/support/strip_attributes.rb
@@ -1,0 +1,5 @@
+require "strip_attributes/matchers"
+
+RSpec.configure do |config|
+  config.include StripAttributes::Matchers
+end


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1566
- https://github.com/zinc-collective/convene/pull/1630#discussion_r1253762788

> Not really part of your PR, but now that we have the
> `strip_attributes` gem, it might be worth throwing that on for
> `headline` and `body`, just so that we don't store trailing/preceding
> whitespace.