### PR TITLE
🧹 `Marketplace`: Remove `Controller#update` and unused `.settings`

### DIFF
--- a/app/furniture/marketplace/marketplace.rb
+++ b/app/furniture/marketplace/marketplace.rb
@@ -17,7 +17,6 @@ class Marketplace
 
     has_many :notification_methods, inverse_of: :marketplace, dependent: :destroy
 
-    setting :notify_emails
     setting :stripe_account
     alias_method :vendor_stripe_account, :stripe_account
     setting :stripe_webhook_endpoint

--- a/app/furniture/marketplace/marketplace_policy.rb
+++ b/app/furniture/marketplace/marketplace_policy.rb
@@ -2,10 +2,6 @@
 
 class Marketplace
   class MarketplacePolicy < Policy
-    def permitted_attributes(_params)
-      [:delivery_fee, :notify_emails, :delivery_window, :order_by]
-    end
-
     alias_method :marketplace, :object
     def show?
       true

--- a/app/furniture/marketplace/marketplaces_controller.rb
+++ b/app/furniture/marketplace/marketplaces_controller.rb
@@ -9,21 +9,8 @@ class Marketplace
       marketplace
     end
 
-    def update
-      if marketplace.update(marketplace_params)
-        redirect_to marketplace.location(:edit), notice: t(".success")
-      else
-        flash[:alert] = t(".failure")
-        render :edit, status: :unprocessable_entity
-      end
-    end
-
     helper_method def marketplace
       authorize(Marketplace.find(params[:id]))
-    end
-
-    def marketplace_params
-      policy(Marketplace).permit(params.require(:marketplace))
     end
   end
 end

--- a/app/furniture/marketplace/order/received_mailer.rb
+++ b/app/furniture/marketplace/order/received_mailer.rb
@@ -2,7 +2,7 @@ class Marketplace
   class Order
     class ReceivedMailer < Mailer
       def to
-        order.marketplace.notify_emails.split(",") + order.marketplace.notification_methods.map(&:contact_location)
+        order.marketplace.notification_methods.map(&:contact_location)
       end
     end
   end

--- a/app/furniture/marketplace/routes.rb
+++ b/app/furniture/marketplace/routes.rb
@@ -1,7 +1,7 @@
 class Marketplace
   class Routes
     def self.append_routes(router)
-      router.resources :marketplaces, only: [:show, :edit, :update], module: "marketplace" do
+      router.resources :marketplaces, only: [:show, :edit], module: "marketplace" do
         router.resources :carts, only: [] do
           router.resources :cart_products
           router.resource :checkout, only: [:show, :create]

--- a/spec/factories/furniture/marketplace.rb
+++ b/spec/factories/furniture/marketplace.rb
@@ -23,10 +23,6 @@ FactoryBot.define do
       tax_rates { Array.new(tax_rate_quantity) { association(:marketplace_tax_rate) } }
     end
 
-    trait :with_notify_emails do
-      notify_emails { Array.new((1..3).to_a.sample) { Faker::Internet.email }.join(",") }
-    end
-
     trait :with_delivery_areas do
       transient do
         delivery_area_quantity { 1 }
@@ -52,7 +48,6 @@ FactoryBot.define do
     trait :full do
       with_tax_rates
       with_delivery_areas
-      with_notify_emails
     end
 
     trait :ready_for_shopping do

--- a/spec/furniture/marketplace/marketplaces_controller_request_spec.rb
+++ b/spec/furniture/marketplace/marketplaces_controller_request_spec.rb
@@ -22,18 +22,6 @@ RSpec.describe Marketplace::MarketplacesController, type: :request do
     end
   end
 
-  describe "#update" do
-    before { sign_in(space, member) }
-
-    it "updates the attributes" do
-      marketplace_attributes = attributes_for(:marketplace, notify_emails: "notify@example.com")
-      put polymorphic_path(marketplace.location), params: {marketplace: marketplace_attributes}
-      marketplace.reload
-
-      expect(marketplace.notify_emails).to eq(marketplace_attributes[:notify_emails])
-    end
-  end
-
   describe "#show" do
     it "does not show guests the edit button" do
       get polymorphic_path(marketplace.location)

--- a/spec/furniture/marketplace/order/received_mailer_spec.rb
+++ b/spec/furniture/marketplace/order/received_mailer_spec.rb
@@ -1,21 +1,17 @@
 require "rails_helper"
 
 RSpec.describe Marketplace::Order::ReceivedMailer, type: :mailer do
-  let(:marketplace) { create(:marketplace, notify_emails: "vendor@example.com,distributor@example.com") }
+  let(:marketplace) { create(:marketplace) }
   let(:order) { build(:marketplace_order, placed_at: 1.hour.ago, marketplace: marketplace) }
 
   describe "#notification" do
     subject(:notification) { described_class.notification(order) }
 
-    it { is_expected.to be_to(marketplace.notify_emails.split(",")) }
-
-    context "when the marketplace has a order notification contact location" do
-      before do
-        marketplace.notification_methods.create(contact_location: "another_place@example.com")
-      end
-
-      it { is_expected.to be_to(marketplace.notify_emails.split(",") + marketplace.notification_methods.map(&:contact_location)) }
+    before do
+      marketplace.notification_methods.create(contact_location: "another_place@example.com")
     end
+
+    it { is_expected.to be_to(marketplace.notification_methods.map(&:contact_location)) }
 
     it { is_expected.to have_subject(t(".notification.subject", marketplace_name: order.marketplace_name, order_id: order.id)) }
 


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1511

Now that the `Marketplace` no longer has any user modifiable attributes, I got rid of all the leftovers.