### PR TITLE
🧹 `Marketplace`: One last tiny tidy  for the fumble

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,3 +28,7 @@ RSpec/NestedGroups:
 
 RSpec/ExampleLength:
   Max: 10
+
+Style/TrailingCommaInArrayLiteral:
+  Exclude:
+    - db/schema.rb

--- a/db/migrate/20230615002110_add_marketplace_order_notification_methods.rb
+++ b/db/migrate/20230615002110_add_marketplace_order_notification_methods.rb
@@ -1,6 +1,6 @@
-class AddMarketplaceNotificationMethods < ActiveRecord::Migration[7.0]
+class AddMarketplaceOrderNotificationMethods < ActiveRecord::Migration[7.0]
   def change
-    create_table :marketplace_notification_methods, id: :uuid do |t|
+    create_table :marketplace_order_notification_methods, id: :uuid do |t|
       t.references :marketplace, type: :uuid, foreign_key: {to_table: :furnitures}
       t.string :contact_method, default: :email, null: false
       t.string :contact_location_ciphertext, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -22,12 +22,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_06_003709) do
     "expired",
     "ignored",
     "revoked",
-    "sent"
+    "sent",
   ], force: :cascade
 
   create_enum :membership_status, [
     "active",
-    "revoked"
+    "revoked",
   ], force: :cascade
 
   create_table "active_storage_attachments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1511

I also meant to revert the accidental rename itself; but I totally forgot to in my rush to unmuck the issue.