### PR TITLE
🥔✨ `Marketplace`: Check `StripeAccount` when `Onboarding`

### DIFF
--- a/app/furniture/marketplace/locales/en.yml
+++ b/app/furniture/marketplace/locales/en.yml
@@ -81,6 +81,8 @@ en:
       destroy:
         link_to: "Remove Product '%{name}'"
     stripe_accounts:
+      new:
+        link_to: "Add Stripe Account"
       show:
         link_to: "Stripe Account"
         missing_stripe_api_key: "Add a Stripe API key to %{space_name}"

--- a/app/furniture/marketplace/onboarding_component.html.erb
+++ b/app/furniture/marketplace/onboarding_component.html.erb
@@ -2,15 +2,14 @@
   <%= render AlertComponent.new(scheme: :warning, icon: :exclamation_triangle,
                                 title: t('.title')) do %>
 
-
     <%- if !marketplace.ready_for_shopping? %>
       <p>
         <%== t('.marketplace_hidden', link: link_to(t('marketplace.marketplace.edit.link_to'), location(:edit)) ) %>
       </p>
     <%- end %>
-
-    <%== onboard(:products) %>
-    <%== onboard(:notification_methods) %>
-    <%== onboard(:delivery_areas) %>
+    <%== onboard(:stripe_account) if marketplace.stripe_account.blank? %>
+    <%== onboard(:products) if marketplace.products.blank? %>
+    <%== onboard(:notification_methods) if marketplace.notification_methods.blank? %>
+    <%== onboard(:delivery_areas) if marketplace.delivery_areas.blank? %>
   <%- end %>
 </section>

--- a/app/furniture/marketplace/onboarding_component.rb
+++ b/app/furniture/marketplace/onboarding_component.rb
@@ -14,7 +14,6 @@ class Marketplace
 
     def onboard(resource)
       resource = resource.to_s.pluralize
-      return if marketplace.send(resource).present?
       tag_builder.p(t(".missing.#{resource}", link: link_to(t("marketplace.#{resource}.new.link_to"), location(:new, child: resource.singularize.to_sym))).html_safe)
     end
 

--- a/app/furniture/marketplace/onboarding_component.yml
+++ b/app/furniture/marketplace/onboarding_component.yml
@@ -2,6 +2,8 @@ en:
   title: "Let's Get your Marketplace Ready!"
   marketplace_hidden: "We've hidden your Marketplace from visitors until it's properly configured. %{link}"
   missing:
+    stripe_accounts:
+      Whose Stripe account should receive Payments? %{link}.
     notification_methods:
       How would you like to get Notifications about Orders? %{link}.
     products:

--- a/app/furniture/marketplace/routes.rb
+++ b/app/furniture/marketplace/routes.rb
@@ -12,7 +12,7 @@ class Marketplace
         router.resources :notification_methods
         router.resources :orders, only: [:show, :index]
         router.resources :products
-        router.resource :stripe_account
+        router.resource :stripe_account, only: [:show, :new, :create]
         router.resources :stripe_events
         router.resources :tax_rates
       end

--- a/app/furniture/marketplace/stripe_accounts_controller.rb
+++ b/app/furniture/marketplace/stripe_accounts_controller.rb
@@ -15,6 +15,11 @@ class Marketplace
       redirect_to marketplace.location(:edit), alert: "Something went wrong! #{e.message}"
     end
 
+    def new
+      authorize(marketplace, :edit?)
+      redirect_to marketplace.location(child: :stripe_account)
+    end
+
     def show
       authorize(marketplace, :edit?)
     end

--- a/spec/furniture/marketplace/onboarding_component_spec.rb
+++ b/spec/furniture/marketplace/onboarding_component_spec.rb
@@ -43,4 +43,14 @@ RSpec.describe Marketplace::OnboardingComponent, type: :component do
     it { is_expected.not_to have_content(t(".missing.delivery_areas", link: t("marketplace.delivery_areas.new.link_to"))) }
     it { is_expected.not_to have_link(t("marketplace.delivery_areas.new.link_to"), href: polymorphic_path(marketplace.location(:new, child: :delivery_area))) }
   end
+
+  it { is_expected.to have_content(t(".missing.stripe_accounts", link: t("marketplace.stripe_accounts.new.link_to"))) }
+  it { is_expected.to have_link(t("marketplace.stripe_accounts.new.link_to"), href: polymorphic_path(marketplace.location(:new, child: :stripe_account))) }
+
+  context "when the Marketplace has a StripeAccount" do
+    let(:marketplace) { create(:marketplace, :with_stripe_account) }
+
+    it { is_expected.not_to have_content(t(".missing.stripe_accounts", link: t("marketplace.stripe_accounts.new.link_to"))) }
+    it { is_expected.not_to have_link(t("marketplace.stripe_accounts.new.link_to"), href: polymorphic_path(marketplace.location(:new, child: :stripe_account))) }
+  end
 end

--- a/spec/furniture/marketplace/stripe_accounts_controller_request_spec.rb
+++ b/spec/furniture/marketplace/stripe_accounts_controller_request_spec.rb
@@ -49,6 +49,16 @@ RSpec.describe Marketplace::StripeAccountsController, type: :request do
     end
   end
 
+  describe "#new" do
+    subject(:call) do
+      sign_in(space, member)
+      get polymorphic_path(marketplace.location(:new, child: :stripe_account))
+      response
+    end
+
+    it { is_expected.to redirect_to(marketplace.location(child: :stripe_account)) }
+  end
+
   describe "#show" do
     subject(:call) do
       sign_in(space, member)


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1641
- https://github.com/zinc-collective/convene/issues/1576
- https://github.com/zinc-collective/convene/issues/1622

Now we encourage people to set up their `StripeAccount`!

We still need cleaner UI for that, but @rosschapman is working on that part. 