### PR TITLE
🧹 `Marketplace`: Pull `StripeAccount` to its own page

### DIFF
--- a/app/components/svg_component.rb
+++ b/app/components/svg_component.rb
@@ -2,6 +2,10 @@ class SvgComponent < ApplicationComponent
   # { symbol: method returning path for symbol }
   ICON_MAPPINGS = {
     cart: :cart,
+    # @todo I don't know where we have been getting the SVG icons;
+    #       and I am hesitant to add one unless it's coming from
+    #       a library we are already using... - ZS
+    money: :cart,
     exclamation_triangle: :exclamation_triangle,
     gear: :gear,
     map: :map,

--- a/app/furniture/marketplace/breadcrumbs.rb
+++ b/app/furniture/marketplace/breadcrumbs.rb
@@ -79,6 +79,11 @@ crumb :edit_delivery_area do |delivery_area|
   link t("marketplace.delivery_areas.edit.link_to", name: delivery_area.label), marketplace.location(:edit, child: :delivery_area)
 end
 
+crumb :show_marketplace_stripe_account do |marketplace|
+  parent :edit_marketplace, marketplace
+  link t("marketplace.stripe_accounts.show.link_to"), marketplace.location(child: :stripe_account)
+end
+
 crumb :marketplace_tax_rates do |marketplace|
   parent :edit_marketplace, marketplace
   link t("marketplace.tax_rates.index.link_to"), marketplace.location(child: :tax_rates)

--- a/app/furniture/marketplace/locales/en.yml
+++ b/app/furniture/marketplace/locales/en.yml
@@ -1,4 +1,3 @@
-
 en:
   activerecord:
     attributes:
@@ -42,10 +41,6 @@ en:
       edit:
         link_to: "Manage Marketplace"
     marketplaces:
-      edit:
-        missing_stripe_api_key: "Add a Stripe API key to %{space_name}"
-        connect_stripe: "Connect to Stripe"
-        stripe_connected: "Stripe Connected!"
       update:
         success: "Marketplace updated successfully!"
         failure: "Marketplace could not be updated."
@@ -85,6 +80,12 @@ en:
         link_to: "Edit Product '%{name}'"
       destroy:
         link_to: "Remove Product '%{name}'"
+    stripe_accounts:
+      show:
+        link_to: "Stripe Account"
+        missing_stripe_api_key: "Add a Stripe API key to %{space_name}"
+        connect_stripe: "Connect to Stripe"
+        stripe_connected: "Stripe Connected!"
     tax_rates:
       index:
         link_to: "Tax Rates"

--- a/app/furniture/marketplace/management_component.html.erb
+++ b/app/furniture/marketplace/management_component.html.erb
@@ -12,7 +12,7 @@
 
   <% card.with_footer do %>
     <nav class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3">
-      <%= render button(:edit, icon: :gear) if policy(marketplace).edit? %>
+      <%= render button({child: :stripe_account}, icon: :money) if policy(marketplace).edit? %>
       <%= render button({child: :products}, icon: :tag)  if policy(marketplace.products).index? %>
       <%= render button({child: :delivery_areas}, icon: :map)  if policy(marketplace.delivery_areas).index? %>
       <%= render button({child: :tax_rates}, icon: :receipt_percent)  if policy(marketplace.tax_rates).index? %>

--- a/app/furniture/marketplace/management_component.rb
+++ b/app/furniture/marketplace/management_component.rb
@@ -16,8 +16,11 @@ class Marketplace
       label, href = if location.is_a?(Symbol)
         [t("marketplace.marketplace.#{location}.link_to"),
           marketplace.location(location)]
-      else
+      elsif location[:child].to_s.pluralize == location[:child].to_s
         [t("marketplace.#{location[:child]}.index.link_to"),
+          marketplace.location(**location)]
+      else
+        [t("marketplace.#{location[:child].to_s.pluralize}.show.link_to"),
           marketplace.location(**location)]
       end
 

--- a/app/furniture/marketplace/marketplaces/edit.html.erb
+++ b/app/furniture/marketplace/marketplaces/edit.html.erb
@@ -1,18 +1,2 @@
 <%- breadcrumb :edit_marketplace, marketplace %>
-<%= render Marketplace::ManagementComponent.new(marketplace: marketplace) do %>
-  <p class="flex justify-between my-5 flex-wrap">
-    <%- if marketplace.stripe_api_key? %>
-      <%- if marketplace.stripe_account_connected? %>
-        <%= t('.stripe_connected') %>
-      <%- end %>
-      <%= button_to t('.connect_stripe'),
-          marketplace.location(child: :stripe_account), method: :post, data: { turbo: false } %>
-    <% else %>
-      <%= render ButtonComponent.new(
-            label: t('.missing_stripe_api_key', space_name: space.name),
-            href: space.location(:edit),
-            method: :get,
-            scheme: :primary ) %>
-    <% end %>
-  </p>
-<% end %>
+<%= render Marketplace::ManagementComponent.new(marketplace: marketplace) %>

--- a/app/furniture/marketplace/stripe_accounts/show.html.erb
+++ b/app/furniture/marketplace/stripe_accounts/show.html.erb
@@ -1,0 +1,18 @@
+<%- breadcrumb :show_marketplace_stripe_account, marketplace %>
+<%= render Marketplace::ManagementComponent.new(marketplace: marketplace) do %>
+  <p class="flex justify-between my-5 flex-wrap">
+    <%- if marketplace.stripe_api_key? %>
+      <%- if marketplace.stripe_account_connected? %>
+        <%= t('.stripe_connected') %>
+      <%- end %>
+      <%= button_to t('.connect_stripe'),
+          marketplace.location(child: :stripe_account), method: :post, data: { turbo: false } %>
+    <% else %>
+      <%= render ButtonComponent.new(
+            label: t('.missing_stripe_api_key', space_name: space.name),
+            href: space.location(:edit),
+            method: :get,
+            scheme: :primary ) %>
+    <% end %>
+  </p>
+<% end %>

--- a/app/furniture/marketplace/stripe_accounts_controller.rb
+++ b/app/furniture/marketplace/stripe_accounts_controller.rb
@@ -15,6 +15,10 @@ class Marketplace
       redirect_to marketplace.location(:edit), alert: "Something went wrong! #{e.message}"
     end
 
+    def show
+      authorize(marketplace, :edit?)
+    end
+
     helper_method def marketplace
       @marketplace ||= policy_scope(Marketplace).find(params[:marketplace_id])
     end

--- a/spec/furniture/marketplace/stripe_accounts_controller_request_spec.rb
+++ b/spec/furniture/marketplace/stripe_accounts_controller_request_spec.rb
@@ -48,5 +48,15 @@ RSpec.describe Marketplace::StripeAccountsController, type: :request do
       end
     end
   end
+
+  describe "#show" do
+    subject(:call) do
+      sign_in(space, member)
+      get polymorphic_path(marketplace.location(child: :stripe_account))
+      response
+    end
+
+    it { is_expected.to render_template(:show) }
+  end
 end
 # rubocop:enable RSpec/VerifiedDoubles


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1576
- https://github.com/zinc-collective/convene/issues/1622
- https://github.com/zinc-collective/convene/issues/1641

This makes it possible to link directly to the `StripeAccount`. Maybe it should be `PaymentMethods` or something once we start adding in other payment sources; but this should do it for now; and make it a bit easier to start improving the Marketplace Onboarding flow.