### PR TITLE
🥗🧹`Journal`: Make relationships of `Entry` Rails-able

### DIFF
--- a/app/furniture/journal/entry.rb
+++ b/app/furniture/journal/entry.rb
@@ -27,8 +27,9 @@ class Journal
 
     # @!attribute journal
     #   @return [Journal::Journal]
-    belongs_to :journal, class_name: "Journal::Journal", inverse_of: :entries
-    delegate :room, :space, to: :journal
+    belongs_to :journal, inverse_of: :entries
+    has_one :room, through: :journal
+    has_one :space, through: :journal
 
     def published?
       published_at.present?

--- a/spec/furniture/journal/entry_spec.rb
+++ b/spec/furniture/journal/entry_spec.rb
@@ -6,6 +6,9 @@ RSpec.describe Journal::Entry, type: :model do
   it { is_expected.to validate_presence_of(:headline) }
   it { is_expected.to validate_presence_of(:body) }
   it { is_expected.to strip_attributes(:slug, :body, :headline) }
+  it { is_expected.to belong_to(:journal).inverse_of(:entries) }
+  it { is_expected.to have_one(:room).through(:journal) }
+  it { is_expected.to have_one(:space).through(:journal) }
 
   describe "#to_html" do
     subject(:to_html) { entry.to_html }


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/pull/1633/

I noticed I'd left the active-record relationship cables on the `Journal::Entry` loose. Getting rid of `delegate`s in favor of the `has_one :x, through: :y`