### PR TITLE
🧹 `Journal`: Move `Entry` rendering to `EntryComponent`

### DIFF
--- a/app/furniture/journal/entries/show.html.erb
+++ b/app/furniture/journal/entries/show.html.erb
@@ -1,2 +1,2 @@
 <%- breadcrumb :journal_entry, entry %>
-<%= render entry %>
+<%= render Journal::EntryComponent.new(entry: entry) %>

--- a/app/furniture/journal/entry.rb
+++ b/app/furniture/journal/entry.rb
@@ -3,7 +3,6 @@ class Journal
     location(parent: :journal)
 
     self.table_name = "journal_entries"
-    include RendersMarkdown
     extend StripsNamespaceFromModelName
 
     scope :recent, -> { order("published_at DESC NULLS FIRST") }
@@ -36,21 +35,6 @@ class Journal
 
     def published?
       published_at.present?
-    end
-
-    def to_html
-      render_markdown(body)
-    end
-
-    def self.renderer
-      @_renderer ||= Redcarpet::Markdown.new(
-        Renderer.new(filter_html: true, with_toc_data: true),
-        autolink: true, strikethrough: true,
-        no_intra_emphasis: true,
-        lax_spacing: true,
-        fenced_code_blocks: true, disable_indented_code_blocks: true,
-        tables: true, footnotes: true, superscript: true, quote: true
-      )
     end
 
     def extract_keywords

--- a/app/furniture/journal/entry_component.html.erb
+++ b/app/furniture/journal/entry_component.html.erb
@@ -2,14 +2,14 @@
   <header class="border-b border-primary-500">
     <h2 class=" text-primary-900"><%= entry.headline %></h2>
     <%- if entry.published?%>
-      <em>Published on <%= link_to entry.published_at.to_fs(:long_ordinal), entry.location %></em>
+      <em>Published on <%= link_to published_at, entry.location %></em>
     <%- else %>
       <em>Unpublished.</em>
     <%- end %>
   </header>
 
   <div class="prose">
-    <%= entry.to_html.html_safe %>
+    <%== body_html %>
   </div>
 
   <footer class="flex justify-between my-2">

--- a/app/furniture/journal/entry_component.rb
+++ b/app/furniture/journal/entry_component.rb
@@ -1,0 +1,30 @@
+class Journal
+  class EntryComponent < ApplicationComponent
+    include RendersMarkdown
+    attr_accessor :entry
+
+    def initialize(*args, entry:, **kwargs)
+      self.entry = entry
+      super(*args, **kwargs)
+    end
+
+    def body_html
+      render_markdown(entry.body)
+    end
+
+    def published_at
+      entry.published_at.to_fs(:long_ordinal)
+    end
+
+    def self.renderer
+      @_renderer ||= Redcarpet::Markdown.new(
+        Renderer.new(filter_html: true, with_toc_data: true),
+        autolink: true, strikethrough: true,
+        no_intra_emphasis: true,
+        lax_spacing: true,
+        fenced_code_blocks: true, disable_indented_code_blocks: true,
+        tables: true, footnotes: true, superscript: true, quote: true
+      )
+    end
+  end
+end

--- a/app/furniture/journal/journals/_journal.html.erb
+++ b/app/furniture/journal/journals/_journal.html.erb
@@ -7,9 +7,9 @@
   <%- end %>
 
   <div class="flex flex-wrap">
-    <%- @pagy, @records = pagy(policy_scope(journal.entries.recent)) %>
+    <%- @pagy, @entries = pagy(policy_scope(journal.entries.recent)) %>
 
-    <%= render @records %>
+    <%= render Journal::EntryComponent.with_collection(@entries) %>
   </div>
 
   <%== pagy_nav(@pagy, nav_extra: 'flex justify-between') %>

--- a/spec/furniture/journal/entry_component_spec.rb
+++ b/spec/furniture/journal/entry_component_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.describe Journal::EntryComponent, type: :component do
+  subject(:output) { render_inline(component) }
+
+  let(:component) { described_class.new(entry: entry) }
+  let(:entry) { create(:journal_entry, body: "https://www.google.com @zee@weirder.earth #GoodTimes") }
+
+  it { is_expected.to have_link("https://www.google.com", href: "https://www.google.com") }
+end

--- a/spec/furniture/journal/entry_spec.rb
+++ b/spec/furniture/journal/entry_spec.rb
@@ -10,16 +10,6 @@ RSpec.describe Journal::Entry, type: :model do
   it { is_expected.to have_one(:room).through(:journal) }
   it { is_expected.to have_one(:space).through(:journal) }
 
-  describe "#to_html" do
-    subject(:to_html) { entry.to_html }
-
-    context "when #body is 'https://www.google.com @zee@weirder.earth'" do
-      let(:entry) { build(:journal_entry, body: "https://www.google.com @zee@weirder.earth") }
-
-      it { is_expected.to include('<a href="https://www.google.com">https://www.google.com</a>') }
-    end
-  end
-
   describe "#save" do
     let(:entry) { create(:journal_entry, body: "#GoodTimes") }
     let(:journal) { entry.journal }


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1566

This refactor allows us to do post-processing of the markdown at the Component level, which has access to the rails URL builders; which should allow us to link to the `Keyword` within the `Entry#body`
