### PR TITLE
🧹 `Journal`: `Entries` store their `Keywords`

### DIFF
--- a/app/furniture/journal/entry.rb
+++ b/app/furniture/journal/entry.rb
@@ -30,7 +30,7 @@ class Journal
     belongs_to :journal, inverse_of: :entries
     has_one :room, through: :journal
     has_one :space, through: :journal
-    after_save :extract_keywords, if: :saved_change_to_body?
+    before_save :extract_keywords, if: :will_save_change_to_body?
 
     def published?
       published_at.present?
@@ -52,7 +52,7 @@ class Journal
     end
 
     def extract_keywords
-      journal.keywords.extract_and_create_from!(body)
+      self.keywords = journal.keywords.extract_and_create_from!(body).pluck(:canonical_keyword)
     end
 
     def to_param

--- a/app/furniture/journal/keyword.rb
+++ b/app/furniture/journal/keyword.rb
@@ -7,9 +7,11 @@ class Journal
     belongs_to :journal, inverse_of: :keywords
 
     def self.extract_and_create_from!(body)
-      body.scan(/#(\w+)/)&.flatten&.each do |keyword|
-        next if where(":aliases = ANY (aliases)", aliases: keyword)
-          .or(where(canonical_keyword: keyword)).exists?
+      body.scan(/#(\w+)/)&.flatten&.map do |keyword|
+        existing_keyword = where(":aliases = ANY (aliases)", aliases: keyword)
+          .or(where(canonical_keyword: keyword)).first
+
+        next existing_keyword if existing_keyword.present?
 
         find_or_create_by!(canonical_keyword: keyword)
       end

--- a/db/migrate/20230713230334_journal_add_keywords_to_entries.rb
+++ b/db/migrate/20230713230334_journal_add_keywords_to_entries.rb
@@ -1,0 +1,5 @@
+class JournalAddKeywordsToEntries < ActiveRecord::Migration[7.0]
+  def change
+    add_column :journal_entries, :keywords, :string, array: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_06_003709) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_13_230334) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -114,6 +114,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_06_003709) do
     t.datetime "published_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "keywords", array: true
     t.index ["journal_id"], name: "index_journal_entries_on_journal_id"
   end
 

--- a/spec/factories/furniture/journal.rb
+++ b/spec/factories/furniture/journal.rb
@@ -9,4 +9,8 @@ FactoryBot.define do
     body { 5.times.map { headline }.join("\n") }
     journal
   end
+
+  factory :journal_keyword, class: "Journal::Keyword" do
+    journal
+  end
 end

--- a/spec/furniture/journal/entry_spec.rb
+++ b/spec/furniture/journal/entry_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Journal::Entry, type: :model do
     let(:journal) { entry.journal }
 
     context "when the body is changing" do
-      it "idempotently creates `Keywords` in the `Journal`" do
+      it "idempotently creates `Keywords` in the `Journal` and `Entry`" do
         bad_apple = entry.journal.keywords.create!(canonical_keyword: "BadApple", aliases: ["BadApples"])
         good_times = entry.journal.keywords.find_by!(canonical_keyword: "GoodTimes")
         expect do
@@ -35,6 +35,7 @@ RSpec.describe Journal::Entry, type: :model do
         expect(journal.keywords.where(canonical_keyword: "GoodTimes")).to exist
         expect(journal.keywords.where(canonical_keyword: "HardCider")).to exist
         expect(journal.keywords.where(canonical_keyword: "BadApples")).not_to exist
+        expect(entry.reload.keywords).to eq(["GoodTimes", "HardCider", "BadApple"])
       end
     end
   end

--- a/spec/furniture/journal/keyword_spec.rb
+++ b/spec/furniture/journal/keyword_spec.rb
@@ -6,4 +6,18 @@ RSpec.describe Journal::Keyword, type: :model do
   it { is_expected.to validate_presence_of(:canonical_keyword) }
   it { is_expected.to validate_uniqueness_of(:canonical_keyword).case_insensitive.scoped_to(:journal_id) }
   it { is_expected.to belong_to(:journal).inverse_of(:keywords) }
+
+  describe ".search" do
+    it "returns the `Keywords` that match either canonicaly or via aliases" do
+      dog = create(:journal_keyword, canonical_keyword: "Dog", aliases: ["doggo"])
+      cat = create(:journal_keyword, canonical_keyword: "Cat", aliases: ["meower"])
+
+      expect(described_class.search("Doggo")).to include(dog)
+      expect(described_class.search("Dog")).to include(dog)
+      expect(described_class.search("Cat")).to include(cat)
+      expect(described_class.search("Meower")).to include(cat)
+      expect(described_class.search("Meower", "Dog")).to include(cat)
+      expect(described_class.search("Meower", "Dog")).to include(dog)
+    end
+  end
 end


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1662
- https://github.com/zinc-collective/convene/issues/1566

This gets us a little bit closer to being able to browse `Entry` by `Keyword`s, since each `Entry` will know it's keywords