### PR TITLE
🥗🧹 `Journal`: `Entry` stores each `Keyword` it uses only once.

### DIFF
--- a/app/furniture/journal/entry.rb
+++ b/app/furniture/journal/entry.rb
@@ -55,6 +55,10 @@ class Journal
       self.keywords = journal.keywords.extract_and_create_from!(body).pluck(:canonical_keyword)
     end
 
+    def keywords=(keywords)
+      super(keywords.uniq)
+    end
+
     def to_param
       slug
     end

--- a/spec/furniture/journal/entry_spec.rb
+++ b/spec/furniture/journal/entry_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Journal::Entry, type: :model do
         bad_apple = entry.journal.keywords.create!(canonical_keyword: "BadApple", aliases: ["BadApples"])
         good_times = entry.journal.keywords.find_by!(canonical_keyword: "GoodTimes")
         expect do
-          entry.update!(body: "#GoodTimes #HardCider #BadApples")
+          entry.update!(body: "#GoodTimes #HardCider #BadApple #BadApples")
         end.not_to change { "#{bad_apple.reload.updated_at} - #{good_times.reload.updated_at}" }
 
         expect(journal.keywords.where(canonical_keyword: "GoodTimes")).to exist


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1566
- https://github.com/zinc-collective/convene/issues/1662

Turns out we were storing the keyword every time it was used; which... isn't bad but isn't great either!