### PR TITLE
🥗 `Marketplace`: Buying `Products` as a `Guest` System Test

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,4 @@ EMAIL_DEFAULT_FROM='Neighborhood Support <set-this-to-your-email@example.com>'
 LOCKBOX_MASTER_KEY=0000000000000000000000000000000000000000000000000000000000000000
 
 OPERATOR_API_KEY=a-secret-that-should-get-changed
+DEFAULT_STRIPE_API_KEY=get-this-from-your-stripe-account

--- a/.env.example
+++ b/.env.example
@@ -28,4 +28,4 @@ EMAIL_DEFAULT_FROM='Neighborhood Support <set-this-to-your-email@example.com>'
 LOCKBOX_MASTER_KEY=0000000000000000000000000000000000000000000000000000000000000000
 
 OPERATOR_API_KEY=a-secret-that-should-get-changed
-DEFAULT_STRIPE_API_KEY=get-this-from-your-stripe-account
+STRIPE_API_KEY=get-this-from-your-stripe-account

--- a/.github/workflows/test-convene-web.yml
+++ b/.github/workflows/test-convene-web.yml
@@ -119,6 +119,13 @@ jobs:
       - name: Setup rails
         run: bin/setup-rails && bin/rails assets:precompile
 
+      - name: Install stripe cli
+        run: |
+          curl -s https://packages.stripe.dev/api/security/keypair/stripe-cli-gpg/public | gpg --dearmor | sudo tee /usr/share/keyrings/stripe.gpg
+          echo "deb [signed-by=/usr/share/keyrings/stripe.gpg] https://packages.stripe.dev/stripe-cli-debian-local stable main" | sudo tee -a /etc/apt/sources.list.d/stripe.list
+          sudo apt update
+          sudo apt install stripe
+
       - name: Run Tests
         env:
           HEADLESS: true

--- a/.github/workflows/test-convene-web.yml
+++ b/.github/workflows/test-convene-web.yml
@@ -14,7 +14,7 @@ env:
   AWS_S3_ACCESS_KEY_ID: ${{ secrets.AWS_S3_ACCESS_KEY_ID }}
   AWS_S3_SECRET_ACCESS_KEY: ${{ secrets.AWS_S3_SECRET_ACCESS_KEY }}
   AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
-  DEFAULT_STRIPE_API_KEY: ${{ secrets.DEFAULT_STRIPE_API_KEY }}
+  STRIPE_API_KEY: ${{ secrets.DEFAULT_STRIPE_API_KEY }}
 
 jobs:
   setup:

--- a/.github/workflows/test-convene-web.yml
+++ b/.github/workflows/test-convene-web.yml
@@ -14,6 +14,7 @@ env:
   AWS_S3_ACCESS_KEY_ID: ${{ secrets.AWS_S3_ACCESS_KEY_ID }}
   AWS_S3_SECRET_ACCESS_KEY: ${{ secrets.AWS_S3_SECRET_ACCESS_KEY }}
   AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+  DEFAULT_STRIPE_API_KEY: ${{ secrets.DEFAULT_STRIPE_API_KEY }}
 
 jobs:
   setup:

--- a/spec/factories/utility.rb
+++ b/spec/factories/utility.rb
@@ -8,6 +8,6 @@ FactoryBot.define do
 
   factory :stripe_utility do
     utility_slug { "stripe" }
-    api_token { ENV.fetch("DEFAULT_STRIPE_API_KEY", "not_real") }
+    api_token { ENV.fetch("STRIPE_API_KEY", "not_real") }
   end
 end

--- a/spec/factories/utility.rb
+++ b/spec/factories/utility.rb
@@ -8,6 +8,6 @@ FactoryBot.define do
 
   factory :stripe_utility do
     utility_slug { "stripe" }
-    api_token { "not_real" }
+    api_token { ENV.fetch("DEFAULT_STRIPE_API_KEY", "not_real") }
   end
 end

--- a/spec/furniture/marketplace/buying_products_system_spec.rb
+++ b/spec/furniture/marketplace/buying_products_system_spec.rb
@@ -76,9 +76,13 @@ describe "Marketplace: Buying Products", type: :system do
         thread.join
       end
     end
-    raise "Can't connect to Stripe using command `#{command}`" if waiting > 5
 
-    sleep(1) until signing_secret
+    until signing_secret
+      raise "Can't connect to Stripe using command `#{command}`" if waiting > 5
+      waiting += 1
+      sleep(1)
+    end
+
     yield(signing_secret)
     thread.kill
   end

--- a/spec/furniture/marketplace/buying_products_system_spec.rb
+++ b/spec/furniture/marketplace/buying_products_system_spec.rb
@@ -78,7 +78,7 @@ describe "Marketplace: Buying Products", type: :system do
     end
 
     until signing_secret
-      raise "Can't connect to Stripe using command `#{command}`" if waiting > 5
+      raise "Can't connect to Stripe!" if waiting > 5
       waiting += 1
       sleep(1)
     end

--- a/spec/furniture/marketplace/buying_products_system_spec.rb
+++ b/spec/furniture/marketplace/buying_products_system_spec.rb
@@ -64,7 +64,7 @@ describe "Marketplace: Buying Products", type: :system do
     waiting = 0
     command = "stripe listen --api-key #{ENV.fetch("DEFAULT_STRIPE_API_KEY")} --forward-to #{listen_url}"
     thread = Thread.new do
-      Open3.popen3(command) do |stdin, stdout, stderr, thread|
+      Open3.popen3(command) do |_, stdout, stderr, thread|
         # read each stream from a new thread
         {out: stdout, err: stderr}.each do |key, stream|
           Thread.new do

--- a/spec/furniture/marketplace/buying_products_system_spec.rb
+++ b/spec/furniture/marketplace/buying_products_system_spec.rb
@@ -1,0 +1,82 @@
+require "rails_helper"
+require "money-rails/helpers/action_view_extension"
+
+# @see https://github.com/zinc-collective/convene/issues/1326
+describe "Marketplace: Buying Products", type: :system do
+  include MoneyRails::ActionViewExtension
+
+  let(:space) { create(:space, :with_entrance, :with_members) }
+  let(:marketplace) { create(:marketplace, :ready_for_shopping, room: space.entrance) }
+
+  around do |ex|
+    with_stripe(listen_url: polymorphic_url(marketplace.location(child: :stripe_events))) do |webhook_signing_secret|
+      marketplace.update(stripe_webhook_endpoint_secret: webhook_signing_secret)
+      ex.run
+    end
+  end
+
+  it "Works for Guests" do
+    visit(polymorphic_path(marketplace.room.location))
+    set_delivery_details(delivery_address: "123 N West St Oakland, CA",
+      delivery_area: marketplace.delivery_areas.first,
+      contact_phone_number: "1234567890")
+
+    add_product_to_cart(marketplace.products.first)
+
+    expect(page).to have_content("Total: #{humanized_money_with_symbol(marketplace.products.first.price + marketplace.delivery_areas.first.price)}")
+
+    click_link_or_button("Checkout")
+    pay(card_number: "4242424242424242", card_expiry: "1240", card_cvc: "123", billing_name: "Ahsoka Tano", email: "AhsokaTano@example.com", billing_postal_code: "12345")
+
+    expect(page).to have_content("Order History", wait: 30)
+    expect(page).to have_content("123 N West St Oakland, CA")
+  end
+
+  def add_product_to_cart(product)
+    within("##{dom_id(product).gsub("product", "cart_product")}") do
+      click_link_or_button(t("marketplace.cart_product_component.add"))
+    end
+  end
+
+  def set_delivery_details(delivery_address:, delivery_area:, contact_phone_number:)
+    click_link_or_button("Add delivery details to checkout")
+    fill_in("Delivery address", with: delivery_address)
+    select(delivery_area.label, from: "Delivery area")
+    fill_in("Contact phone number", with: "1234567890")
+    fill_in("Contact email", with: "hello@example.com")
+    click_link_or_button("Save changes")
+  end
+
+  def pay(card_number:, card_expiry:, card_cvc:, billing_name:, email:, billing_postal_code:)
+    fill_in("cardNumber", with: card_number)
+    fill_in("cardExpiry", with: card_expiry)
+    fill_in("cardCvc", with: card_cvc)
+    fill_in("billingName", with: billing_name)
+    fill_in("email", with: email)
+    fill_in("billingPostalCode", with: billing_postal_code)
+
+    find("label[for='enableStripePass']").click
+    find("*[data-testid='hosted-payment-submit-button']").click
+  end
+
+  def with_stripe(listen_url:, &block)
+    signing_secret = nil
+    thread = Thread.new do
+      Open3.popen3("stripe listen --forward-to #{listen_url}") do |stdin, stdout, stderr, thread|
+        # read each stream from a new thread
+        {out: stdout, err: stderr}.each do |key, stream|
+          Thread.new do
+            until (raw_line = stream.gets).nil?
+              signing_secret = raw_line[/whsec_\w+/] if raw_line.include?("webhook")
+            end
+          end
+        end
+        thread.join
+      end
+    end
+    sleep(1) until signing_secret
+
+    yield(signing_secret)
+    thread.kill
+  end
+end

--- a/spec/furniture/marketplace/checkouts_controller_request_spec.rb
+++ b/spec/furniture/marketplace/checkouts_controller_request_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Marketplace::Checkout, type: :request do
         perform_request
         expect(Stripe::Checkout::Session).to have_received(:create).with(
           hash_including(mode: "payment", customer_email: cart.contact_email),
-          {api_key: "not_real"}
+          {api_key: marketplace.stripe_api_key}
         )
       end
     end

--- a/spec/support/stripe_cli.rb
+++ b/spec/support/stripe_cli.rb
@@ -1,0 +1,36 @@
+module Spec
+  class StripeCLI
+    module Helpers
+      # Launches `stripe listen` with the provided url in a background thread,
+      # waits up to 5 seconds for the webhook signing secret to be assigned,
+      # then yields the secret to the passed in block.
+      def stripe_listen(forward_to:, api_key: ENV.fetch("STRIPE_API_KEY"), &block)
+        signing_secret = nil
+        waiting = 0
+        command = "stripe listen --api-key #{api_key} --forward-to #{forward_to}"
+        thread = Thread.new do
+          Open3.popen3(command) do |_, stdout, stderr, thread|
+            # read each stream from a new thread
+            [stdout, stderr].each do |stream|
+              Thread.new do
+                until (raw_line = stream.gets).nil?
+                  signing_secret = raw_line[/whsec_\w+/] if raw_line.include?("webhook")
+                end
+              end
+            end
+            thread.join
+          end
+        end
+
+        until signing_secret
+          raise "Can't connect to Stripe!" if waiting > 5
+          waiting += 1
+          sleep(1)
+        end
+
+        yield(signing_secret)
+        thread.kill
+      end
+    end
+  end
+end

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -1,0 +1,27 @@
+module Spec
+  module SystemHelpers
+    def sign_in(user, space)
+      visit(polymorphic_path(space.location))
+      click_link_or_button("Sign in")
+      fill_in("authenticated_session[contact_location]", with: user.email)
+      find('input[type="submit"]').click
+      perform_enqueued_jobs
+      delivery = ActionMailer::Base.deliveries.first
+      return sign_in(user, space) unless delivery
+      visit(URI.parse(URI.extract(delivery.body.to_s)[1]).request_uri)
+    end
+
+    def dom_id(*args, **kwargs)
+      ActionView::RecordIdentifier.dom_id(*args, **kwargs)
+    end
+
+    def t(*args, **kwargs)
+      I18n.t(*args, **kwargs)
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include(ActiveJob::TestHelper, type: :system)
+  config.include(Spec::SystemHelpers, type: :system)
+end

--- a/spec/system/furniture_spec.rb
+++ b/spec/system/furniture_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 # @see https://github.com/zinc-collective/convene/issues/709
 describe "Furniture" do
-  include ActiveJob::TestHelper
   it "Managing Furniture" do
     space = create(:space, :with_entrance, :with_members, member_count: 1)
     sign_in(space.members.first, space)
@@ -14,16 +13,6 @@ describe "Furniture" do
     expect(page).to have_text("No gizmos yet.")
   end
 
-  def sign_in(user, space)
-    visit(polymorphic_path(space.location))
-    click_link_or_button("Sign in")
-    fill_in("authenticated_session[contact_location]", with: user.email)
-    find('input[type="submit"]').click
-    perform_enqueued_jobs
-
-    visit(URI.parse(URI.extract(ActionMailer::Base.deliveries.first.body.to_s)[1]).request_uri)
-  end
-
   def add_gizmo(type, room:)
     visit(polymorphic_path(room.location(:edit)))
     select(type, from: "Type of gizmo")
@@ -33,7 +22,7 @@ describe "Furniture" do
   def remove_gizmo(type, room:)
     visit(polymorphic_path(room.location(:edit)))
     expect(page).to have_text("Markdown Text Block")
-    within("##{ActionView::RecordIdentifier.dom_id(room.gizmos.first)}") do
+    within("##{dom_id(room.gizmos.first)}") do
       click_link_or_button "Configure Markdown Text Block"
     end
     click_link_or_button "Remove Gizmo"


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1326

The bug is fixed in https://github.com/zinc-collective/convene/pull/1685

For grokability reasons, I am considering splitting this into a few different PRs:

- A introduces the new ENV variable
- B extracts the shared system spec helpers
- C implements the stripe cli forwarding
- D implements the system test 
