### PR TITLE
🌸✨ `Marketplace`: `Management` includes ` Payment Settings` screen

### DIFF
--- a/app/components/marketplace/stripe_overview_component.rb
+++ b/app/components/marketplace/stripe_overview_component.rb
@@ -1,7 +1,7 @@
 # Renders a tile with a link to view the Marketplace Stripe account page
 class Marketplace::StripeOverviewComponent < ApplicationComponent
   attr_accessor :marketplace
-  attr_accessor :marketplace_stripe_utility
+  delegate :stripe_utility, to: :marketplace, prefix: true
 
   def initialize(marketplace:, **kwargs)
     super(**kwargs)

--- a/app/components/marketplace/stripe_overview_component.rb
+++ b/app/components/marketplace/stripe_overview_component.rb
@@ -1,0 +1,12 @@
+# Renders a tile with a link to view the Marketplace Stripe account page
+class Marketplace::StripeOverviewComponent < ApplicationComponent
+  attr_accessor :marketplace
+  attr_accessor :marketplace_stripe_utility
+
+  def initialize(marketplace:, **kwargs)
+    super(**kwargs)
+
+    @marketplace = marketplace
+    @marketplace_stripe_utility = marketplace.stripe_utility
+  end
+end

--- a/app/components/marketplace/stripe_overview_component/stripe_overview_component.html.erb
+++ b/app/components/marketplace/stripe_overview_component/stripe_overview_component.html.erb
@@ -1,0 +1,14 @@
+<%= render CardComponent.new(classes: "flex flex-col h-full
+") do %>
+  <header class="flex font-bold">
+    <%= marketplace_stripe_utility.name %>
+  </header>
+  <footer class="flex flex-row justify-between mt-3">
+    <%= render ButtonComponent.new(
+      label: "View #{t('marketplace.stripe_accounts.show.link_to')}",
+      title: t('marketplace.stripe_accounts.show.link_to'),
+      href: marketplace.location(:index, child: :stripe_account),
+      method: :get,
+      scheme: :secondary) %>
+  </footer>
+<%- end %>

--- a/app/furniture/marketplace/breadcrumbs.rb
+++ b/app/furniture/marketplace/breadcrumbs.rb
@@ -108,3 +108,8 @@ crumb :edit_tax_rate do |tax_rate|
   parent :marketplace_tax_rates, tax_rate.marketplace
   link "Edit Tax Rate '#{tax_rate.label}'", marketplace.location(:new, child: :tax_rate)
 end
+
+crumb :payment_settings do |marketplace|
+  parent :edit_marketplace, marketplace
+  link "Manage Payment Settings", marketplace.location(:index, child: :payment_settings)
+end

--- a/app/furniture/marketplace/locales/en.yml
+++ b/app/furniture/marketplace/locales/en.yml
@@ -115,3 +115,6 @@ en:
     cart_product_component:
       remove: Remove from Cart
       add: Add to Cart
+    payment_settings:
+      index:
+        link_to: "Payment Settings"

--- a/app/furniture/marketplace/management_component.html.erb
+++ b/app/furniture/marketplace/management_component.html.erb
@@ -12,7 +12,7 @@
     <%= content %>
     <% card.with_footer do %>
       <nav class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3">
-        <%= render button({child: :stripe_account}, icon: :money) if policy(marketplace).edit? %>
+        <%= render button({child: :payment_settings}, icon: :money) if policy(marketplace).edit? %>
         <%= render button({child: :products}, icon: :tag)  if policy(marketplace.products).index? %>
         <%= render button({child: :delivery_areas}, icon: :map)  if policy(marketplace.delivery_areas).index? %>
         <%= render button({child: :tax_rates}, icon: :receipt_percent)  if policy(marketplace.tax_rates).index? %>

--- a/app/furniture/marketplace/marketplace.rb
+++ b/app/furniture/marketplace/marketplace.rb
@@ -41,9 +41,13 @@ class Marketplace
       products.present? && stripe_api_key? && delivery_areas.present? && stripe_account_connected?
     end
 
+    def stripe_utility
+      space.utilities.find_by!(utility_slug: :stripe).utility
+    end
+
     # The Secret Stripe API key belonging to the owner of the Marketplace
     def stripe_api_key
-      space.utilities.find_by!(utility_slug: :stripe).utility.api_token
+      stripe_utility.api_token
     end
 
     def stripe_api_key?

--- a/app/furniture/marketplace/marketplace.rb
+++ b/app/furniture/marketplace/marketplace.rb
@@ -42,7 +42,7 @@ class Marketplace
     end
 
     def stripe_utility
-      space.utilities.find_by!(utility_slug: :stripe).utility
+      @stripe_utility ||= space.utilities.find_by!(utility_slug: :stripe).utility
     end
 
     # The Secret Stripe API key belonging to the owner of the Marketplace

--- a/app/furniture/marketplace/payment_settings/index.html.erb
+++ b/app/furniture/marketplace/payment_settings/index.html.erb
@@ -1,0 +1,24 @@
+<%- breadcrumb :payment_settings, marketplace %>
+<%= render Marketplace::ManagementComponent.new(marketplace: marketplace) do %>
+  <h1>Payment Settings</h1>
+  <main>
+    <div class="grid grid-cols-1 gap-3 sm:gap-5 sm:grid-cols-3">
+      <%= render Marketplace::StripeOverviewComponent.new(marketplace: marketplace) %>
+      <%= render CardComponent.new(classes: "flex flex-col h-full") do %>
+        <header class="flex font-bold">
+          Did we miss something?
+        </header>
+        <div class="grow flex flex-col justify-between">
+          Let us know about other payment service options that will help your marketplace to thrive.
+        </div>
+        <footer class="flex flex-row justify-between mt-3">
+          <%= render ButtonComponent.new(
+            label: "Contact Us",
+            title: "Contact Us",
+            href: "mailto:#{ApplicationMailer::DEFAULT_FROM}",
+            scheme: :secondary) %>
+        </footer>
+      <% end %>
+    </div>
+  </main>
+<% end %>

--- a/app/furniture/marketplace/payment_settings_controller.rb
+++ b/app/furniture/marketplace/payment_settings_controller.rb
@@ -1,0 +1,11 @@
+class Marketplace
+  class PaymentSettingsController < FurnitureController
+    def index
+      authorize(marketplace, :edit?)
+    end
+
+    helper_method def marketplace
+      @marketplace ||= policy_scope(Marketplace).find(params[:marketplace_id])
+    end
+  end
+end

--- a/app/furniture/marketplace/routes.rb
+++ b/app/furniture/marketplace/routes.rb
@@ -16,6 +16,7 @@ class Marketplace
         router.resource :stripe_account, only: [:show, :new, :create]
         router.resources :stripe_events
         router.resources :tax_rates
+        router.resources :payment_settings, only: [:index]
       end
     end
   end

--- a/spec/components/marketplace/stripe_overview_component_spec.rb
+++ b/spec/components/marketplace/stripe_overview_component_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Marketplace::StripeOverviewComponent, type: :component do
+  pending "add some examples to (or delete) #{__FILE__}"
+
+  # it "renders something useful" do
+  #   expect(
+  #     render_inline(described_class.new(attr: "value")) { "Hello, components!" }.css("p").to_html
+  #   ).to include(
+  #     "Hello, components!"
+  #   )
+  # end
+end

--- a/spec/components/previews/marketplace/stripe_overview_component_preview.rb
+++ b/spec/components/previews/marketplace/stripe_overview_component_preview.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Marketplace::StripeOverviewComponentPreview < ViewComponent::Preview
+  def default
+    render(Marketplace::StripeOverviewComponent.new)
+  end
+end


### PR DESCRIPTION
This changeset is more the result of developer onboarding (for me) as I prototyped (in code) consolidating configuration for payment related things. This is merely a piece of a partial solve for requirements of https://github.com/zinc-collective/convene/discussions/1605 or https://github.com/zinc-collective/convene/discussions/1622. But was invaluable to help me understand _how to frontend_ in the Marketplace domain. I think this is going to be a boon for my 🍐 session with @KellyAH next week. 

### Notable details: 
- The CardComponent styling refactor does force automatically bottom-aligned CTAs. 

After: 
![image](https://github.com/zinc-collective/convene/assets/5185/401de5d4-e3be-4b79-aa45-abd624acce72)
<img width="1168" alt="image" src="https://github.com/zinc-collective/convene/assets/5185/820c03b6-25fa-401e-8690-e8712d224cc0">
