### PR TITLE
🐞🔨 `Marketplace`: `Guest` may see recent `Order`s

### DIFF
--- a/app/furniture/marketplace/order_policy.rb
+++ b/app/furniture/marketplace/order_policy.rb
@@ -6,8 +6,13 @@ class Marketplace
       def resolve
         return scope.all if person.operator?
 
-        scope.joins(marketplace: [:room]).where(rooms: {space_id: person.spaces})
-          .or(scope.where(shopper: Shopper.where(person: person)))
+        if person.authenticated?
+          scope.where(rooms: {space_id: person.spaces})
+            .or(scope.where(shopper: Shopper.where(person: person)))
+        else
+          scope.where(shopper: Shopper.where(person: nil))
+            .where("marketplace_orders.created_at > ?", 1.week.ago)
+        end.joins(marketplace: [:room])
       end
     end
   end

--- a/spec/furniture/marketplace/order_policy_spec.rb
+++ b/spec/furniture/marketplace/order_policy_spec.rb
@@ -52,8 +52,12 @@ RSpec.describe Marketplace::OrderPolicy, type: :policy do
 
     context "when a guest" do
       let(:actor) { guest }
+      let!(:old_guest_order) do
+        create(:marketplace_order, marketplace: marketplace, shopper: create(:marketplace_shopper), created_at: 2.weeks.ago)
+      end
 
-      it { is_expected.to be_empty }
+      it { is_expected.to contain_exactly(guest_order) }
+      it { is_expected.not_to include(old_guest_order) }
     end
 
     context "when a member of the space" do

--- a/spec/furniture/marketplace/orders_controller_request_spec.rb
+++ b/spec/furniture/marketplace/orders_controller_request_spec.rb
@@ -24,8 +24,9 @@ RSpec.describe Marketplace::OrdersController, type: :request do
     end
 
     context "when the order is not viewable by the current person" do
+      before { sign_in(space, create(:person)) }
+
       specify { expect { perform_request }.to raise_error(ActiveRecord::RecordNotFound) }
-      # it { is_expected.to be_not_found}
     end
   end
 end


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1657
- Alternative to https://github.com/zinc-collective/convene/pull/1688

This allows `Orders` placed by `Guests` to be seen by any `Guest` for 1 week; after which they will 404.

There's probably something smerter to do around the `Marketplace::Policy` to use the `Shopper`, which *is* both present and persisted in all cases...