### PR TITLE
Removes unused instance variable in `AuthenticatedSessionMailer`

### DIFF
--- a/app/mailers/authenticated_session_mailer.rb
+++ b/app/mailers/authenticated_session_mailer.rb
@@ -1,7 +1,6 @@
 class AuthenticatedSessionMailer < ApplicationMailer
-  def one_time_password_email(authentication_method, space)
+  def one_time_password_email(authentication_method)
     @authentication_method = authentication_method
-    @space = space
     mail(to: authentication_method.contact_location, subject: "Your One Time Password")
   end
 end

--- a/app/models/authentication_method.rb
+++ b/app/models/authentication_method.rb
@@ -58,7 +58,7 @@ class AuthenticationMethod < ApplicationRecord
 
   def send_one_time_password!(space)
     bump_one_time_password!
-    AuthenticatedSessionMailer.one_time_password_email(self, space).deliver_later
+    AuthenticatedSessionMailer.one_time_password_email(self).deliver_later
   end
 
   def confirm!


### PR DESCRIPTION
Was I correct in noticing this instance var is unused (and not implicitly used anywhere magically 😅)? 