### PR TITLE
🐞🔨 `Marketplace`: `Guest` can see only their `Orders`

### DIFF
--- a/app/furniture/marketplace/order_policy.rb
+++ b/app/furniture/marketplace/order_policy.rb
@@ -2,12 +2,20 @@
 
 class Marketplace
   class OrderPolicy < Policy
-    class Scope < ApplicationScope
-      def resolve
-        return scope.all if person.operator?
+    class Scope
+      attr_accessor :scope, :shopper
+      delegate :person, to: :shopper
 
-        scope.joins(marketplace: [:room]).where(rooms: {space_id: person.spaces})
-          .or(scope.where(shopper: Shopper.where(person: person)))
+      def initialize(shopper, scope)
+        self.scope = scope
+        self.shopper = shopper
+      end
+
+      def resolve
+        return scope.all if person&.operator?
+
+        scope.joins(marketplace: [:room]).where(rooms: {space_id: person&.spaces})
+          .or(scope.where(shopper: shopper))
       end
     end
   end

--- a/app/furniture/marketplace/orders_controller.rb
+++ b/app/furniture/marketplace/orders_controller.rb
@@ -1,7 +1,7 @@
 class Marketplace
   class OrdersController < Controller
     expose :order, scope: -> { orders }, model: Order
-    expose :orders, -> { policy_scope(marketplace.orders).order(created_at: :desc) }
+    expose :orders, -> { OrderPolicy::Scope.new(shopper, marketplace.orders).resolve.order(created_at: :desc) }
 
     def show
       authorize(order)

--- a/spec/furniture/marketplace/order_policy_spec.rb
+++ b/spec/furniture/marketplace/order_policy_spec.rb
@@ -39,25 +39,30 @@ RSpec.describe Marketplace::OrderPolicy, type: :policy do
     let!(:neighbor_order) { create(:marketplace_order, marketplace: marketplace, shopper: create(:marketplace_shopper, person: neighbor)) }
 
     context "when an operator" do
-      let(:actor) { operator }
+      let(:actor) { create(:marketplace_shopper, person: operator) }
 
       it { is_expected.to contain_exactly(guest_order, neighbor_order) }
     end
 
     context "when the neighbor who placed the order" do
-      let(:actor) { neighbor }
+      let(:actor) { neighbor_order.shopper }
 
       it { is_expected.to contain_exactly(neighbor_order) }
     end
 
     context "when a guest" do
-      let(:actor) { guest }
+      before do
+        # Creates another Guest order to prove we only load their own
+        create(:marketplace_order, marketplace: marketplace, shopper: create(:marketplace_shopper))
+      end
 
-      it { is_expected.to be_empty }
+      let(:actor) { guest_order.shopper }
+
+      it { is_expected.to contain_exactly(guest_order) }
     end
 
     context "when a member of the space" do
-      let(:actor) { member }
+      let(:actor) { create(:marketplace_shopper, person: member) }
 
       it { is_expected.to contain_exactly(guest_order, neighbor_order) }
     end


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1657
- Alternative to https://github.com/zinc-collective/convene/pull/1685

This adjusts the `OrdersController` to use the `Shopper` for the `OrderPolicy::Scope`; which ensures
when `Guests` place an order, only the device used to place the `Order` will be able to see the `Order`

Pros:
- If the `Order` url  is intercepted by a nefarious actor, it won't leak the `Shopper`s information

Cons:
- `Shopper` for `Guests` is device-dependent, so if I order something on my laptop I can't open the `Order` on my phone.

