### PR TITLE
🥗🐞🔨 `Marketplace`: Prevent duplicate `Order::Notification`

### DIFF
--- a/app/furniture/marketplace/stripe_events_controller.rb
+++ b/app/furniture/marketplace/stripe_events_controller.rb
@@ -14,9 +14,9 @@ class Marketplace
       when "checkout.session.completed"
         payment_intent = Stripe::PaymentIntent.retrieve(event.data.object.payment_intent, {api_key: marketplace.stripe_api_key})
 
-        order = Order.find(payment_intent.transfer_group)
+        order = marketplace.orders.find_by(id: payment_intent.transfer_group)
 
-        return if order.paid?
+        return if order.nil? || order.paid?
 
         latest_charge = Stripe::Charge.retrieve(payment_intent.latest_charge, api_key: marketplace.stripe_api_key)
         balance_transaction = Stripe::BalanceTransaction.retrieve(latest_charge.balance_transaction, api_key: marketplace.stripe_api_key)


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1656

Stripe sends every event to every `Stripe::Webhook` listening for it's type; which makes a lot of sense but does not play well with our current design where every Marketplace creates their own `Stripe::Webhook`.

In the short-term, discarding events for orders that do not belong to the given `Marketplace` gets us away from accidental double-mailing (or worse, double-transfering!)