### PR TITLE
🧹 `Marketplace`: Cache the fee amount on the `Order`

### DIFF
--- a/app/furniture/marketplace/order.rb
+++ b/app/furniture/marketplace/order.rb
@@ -22,6 +22,11 @@ class Marketplace
       paid: "paid"
     }
 
+    monetize :payment_processor_fee_cents
+    def vendors_share
+      product_total - payment_processor_fee
+    end
+
     def product_total
       ordered_products.sum(0, &:price_total)
     end

--- a/app/furniture/marketplace/stripe_events_controller.rb
+++ b/app/furniture/marketplace/stripe_events_controller.rb
@@ -21,7 +21,7 @@ class Marketplace
         latest_charge = Stripe::Charge.retrieve(payment_intent.latest_charge, api_key: marketplace.stripe_api_key)
         balance_transaction = Stripe::BalanceTransaction.retrieve(latest_charge.balance_transaction, api_key: marketplace.stripe_api_key)
 
-        order.update(status: :paid, placed_at: DateTime.now)
+        order.update(status: :paid, placed_at: DateTime.now, payment_processor_fee_cents: balance_transaction.fee)
 
         Order::ReceivedMailer.notification(order).deliver_later
         Order::PlacedMailer.notification(order).deliver_later

--- a/db/migrate/20230725192832_marketplace_add_payment_processor_fees_to_order.rb
+++ b/db/migrate/20230725192832_marketplace_add_payment_processor_fees_to_order.rb
@@ -1,0 +1,5 @@
+class MarketplaceAddPaymentProcessorFeesToOrder < ActiveRecord::Migration[7.0]
+  def change
+    add_monetize :marketplace_orders, :payment_processor_fee, null: true, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_13_230334) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_25_192832) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -171,6 +171,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_13_230334) do
     t.string "delivery_notes"
     t.string "contact_email_ciphertext"
     t.uuid "delivery_area_id"
+    t.integer "payment_processor_fee_cents", default: 0, null: false
+    t.string "payment_processor_fee_currency", default: "USD", null: false
     t.index ["delivery_area_id"], name: "index_marketplace_orders_on_delivery_area_id"
     t.index ["marketplace_id"], name: "index_marketplace_orders_on_marketplace_id"
     t.index ["shopper_id"], name: "index_marketplace_orders_on_shopper_id"

--- a/spec/furniture/marketplace/order_spec.rb
+++ b/spec/furniture/marketplace/order_spec.rb
@@ -10,6 +10,14 @@ RSpec.describe Marketplace::Order, type: :model do
   it { is_expected.to belong_to(:shopper).inverse_of(:orders) }
   it { is_expected.to belong_to(:delivery_area).inverse_of(:orders).optional }
 
+  describe "#vendors_share" do
+    subject(:vendors_share) { order.vendors_share }
+
+    let(:order) { build(:marketplace_order, :with_products, payment_processor_fee: 10_00) }
+
+    it { is_expected.to eq(order.product_total - order.payment_processor_fee) }
+  end
+
   describe "#price_total" do
     subject(:price_total) { order.price_total }
 


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1327

In order to pull the splitting of the payment to a retriable background job; we need to cache the payment processor fee information.