### PR TITLE
🥗🥔✨ `Marketplace`: Failed Automatic `Split` payments try again

### DIFF
--- a/app/furniture/marketplace/split_job.rb
+++ b/app/furniture/marketplace/split_job.rb
@@ -9,14 +9,14 @@ class Marketplace
 
     def perform(order:)
       self.order = order
-
+      order.events.create(description: "Payment Split Attempted")
       Stripe::Transfer.create({
         amount: vendors_share,
         currency: "usd",
         destination: vendor_stripe_account,
         transfer_group: order.id
       }, {api_key: stripe_api_key})
-      order.events.create(description: "Payment Split")
+      order.events.create(description: "Payment Split Completed")
     end
   end
 end

--- a/app/furniture/marketplace/split_job.rb
+++ b/app/furniture/marketplace/split_job.rb
@@ -1,0 +1,22 @@
+class Marketplace
+  class SplitJob < ApplicationJob
+    attr_accessor :order
+    delegate :vendors_share, :marketplace, to: :order
+    delegate :stripe_api_key, :vendor_stripe_account, to: :marketplace
+
+    sidekiq_options retry: 5
+    sidekiq_retry_in { |count, exception, jobhash| 1.day }
+
+    def perform(order:)
+      self.order = order
+
+      Stripe::Transfer.create({
+        amount: vendors_share,
+        currency: "usd",
+        destination: vendor_stripe_account,
+        transfer_group: order.id
+      }, {api_key: stripe_api_key})
+      order.events.create(description: "Payment Split")
+    end
+  end
+end

--- a/app/furniture/marketplace/split_job.rb
+++ b/app/furniture/marketplace/split_job.rb
@@ -10,12 +10,19 @@ class Marketplace
     def perform(order:)
       self.order = order
       order.events.create(description: "Payment Split Attempted")
-      Stripe::Transfer.create({
+      if order.stripe_transfer_id.present?
+        order.events.create(description: "Payment Split Detected Existing Transfer")
+        return
+      end
+
+      transfer = Stripe::Transfer.create({
         amount: vendors_share.to_i,
         currency: "usd",
         destination: vendor_stripe_account,
         transfer_group: order.id
       }, {api_key: stripe_api_key})
+
+      order.update(stripe_transfer_id: transfer.id)
       order.events.create(description: "Payment Split Completed")
     end
   end

--- a/app/furniture/marketplace/split_job.rb
+++ b/app/furniture/marketplace/split_job.rb
@@ -11,7 +11,7 @@ class Marketplace
       self.order = order
       order.events.create(description: "Payment Split Attempted")
       Stripe::Transfer.create({
-        amount: vendors_share,
+        amount: vendors_share.to_i,
         currency: "usd",
         destination: vendor_stripe_account,
         transfer_group: order.id

--- a/app/furniture/marketplace/stripe_events_controller.rb
+++ b/app/furniture/marketplace/stripe_events_controller.rb
@@ -29,14 +29,7 @@ class Marketplace
         Order::PlacedMailer.notification(order).deliver_later
         order.events.create(description: "Notification to Buyer Sent")
 
-        Stripe::Transfer.create({
-          # Leave the Stripe Fees in the `Distributor`'s account
-          amount: order.product_total.cents - balance_transaction.fee,
-          currency: "usd",
-          destination: marketplace.vendor_stripe_account,
-          transfer_group: order.id
-        }, {api_key: marketplace.stripe_api_key})
-        order.events.create(description: "Payment Split")
+        SplitJob.perform_later(order: order)
       else
         raise UnexpectedStripeEventTypeError, event.type
       end

--- a/db/migrate/20230814180326_marketplace_add_stripe_transfer_id_to_orders.rb
+++ b/db/migrate/20230814180326_marketplace_add_stripe_transfer_id_to_orders.rb
@@ -1,0 +1,5 @@
+class MarketplaceAddStripeTransferIdToOrders < ActiveRecord::Migration[7.0]
+  def change
+    add_column :marketplace_orders, :stripe_transfer_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_02_232010) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_14_180326) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -183,6 +183,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_02_232010) do
     t.uuid "delivery_area_id"
     t.integer "payment_processor_fee_cents", default: 0, null: false
     t.string "payment_processor_fee_currency", default: "USD", null: false
+    t.string "stripe_transfer_id"
     t.index ["delivery_area_id"], name: "index_marketplace_orders_on_delivery_area_id"
     t.index ["marketplace_id"], name: "index_marketplace_orders_on_marketplace_id"
     t.index ["shopper_id"], name: "index_marketplace_orders_on_shopper_id"

--- a/spec/furniture/marketplace/split_job_spec.rb
+++ b/spec/furniture/marketplace/split_job_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe Marketplace::SplitJob, type: :job do
+  describe "#perform" do
+    before do
+      allow(Stripe::Transfer).to receive(:create)
+    end
+
+    context "when the order has already been split" do
+      let(:order) { create(:marketplace_order, stripe_transfer_id: "st_fake_1234") }
+
+      it "does not create a stripe transfer" do
+        described_class.new.perform(order: order)
+
+        expect(Stripe::Transfer).not_to have_received(:create)
+      end
+    end
+  end
+end

--- a/spec/furniture/marketplace/stripe_events_controller_request_spec.rb
+++ b/spec/furniture/marketplace/stripe_events_controller_request_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe Marketplace::StripeEventsController, type: :request do
       expect(order.payment_processor_fee_cents).to(eq(balance_transaction.fee))
 
       perform_enqueued_jobs(only: Marketplace::SplitJob)
-
-      expect(order.events).to exist(description: "Payment Split")
+      expect(order.events).to exist(description: "Payment Split Attempted")
+      expect(order.events).to exist(description: "Payment Split Completed")
       expect(Stripe::Transfer).to(have_received(:create).with({amount: order.vendors_share, currency: "usd", destination: marketplace.stripe_account, transfer_group: order.id}, {api_key: marketplace.stripe_api_key}))
     end
 

--- a/spec/furniture/marketplace/stripe_events_controller_request_spec.rb
+++ b/spec/furniture/marketplace/stripe_events_controller_request_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Marketplace::StripeEventsController, type: :request do
       response
     end
 
-    it "transfers the money automatically and notifies the buyer and seller" do
+    it "transfers the money automatically and notifies the buyer and seller" do # rubocop:disable RSpec/ExampleLength
       expect { call }.to(have_enqueued_mail(Marketplace::Order::ReceivedMailer, :notification).with(order)
       .and(have_enqueued_mail(Marketplace::Order::PlacedMailer, :notification).with(order))
       .and(change(order, :placed_at).from(nil)))

--- a/spec/furniture/marketplace/stripe_events_controller_request_spec.rb
+++ b/spec/furniture/marketplace/stripe_events_controller_request_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Marketplace::StripeEventsController, type: :request do
       perform_enqueued_jobs(only: Marketplace::SplitJob)
       expect(order.events).to exist(description: "Payment Split Attempted")
       expect(order.events).to exist(description: "Payment Split Completed")
-      expect(Stripe::Transfer).to(have_received(:create).with({amount: order.vendors_share, currency: "usd", destination: marketplace.stripe_account, transfer_group: order.id}, {api_key: marketplace.stripe_api_key}))
+      expect(Stripe::Transfer).to(have_received(:create).with({amount: order.vendors_share.to_i, currency: "usd", destination: marketplace.stripe_account, transfer_group: order.id}, {api_key: marketplace.stripe_api_key}))
     end
 
     context "when stripe sends us an event we can't handle" do

--- a/spec/furniture/marketplace/stripe_events_controller_request_spec.rb
+++ b/spec/furniture/marketplace/stripe_events_controller_request_spec.rb
@@ -2,10 +2,10 @@ require "rails_helper"
 # `Stripe` gem doesn't support verified doubles for some reason...
 # rubocop:disable RSpec/VerifiedDoubles
 RSpec.describe Marketplace::StripeEventsController, type: :request do
-  let(:marketplace) { create(:marketplace, :with_stripe_utility, :with_notification_methods, stripe_account: "sa_1234", stripe_webhook_endpoint_secret: "whsec_1234") }
+  let(:marketplace) { create(:marketplace, :with_stripe_utility, stripe_account: "sa_1234", stripe_webhook_endpoint_secret: "whsec_1234") }
   let(:space) { marketplace.space }
   let(:member) { create(:membership, space: space).member }
-  let(:order) { create(:marketplace_order, :with_products, status: :pre_checkout, contact_email: "test@example.com", marketplace: marketplace) }
+  let(:order) { create(:marketplace_order, :with_products, status: :pre_checkout, marketplace: marketplace) }
 
   let(:stripe_event) do
     double(Stripe::Event, type: "checkout.session.completed",


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1700

This may not be the right call, so I'm just tossing it up for conversation. In particular:

- Sidekiq does *not* guarantee once-and-only-once execution of jobs; which means if we have two workers and they both grab the job off the queue we might get two transfers. Not a good look.
- It would probably be better for us to explicitely record on our end that a Transfer has been created (or perhaps query the Stripe API?
- While automatic splitting seems like the right call; I don't know that splitting immediately upon payment is the right call. Stripe holds funds for 3 days; which indicates we should not pull it from the float until it's cleared?

Anyway, it should at least fix the bug where initial payment splits will fail if there is an insufficient balance...