### PR TITLE
🐞🔨 `Marketplace`: Only list `paid` `Orders`

### DIFF
--- a/app/furniture/marketplace/orders/index.html.erb
+++ b/app/furniture/marketplace/orders/index.html.erb
@@ -1,5 +1,5 @@
 <%- breadcrumb :marketplace_orders, marketplace %>
-<%- @pagy, @records = pagy(orders) %>
+<%- @pagy, @records = pagy(orders.paid) %>
 
 <div class="mx-auto w-full max-w-prose">
   <%= render @records %>

--- a/app/furniture/marketplace/orders_controller.rb
+++ b/app/furniture/marketplace/orders_controller.rb
@@ -1,7 +1,7 @@
 class Marketplace
   class OrdersController < Controller
     expose :order, scope: -> { orders }, model: Order
-    expose :orders, -> { OrderPolicy::Scope.new(shopper, marketplace.orders).resolve.order(created_at: :desc) }
+    expose :orders, -> { OrderPolicy::Scope.new(shopper, marketplace.orders).resolve.paid.order(created_at: :desc) }
 
     def show
       authorize(order)

--- a/app/furniture/marketplace/orders_controller.rb
+++ b/app/furniture/marketplace/orders_controller.rb
@@ -1,7 +1,7 @@
 class Marketplace
   class OrdersController < Controller
     expose :order, scope: -> { orders }, model: Order
-    expose :orders, -> { OrderPolicy::Scope.new(shopper, marketplace.orders).resolve.paid.order(created_at: :desc) }
+    expose :orders, -> { OrderPolicy::Scope.new(shopper, marketplace.orders).resolve.order(created_at: :desc) }
 
     def show
       authorize(order)

--- a/spec/furniture/marketplace/orders_controller_request_spec.rb
+++ b/spec/furniture/marketplace/orders_controller_request_spec.rb
@@ -6,6 +6,18 @@ RSpec.describe Marketplace::OrdersController, type: :request do
   let(:marketplace) { create(:marketplace, space: space) }
   let(:order) { create(:marketplace_order, marketplace: marketplace, delivery_address: "123 N West St") }
 
+  describe "#index" do
+    it "only includes paid orders by default" do
+      sign_in(space, member)
+      create(:marketplace_order, marketplace: marketplace, delivery_address: "123 W Unpaid St", status: :pre_checkout)
+      create(:marketplace_order, marketplace: marketplace, delivery_address: "123 N Paid St")
+      get polymorphic_path(marketplace.location(child: :orders))
+
+      expect(response.body).to include("123 N Paid St")
+      expect(response.body).not_to include("123 W Unpaid St")
+    end
+  end
+
   describe "#show" do
     subject(:perform_request) do
       get polymorphic_path(order.location)


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1691

This just makes sure the orders index isn't overwhelming with all the un-checked-out-carts