### PR TITLE
🌸 `Marketplace`: Group `Delivery` `Window` and `Address`

### DIFF
--- a/app/furniture/marketplace/cart/deliveries/_delivery.html.erb
+++ b/app/furniture/marketplace/cart/deliveries/_delivery.html.erb
@@ -1,9 +1,15 @@
 <div id="<%=dom_id(delivery) %>" class="flex flex-wrap items-center justify-between text-sm mt-1 sm:mt-2">
     <span>
+      <p class="text-left px-2 sm:px-4 py-2 text-sm">
+        <span class="font-bold">Delivery Time:</span>
+        <%= render(Marketplace::Cart::DeliveryExpectationsComponent.new(cart: delivery.cart)) %>
+      </p>
       <% if delivery.details_filled_in? || delivery.delivery_area.present? %>
-        <span class="font-bold">Delivering to:</span>
-          <%= delivery.delivery_address if delivery.delivery_address.present? %>
-          <%= render(delivery.delivery_area) if delivery.delivery_area.present? %>
+        <p class="text-left px-2 sm:px-4 py-2 text-sm">
+          <span class="font-bold">Delivering to:</span>
+            <%= delivery.delivery_address if delivery.delivery_address.present? %>
+            <%= render(delivery.delivery_area) if delivery.delivery_area.present? %>
+        </p>
       <% end %>
     </span>
 

--- a/app/furniture/marketplace/carts/_cart.html.erb
+++ b/app/furniture/marketplace/carts/_cart.html.erb
@@ -23,8 +23,4 @@
       <%= render "marketplace/carts/footer", cart: cart %>
     </table>
   </div>
-
-  <p class="text-right px-2 sm:px-4 py-2 text-sm">
-    <%= render(Marketplace::Cart::DeliveryExpectationsComponent.new(cart: cart)) %>
-  </p>
 </div>


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1325
- https://github.com/zinc-collective/convene/issues/1672

🍐 w/ @rosschapman 

- [MVP](https://docs.google.com/document/d/1wbXO82OeEkoIOj8zL6B24fiCC2Wg-w7949fo6wg3qhc/edit#heading=h.q036oj2sxhx6) part of https://github.com/zinc-collective/convene/issues/1672

display DeliveryExpectations above deliveryAddress because IMHO it looks better.

**Before**
Mobile
![Screenshot 2023-07-25 at 6 52 46 PM](https://github.com/zinc-collective/convene/assets/16140873/36a6918a-7d56-439c-ad2f-4dce150475a0)

Desktop
![Screenshot 2023-07-25 at 6 52 38 PM](https://github.com/zinc-collective/convene/assets/16140873/e97f8d9e-8625-4f14-8c01-ed2bf9c0642b)


**After**
Mobile
![Screenshot 2023-07-25 at 6 33 03 PM](https://github.com/zinc-collective/convene/assets/16140873/a3c479f2-bc08-4e7c-89c1-2ae170ce9ecd)

Desktop
![Screenshot 2023-07-25 at 6 33 07 PM](https://github.com/zinc-collective/convene/assets/16140873/5f2cfdd4-02b7-402c-a140-9538ad2b0890)


