### PR TITLE
🧹 `Journal`: Rename the method that turns Keywords into Links

### DIFF
--- a/app/furniture/journal/entry_component.rb
+++ b/app/furniture/journal/entry_component.rb
@@ -14,13 +14,13 @@ class Journal
 
     private def postprocess(text)
       entry.keywords.map do |keyword|
-        replace_keyword(text, keyword)
+        linkify_keyword(text, keyword)
       end
 
       text
     end
 
-    private def replace_keyword(text, keyword)
+    private def linkify_keyword(text, keyword)
       text.gsub!(keywords_regex(keyword)) do |match|
         link_to(match, keyword.location)
       end


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/pull/1684#discussion_r1270924805
- https://github.com/zinc-collective/convene/issues/1662

Better name thanks to @RossChapman