### PR TITLE
🌸`Components`: Remove blank space from `Cards` without `content`

### DIFF
--- a/app/components/card_component.html.erb
+++ b/app/components/card_component.html.erb
@@ -1,9 +1,12 @@
-<div <%== attributes(classes: card_classes) %>>
-  <%= content %>
+<div class="<%== card_classes_wrapper %>">
+  <% if content? %>
+    <div <%== attributes(classes: card_classes_content) %>">
+      <%= content %>
+    </div>
+  <% end %>
+  <% if footer? %>
+    <div class="<%== card_classes_footer %>">
+      <%= footer %>
+    </div>
+  <% end %>
 </div>
-
-<% if footer? %>
-  <div class="bg-purple-50 p-4 sm:p-6 rounded-lg rounded-t-none shadow">
-    <%= footer %>
-  </div>
-<% end %>

--- a/app/components/card_component.html.erb
+++ b/app/components/card_component.html.erb
@@ -1,6 +1,6 @@
 <div class="<%== card_classes_wrapper %>">
   <%#
-    NOTE: content? is not working as described, and is returning a proc in some cases rather than a boolean
+    NOTE: content? is not always working as described, and is returning a proc in some cases rather than a boolean
   %>
   <% if content.present? %>
     <div <%== attributes(classes: card_classes_content) %>">

--- a/app/components/card_component.html.erb
+++ b/app/components/card_component.html.erb
@@ -1,5 +1,8 @@
 <div class="<%== card_classes_wrapper %>">
-  <% if content? %>
+  <%#
+    NOTE: content? is not working as described, and is returning a proc in some cases rather than a boolean
+  %>
+  <% if content.present? %>
     <div <%== attributes(classes: card_classes_content) %>">
       <%= content %>
     </div>

--- a/app/components/card_component.rb
+++ b/app/components/card_component.rb
@@ -3,14 +3,27 @@ class CardComponent < ApplicationComponent
 
   private
 
-  def card_classes
+  def card_classes_content
+    [
+      "p-4",
+      "sm:p-6"
+    ].compact.join(" ")
+  end
+
+  def card_classes_wrapper
     [
       "shadow",
       "rounded-lg",
-      "bg-white",
+      "bg-white"
+    ].compact.join(" ")
+  end
+
+  def card_classes_footer
+    [
+      "bg-purple-50",
       "p-4",
       "sm:p-6",
-      ("rounded-b-none" if footer?)
+      ("rounded-t-none" unless content.blank?)
     ].compact.join(" ")
   end
 end

--- a/app/components/card_component.rb
+++ b/app/components/card_component.rb
@@ -23,7 +23,7 @@ class CardComponent < ApplicationComponent
       "bg-purple-50",
       "p-4",
       "sm:p-6",
-      ("rounded-t-none" unless content.blank?)
+      ("rounded-t-none" unless content.present?)
     ].compact.join(" ")
   end
 end

--- a/app/components/card_component.rb
+++ b/app/components/card_component.rb
@@ -23,6 +23,7 @@ class CardComponent < ApplicationComponent
       "bg-purple-50",
       "p-4",
       "sm:p-6",
+      # content? is not always working as described, and is returning a proc in some cases rather than a boolean
       ("rounded-t-none" unless content.present?)
     ].compact.join(" ")
   end

--- a/app/components/card_component.rb
+++ b/app/components/card_component.rb
@@ -24,7 +24,7 @@ class CardComponent < ApplicationComponent
       "p-4",
       "sm:p-6",
       # content? is not always working as described, and is returning a proc in some cases rather than a boolean
-      ("rounded-t-none" unless content.present?)
+      ("rounded-t-none" if content.blank?)
     ].compact.join(" ")
   end
 end

--- a/app/furniture/marketplace/management_component.html.erb
+++ b/app/furniture/marketplace/management_component.html.erb
@@ -6,18 +6,19 @@
     <%= marketplace.room.name %>
   </p>
 </div>
-<%= render onboarding_component %>
-<%= render CardComponent.new(classes: "mt-3") do |card| %>
-  <%= content %>
-
-  <% card.with_footer do %>
-    <nav class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3">
-      <%= render button({child: :stripe_account}, icon: :money) if policy(marketplace).edit? %>
-      <%= render button({child: :products}, icon: :tag)  if policy(marketplace.products).index? %>
-      <%= render button({child: :delivery_areas}, icon: :map)  if policy(marketplace.delivery_areas).index? %>
-      <%= render button({child: :tax_rates}, icon: :receipt_percent)  if policy(marketplace.tax_rates).index? %>
-      <%= render button({child: :orders}, icon: :cart)  if policy(marketplace.orders).index? %>
-      <%= render button({child: :notification_methods}, icon: :bell)  if policy(marketplace.notification_methods).index? %>
-    </nav>
+<div class="flex flex-col space-y-3">
+  <%= render onboarding_component %>
+  <%= render CardComponent.new do |card| %>
+    <%= content %>
+    <% card.with_footer do %>
+      <nav class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3">
+        <%= render button({child: :stripe_account}, icon: :money) if policy(marketplace).edit? %>
+        <%= render button({child: :products}, icon: :tag)  if policy(marketplace.products).index? %>
+        <%= render button({child: :delivery_areas}, icon: :map)  if policy(marketplace.delivery_areas).index? %>
+        <%= render button({child: :tax_rates}, icon: :receipt_percent)  if policy(marketplace.tax_rates).index? %>
+        <%= render button({child: :orders}, icon: :cart)  if policy(marketplace.orders).index? %>
+        <%= render button({child: :notification_methods}, icon: :bell)  if policy(marketplace.notification_methods).index? %>
+      </nav>
+    <% end %>
   <% end %>
-<% end %>
+</div>

--- a/app/furniture/marketplace/tax_rate_component.html.erb
+++ b/app/furniture/marketplace/tax_rate_component.html.erb
@@ -1,13 +1,10 @@
-
 <%= render CardComponent.new(dom_id: dom_id(tax_rate), classes: "flex flex-col justify-between gap-y-2 w-full") do %>
   <header class="flex font-bold">
     <%= label %>
   </header>
-
   <div class="italic">
     <%= rate  %>
   </div>
-
   <div class="flex flex-row justify-between">
     <%= render edit_button if edit_button? %>
     <%= render destroy_button if destroy_button?  %>


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1187

# Testing
 - [x] I've QA'd every usage of `CardComponent` I could find and didn't notice any UI issues.

# Screenshots
Here's a before/after of the `Marketplace::ManagementComponent` on the Manage Marketplace landing screen. If there is no content, the content section will not display:

<img width="714" alt="image" src="https://github.com/zinc-collective/convene/assets/5185/081bc3b9-a4b6-4078-acda-cfbfafe6efff">

<img width="720" alt="image" src="https://github.com/zinc-collective/convene/assets/5185/e8bff2ab-667c-4095-bf8c-3389701c3779">
