### PR TITLE
🧹 `CardComponent`: Tighten method names, and `if` vs `unless`

### DIFF
--- a/app/components/card_component.html.erb
+++ b/app/components/card_component.html.erb
@@ -1,11 +1,11 @@
-<div class="<%== card_classes_wrapper %>">
+<div class="<%== wrapper_classes %>">
   <% if content? %>
-    <div <%== attributes(classes: card_classes_content) %>">
+    <div <%== attributes(classes: content_classes) %>">
       <%= content %>
     </div>
   <% end %>
   <% if footer? %>
-    <div class="<%== card_classes_footer %>">
+    <div class="<%== footer_classes %>">
       <%= footer %>
     </div>
   <% end %>

--- a/app/components/card_component.rb
+++ b/app/components/card_component.rb
@@ -3,14 +3,14 @@ class CardComponent < ApplicationComponent
 
   private
 
-  def card_classes_content
+  def content_classes
     [
       "p-4",
       "sm:p-6"
     ].compact.join(" ")
   end
 
-  def card_classes_wrapper
+  def wrapper_classes
     [
       "shadow",
       "rounded-lg",
@@ -18,12 +18,12 @@ class CardComponent < ApplicationComponent
     ].compact.join(" ")
   end
 
-  def card_classes_footer
+  def footer_classes
     [
       "bg-purple-50",
       "p-4",
       "sm:p-6",
-      ("rounded-t-none" unless content.blank?)
+      ("rounded-t-none" if content?)
     ].compact.join(" ")
   end
 end


### PR DESCRIPTION
`unless` is kind of a mixed bag, and `standardrb` encourages us to use `if` whenever possible.

Since we're in the `CardComponent`, it didn't feel necessary to prefix each method with `card_`...

And I tend to like to group things with the thing they modify, rather than their type. I.e. `footer_classes` vs `classes_footer`

But feel free to ditch this of course.