### PR TITLE
🐞🔨 `Journal`: `Entry` supports overlapping `Keywords`

### DIFF
--- a/app/furniture/journal/entry_component.rb
+++ b/app/furniture/journal/entry_component.rb
@@ -28,7 +28,7 @@ class Journal
 
     # We sort the variants longest to shortest because regex matches groups left-to-right
     private def keywords_regex(keyword)
-      /(\##{keyword.canonical_with_aliases.sort.reverse.join("|\#")})/i
+      /(\##{keyword.canonical_with_aliases.sort.reverse.join("|#")})/i
     end
 
     private def published_at

--- a/app/furniture/journal/entry_component.rb
+++ b/app/furniture/journal/entry_component.rb
@@ -28,7 +28,7 @@ class Journal
 
     # We sort the variants longest to shortest because regex matches groups left-to-right
     private def keywords_regex(keyword)
-      /(\##{keyword.canonical_with_aliases.sort.join("|")})/i
+      /(\##{keyword.canonical_with_aliases.sort.reverse.join("|\#")})/i
     end
 
     private def published_at

--- a/app/furniture/journal/entry_component.rb
+++ b/app/furniture/journal/entry_component.rb
@@ -13,7 +13,7 @@ class Journal
     end
 
     private def postprocess(text)
-      entry.keywords.map do |keyword|
+      entry.keywords.by_length.map do |keyword|
         linkify_keyword(text, keyword)
       end
 
@@ -22,13 +22,13 @@ class Journal
 
     private def linkify_keyword(text, keyword)
       text.gsub!(keywords_regex(keyword)) do |match|
-        link_to(match, keyword.location)
+        link_to(match.gsub("#", "&#35;").html_safe, keyword.location) # rubocop:disable Rails/OutputSafety
       end
     end
 
-    # We sort the keywords longest to shortest because regex matches groups left-to-right
+    # We sort the variants longest to shortest because regex matches groups left-to-right
     private def keywords_regex(keyword)
-      /\#(#{keyword.canonical_with_aliases.sort.reverse.join("|")})/i
+      /(\##{keyword.canonical_with_aliases.sort.join("|")})/i
     end
 
     private def published_at

--- a/app/furniture/journal/keyword.rb
+++ b/app/furniture/journal/keyword.rb
@@ -7,6 +7,8 @@ class Journal
     validates :canonical_keyword, presence: true, uniqueness: {case_sensitive: false, scope: :journal_id}
     belongs_to :journal, inverse_of: :keywords
 
+    scope(:by_length, -> { order("LENGTH(canonical_keyword) DESC") })
+
     scope(:search, lambda do |*keywords|
       where("lower(aliases::text)::text[] && ARRAY[?]::text[]", keywords.map(&:downcase))
           .or(where("lower(canonical_keyword) IN (?)", keywords.map(&:downcase)))

--- a/spec/furniture/journal/entry_component_spec.rb
+++ b/spec/furniture/journal/entry_component_spec.rb
@@ -4,8 +4,10 @@ RSpec.describe Journal::EntryComponent, type: :component do
   subject(:output) { render_inline(component) }
 
   let(:component) { described_class.new(entry: entry) }
-  let(:entry) { create(:journal_entry, body: "https://www.google.com @zee@weirder.earth #GoodTimes") }
+  let(:entry) { create(:journal_entry, body: "https://www.google.com @zee@weirder.earth #GoodTimes with the #GoodTimesBand") }
 
   it { is_expected.to have_link("https://www.google.com", href: "https://www.google.com") }
   it { is_expected.to have_link("#GoodTimes", href: polymorphic_path(entry.journal.keywords.find_by(canonical_keyword: "GoodTimes").location)) }
+
+  it { is_expected.to have_link("#GoodTimesBand", href: polymorphic_path(entry.journal.keywords.find_by(canonical_keyword: "GoodTimesBand").location)) }
 end

--- a/spec/furniture/journal/entry_component_spec.rb
+++ b/spec/furniture/journal/entry_component_spec.rb
@@ -4,13 +4,15 @@ RSpec.describe Journal::EntryComponent, type: :component do
   subject(:output) { render_inline(component) }
 
   let(:component) { described_class.new(entry: entry) }
-  let(:entry) { create(:journal_entry, body: "https://www.google.com @zee@weirder.earth #GoodTime and #GoodTimes with the #GoodTimesBand", journal: journal) }
+  let(:entry) { create(:journal_entry, body: "https://www.google.com zee@example.com @zee@weirder.earth #GoodTime and #GoodTimes with the #GoodTimesBand", journal: journal) }
 
   let(:journal) do
     create(:journal).tap do |journal|
       journal.keywords.create(canonical_keyword: "GoodTime", aliases: ["GoodTimes"])
     end
   end
+
+  it { is_expected.to have_link("@zee@weirder.earth", href: "https://weirder.earth/@zee") }
 
   it { is_expected.to have_link("https://www.google.com", href: "https://www.google.com") }
 

--- a/spec/furniture/journal/entry_component_spec.rb
+++ b/spec/furniture/journal/entry_component_spec.rb
@@ -4,10 +4,17 @@ RSpec.describe Journal::EntryComponent, type: :component do
   subject(:output) { render_inline(component) }
 
   let(:component) { described_class.new(entry: entry) }
-  let(:entry) { create(:journal_entry, body: "https://www.google.com @zee@weirder.earth #GoodTimes with the #GoodTimesBand") }
+  let(:entry) { create(:journal_entry, body: "https://www.google.com @zee@weirder.earth #GoodTime and #GoodTimes with the #GoodTimesBand", journal: journal) }
+
+  let(:journal) do
+    create(:journal).tap do |journal|
+      journal.keywords.create(canonical_keyword: "GoodTime", aliases: ["GoodTimes"])
+    end
+  end
 
   it { is_expected.to have_link("https://www.google.com", href: "https://www.google.com") }
-  it { is_expected.to have_link("#GoodTimes", href: polymorphic_path(entry.journal.keywords.find_by(canonical_keyword: "GoodTimes").location)) }
 
-  it { is_expected.to have_link("#GoodTimesBand", href: polymorphic_path(entry.journal.keywords.find_by(canonical_keyword: "GoodTimesBand").location)) }
+  it { is_expected.to have_link("#GoodTimes", href: polymorphic_path(journal.keywords.find_by(canonical_keyword: "GoodTime").location)) }
+  it { is_expected.to have_link("#GoodTime", href: polymorphic_path(journal.keywords.find_by(canonical_keyword: "GoodTime").location)) }
+  it { is_expected.to have_link("#GoodTimesBand", href: polymorphic_path(journal.keywords.find_by(canonical_keyword: "GoodTimesBand").location)) }
 end

--- a/spec/furniture/journal/keyword_spec.rb
+++ b/spec/furniture/journal/keyword_spec.rb
@@ -7,6 +7,29 @@ RSpec.describe Journal::Keyword, type: :model do
   it { is_expected.to validate_uniqueness_of(:canonical_keyword).case_insensitive.scoped_to(:journal_id) }
   it { is_expected.to belong_to(:journal).inverse_of(:keywords) }
 
+  describe ".by_length" do
+    it "orders the results by the length of their canonical keyword" do
+      journal = create(:journal)
+      create_list(:journal_keyword, 5, journal: journal)
+      results = described_class.by_length
+      expect(results[0].canonical_keyword.length).to be >= results[1].canonical_keyword.length
+      expect(results[1].canonical_keyword.length).to be >= results[2].canonical_keyword.length
+      expect(results[2].canonical_keyword.length).to be >= results[3].canonical_keyword.length
+      expect(results[3].canonical_keyword.length).to be >= results[4].canonical_keyword.length
+    end
+  end
+
+  describe ".extract_and_create_from!" do
+    it "doesn't skip longer versions" do
+      journal = create(:journal)
+      journal.keywords.extract_and_create_from!("#SarinsGarden is a large #WorldGarden on the planet #Sarin.")
+
+      expect(described_class).to exist(canonical_keyword: "SarinsGarden", journal: journal)
+      expect(described_class).to exist(canonical_keyword: "WorldGarden", journal: journal)
+      expect(described_class).to exist(canonical_keyword: "Sarin", journal: journal)
+    end
+  end
+
   describe ".search" do
     it "returns the `Keywords` that match either canonicaly or via aliases" do
       dog = create(:journal_keyword, canonical_keyword: "Dog", aliases: ["doggo"])


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1714

Turns out, it was a renderer-layer thing; where the shorter `Keyword` was getting linkfied prior to the longer `Keyword`, and when I switched to linkify the longer `Keyword` first it would double-down on the links putting a link to the shorter keyword within the longer one!

So now I'm matching the `#` as part of the `Keyword`, and replacing it with the html entity for `#`, (aka `&#35;`)

This makes it so when we linkify keywords long-to-short; the longer keywords no longer contain the shorter keyword; eliminating the nested `a` tags.