### PR TITLE
✨ `Journal`: `Entry` can be migrated to another `Journal`

### DIFF
--- a/app/furniture/journal/entry.rb
+++ b/app/furniture/journal/entry.rb
@@ -9,7 +9,7 @@ class Journal
 
     attribute :headline, :string
     validates :headline, presence: true
-    attribute :body, :string
+    attribute :body, :string, default: ""
     validates :body, presence: true
 
     # URI-friendly description of the entry.
@@ -32,6 +32,11 @@ class Journal
     before_save :extract_keywords, if: :will_save_change_to_body?
 
     scope :matching_keywords, ->(keywords) { where("keywords::text[] && ARRAY[?]::text[]", keywords) }
+
+    def migrate_to(journal:, keywords: [])
+      new_body = keywords.present? ? body + "\n##{keywords.join(" #")}" : body
+      update(journal: journal, body: new_body)
+    end
 
     def published?
       published_at.present?

--- a/spec/furniture/journal/entry_spec.rb
+++ b/spec/furniture/journal/entry_spec.rb
@@ -10,6 +10,18 @@ RSpec.describe Journal::Entry, type: :model do
   it { is_expected.to have_one(:room).through(:journal) }
   it { is_expected.to have_one(:space).through(:journal) }
 
+  describe "#migrate_to(journal:, keywords: [])" do
+    it "appends the given keywords to body and swaps the different journal" do
+      entry = create(:journal_entry)
+      destination_journal = create(:journal)
+
+      entry.migrate_to(journal: destination_journal, keywords: ["Cooking", "Recipes"])
+      expect(entry.journal).to eql(destination_journal)
+      expect(entry.keywords).to include(destination_journal.keywords.find_by(canonical_keyword: "Recipes"))
+      expect(entry.keywords).to include(destination_journal.keywords.find_by(canonical_keyword: "Cooking"))
+    end
+  end
+
   describe "#save" do
     let(:entry) { create(:journal_entry, body: "#GoodTimes") }
     let(:journal) { entry.journal }


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1566

Also part of the writing I'm doing on https://slipvector.games, I have a Journal for non-canon (well, several; depending on if it's worldbuilding or concept art or a story) and then a `Journal` for canon content.

I want to be able to take an entry and move it into the Canon journal; and I'm fine doing it from the rails console for now; but I probably will expose a command end-point like
`/journal/:entry_id/migrate_to?journal_id=...&keywords[]=AKeyword&keywords[]=BKeyword` and add a button on the `Entry#edit` screen to enter the flow for selecting the Journal / adding Keywords.