### PR TITLE
🧹 `Marketplace`: Cause Stripe to Retry if we can't mark an `Order` as `paid`

### DIFF
--- a/app/furniture/marketplace/stripe_events_controller.rb
+++ b/app/furniture/marketplace/stripe_events_controller.rb
@@ -21,7 +21,7 @@ class Marketplace
         latest_charge = Stripe::Charge.retrieve(payment_intent.latest_charge, api_key: marketplace.stripe_api_key)
         balance_transaction = Stripe::BalanceTransaction.retrieve(latest_charge.balance_transaction, api_key: marketplace.stripe_api_key)
 
-        order.update(status: :paid, placed_at: DateTime.now, payment_processor_fee_cents: balance_transaction.fee)
+        order.update!(status: :paid, placed_at: DateTime.now, payment_processor_fee_cents: balance_transaction.fee)
         order.events.create(description: "Payment Received")
 
         Order::ReceivedMailer.notification(order).deliver_later


### PR DESCRIPTION
- Recommended by @anaulin https://github.com/zinc-collective/convene/pull/1701#discussion_r1275566331