### PR TITLE
🥔✨`Journal`: Enter `Entry#new` flow via `Keyword#show`

### DIFF
--- a/app/furniture/journal/journals/_journal.html.erb
+++ b/app/furniture/journal/journals/_journal.html.erb
@@ -1,10 +1,5 @@
 <section class="max-w-3xl mx-auto">
-  <%- new_entry = journal.entries.new %>
-  <%- if policy(new_entry).new? %>
-    <div class="text-center p-2">
-      <%= link_to "New Journal Entry", journal.location(:new, child: :entry) %>
-    </div>
-  <%- end %>
+  <%= render Journal::NewEntryButtonComponent.new(journal: journal) %>
 
   <div class="flex flex-wrap">
     <%- @pagy, @entries = pagy(policy_scope(journal.entries.recent)) %>
@@ -14,9 +9,5 @@
 
   <%== pagy_nav(@pagy, nav_extra: 'flex justify-between') %>
 
-  <%- if policy(new_entry).new? %>
-    <footer class="text-center p-2">
-      <%= link_to "New Journal Entry", journal.location(:new, child: :entry) %>
-    </footer>
-  <%- end %>
+  <%= render Journal::NewEntryButtonComponent.new(journal: journal) %>
 </section>

--- a/app/furniture/journal/keywords/show.html.erb
+++ b/app/furniture/journal/keywords/show.html.erb
@@ -4,8 +4,10 @@
 <%- end %>
 
 <h2>Entries about <span class="italic"><%= keyword.canonical_keyword %></span></h2>
+<%= render Journal::NewEntryButtonComponent.new(keyword: keyword) %>
 <ul>
   <%- policy_scope(keyword.entries).each do |entry|%>
     <li><%= link_to(entry.headline, entry.location) %></li>
   <%- end %>
 </ul>
+<%= render Journal::NewEntryButtonComponent.new(keyword: keyword) %>

--- a/app/furniture/journal/locales/en.yml
+++ b/app/furniture/journal/locales/en.yml
@@ -1,0 +1,5 @@
+en:
+  journal:
+    entries:
+      new:
+        link_to: "New Journal Entry"

--- a/app/furniture/journal/new_entry_button_component.html.erb
+++ b/app/furniture/journal/new_entry_button_component.html.erb
@@ -1,0 +1,3 @@
+<div class="text-center p-2">
+  <%= link_to t("journal.entries.new.link_to"), location %>
+</div>

--- a/app/furniture/journal/new_entry_button_component.rb
+++ b/app/furniture/journal/new_entry_button_component.rb
@@ -1,0 +1,27 @@
+class Journal
+  class NewEntryButtonComponent < ApplicationComponent
+    attr_accessor :keyword, :journal
+    def initialize(keyword: nil, journal: keyword&.journal)
+      self.keyword = keyword
+      self.journal = journal
+    end
+
+    def render?
+      policy(new_entry).new?
+    end
+
+    def location
+      journal.location(:new, child: :entry, query_params: location_query_params)
+    end
+
+    private def location_query_params
+      return nil if keyword.blank?
+
+      {entry: {body: "##{keyword.canonical_with_aliases.join(" #")}"}}
+    end
+
+    private def new_entry
+      @new_entry ||= journal.entries.new
+    end
+  end
+end


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1713
- https://github.com/zinc-collective/convene/issues/1566

I thought I would tilt at this while I waited for the build to go out; since I noticed I go from an `Entry` to a `Keyword` when trying to decide what to fill in next when world building.

It also auto-fills the new `Entry` body with the `Keywords` canonical version and it's aliases!

Which... I need to make a UI for soonish.

## After
<img width="433" alt="Screenshot 2023-07-28 at 1 19 41 PM" src="https://github.com/zinc-collective/convene/assets/50284/face70a1-8a19-451c-88a3-2ce83d936161">

<img width="424" alt="Screenshot 2023-07-28 at 1 19 47 PM" src="https://github.com/zinc-collective/convene/assets/50284/a88b1a18-c227-4490-9b6f-5ff7fe8b66e4">
