### PR TITLE
🥗✨ `Journal`: `Keyword`s can be merged into one another

### DIFF
--- a/app/furniture/journal/keyword/merge.rb
+++ b/app/furniture/journal/keyword/merge.rb
@@ -1,0 +1,18 @@
+class Journal
+  # Merges one {Journal::Keyword} into another and tidies up after.
+  class Keyword::Merge
+    # @param from {Journal::Keyword}
+    # @param into {Journal::Keyword}
+    def self.call(from:, into:)
+      into.aliases = into.aliases + from.canonical_with_aliases
+      Keyword.transaction do
+        into.save!
+        from.destroy!
+        into.entries.find_each do |entry|
+          entry.extract_keywords
+          entry.save!
+        end
+      end
+    end
+  end
+end

--- a/spec/furniture/journal/keyword_spec.rb
+++ b/spec/furniture/journal/keyword_spec.rb
@@ -8,19 +8,31 @@ RSpec.describe Journal::Keyword, type: :model do
   it { is_expected.to belong_to(:journal).inverse_of(:keywords) }
 
   describe "#merge" do
+    let(:journal) { create(:journal) }
+    let(:entry) { create(:journal_entry, body: "#GoodTime and #GoodTimes", journal: journal) }
+    let(:other_entry) { create(:journal_entry, body: "#GoodTime", journal: journal) }
+    let(:good_time_keyword) do
+      entry.journal.keywords.find_by(canonical_keyword: "GoodTime").tap do |keyword|
+        keyword.update!(aliases: ["GooodTime"])
+      end
+    end
+    let(:good_times_keyword) { entry.journal.keywords.find_by(canonical_keyword: "GoodTimes") }
+
+    before do
+      [entry, other_entry]
+    end
+
     it "adds aliases for the other `Keywords` canonical and aliases, deletes the other Keyword, and re-detects the entries keywords" do
-      entry = create(:journal_entry, body: "#GoodTime and #GoodTimes")
-
-      good_time_keyword = entry.journal.keywords.find_by(canonical_keyword: "GoodTime")
-      good_time_keyword.update!(aliases: ["GooodTime"])
-      good_times_keyword = entry.journal.keywords.find_by(canonical_keyword: "GoodTimes")
-
       good_times_keyword.merge(good_time_keyword)
-      entry.reload
+      [other_entry, entry].each(&:reload)
 
+      expect(journal.entries).to exist(other_entry.id)
+      expect(journal.entries).to exist(entry.id)
       expect(good_times_keyword.aliases).to eq(["GoodTime", "GooodTime"])
       expect(entry.keywords).not_to(include(good_time_keyword))
       expect(entry.keywords).to(include(good_times_keyword))
+      expect(other_entry.keywords).not_to(include(good_time_keyword))
+      expect(other_entry.keywords).to(include(good_times_keyword))
       expect(good_time_keyword).to be_destroyed
     end
   end


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1713

There's a number of things that can and will go wrong with this code eventually, including (but not limited to)

1. What happens when a `Keyword` has 1000s of entries?!
2. If this happens on-request-thread it will probably be very very slow; but if we do it *off* request-thread; the `Keyword#show` UI will be out-of-date; and we haven't implemented `ActionCable` yet

But hey, at least I will have a Heroku-CLI affordance for merging some of the `Keywords` that are synonyms...

I'll probably want to build out a WUI as well; but I wanted to get the basic logic written down and tested before I tilted at the WUI.