### PR TITLE
🔨 `Gizmo`: Don't try to set default `secrets` if the `secrets_ciphertext` isn't loaded

### DIFF
--- a/app/models/furniture.rb
+++ b/app/models/furniture.rb
@@ -30,7 +30,12 @@ class Furniture < ApplicationRecord
 
   # Forces consistent access, rather than having to work with a nil value
   after_initialize do
-    self.secrets ||= {}
+    # The `RankedModel` gem uses
+    #   [`ActiveRecord::QueryMethods.select`](https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-select)
+    # to do some stuff (Validation?) under the covers while keeping memory usage light... Which is good!
+    # But it also means that we don't have the ciphertext!
+    # So we can't set the secrets in that case (nor would we want to)
+    self.secrets ||= {} if has_attribute?("secrets_ciphertext")
   end
 
   def gizmo


### PR DESCRIPTION
So, I tried a few things:

- "Maybe lockbox/rails needs updating!" (They didn't)
- "Maybe `secrets` is a reserved word?" (It wasn't)

And then while spelunking the stacktrace, I noticed that the exception was being thrown within the `RankedModel` gem!!!

So then I dug in a bit, calling `self.attributes` in a byebug within the `after_initialize` and realized that in the cases the exception was not being thrown the attribute was actually missing.

Which gave me the affordances for making the logical leap to [`ActiveRecord::QueryMethods.select`](https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-select)