### PR TITLE
🔨 `Space`: Properly 404 when `current_person` cannot create or update `Space`

### DIFF
--- a/app/controllers/spaces_controller.rb
+++ b/app/controllers/spaces_controller.rb
@@ -71,5 +71,7 @@ class SpacesController < ApplicationController
 
   helper_method def current_space
     space.persisted? ? space : nil
+  rescue Pundit::NotAuthorizedError
+    @space
   end
 end


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/pull/1727

Since we use the `current_space` in the application layout; and we alias `current_space` to the `space` being interacted with in the `SpacesController`, the tests for what should happen when someone who isn't allowed to create a `Space` hit the `new` endpoint began to fail.

This adjusts so that `current_space` will return `space` in the `SpacesController` when the user is unauthorized; which will give them the appropriate layout for the space but does not let them actually make data changes.