### PR TITLE
🧹 `Neighborhood`: Apparently `MiniTest` is no more

### DIFF
--- a/spec/support/mailer.rb
+++ b/spec/support/mailer.rb
@@ -56,7 +56,7 @@ module Spec
       end
 
       class RenderComponentMatcher
-        include MiniTest::Assertions
+        include Minitest::Assertions
         include Rails::Dom::Testing::Assertions
         attr_accessor :expected_component, :mail, :args, :kwargs, :failing_select
 

--- a/spec/support/turbo.rb
+++ b/spec/support/turbo.rb
@@ -5,7 +5,7 @@ module Spec
     end
 
     class HaveRenderedTurboStream
-      include MiniTest::Assertions
+      include Minitest::Assertions
       include ::Turbo::TestAssertions
       include Rails::Dom::Testing::Assertions
       include ::ActionDispatch::Assertions::ResponseAssertions


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/892

I noticed this Sunday with Dalton, but don't know if I actually made any PRs with it...

Anyway, apparently the `MiniTest` namespace is no more; and it is only `Minitest`. It had been deprecated for a while but I am old and set in my ways.