### PR TITLE
🥔✨ `Contributor`: Support `Bust A Gem` VSCode Extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ app/assets/builds/
 .yardoc
 
 .devcontainer/output
+
+TAGS

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -10,6 +10,7 @@
     "wingrunr21.vscode-ruby",
     "valentjn.vscode-ltex",
     "bierner.markdown-mermaid",
-    "bpruitt-goddard.mermaid-markdown-syntax-highlighting"
+    "bpruitt-goddard.mermaid-markdown-syntax-highlighting",
+    "gurgeous.bust-a-gem"
   ]
 }


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1737

[Bust A Gem](https://marketplace.visualstudio.com/items?itemName=gurgeous.bust-a-gem) was recommended by @RossChapman as a way to provide jump-to-definition support for gems.

It seems neat, and seems worth adding to our recommended extensions / `.gitignore` so that folks who want/like to use it can do so.