### PR TITLE
🐞🔨 `Journal`: Fix `Keywords#show` erroring instead of 404ing

### DIFF
--- a/app/furniture/journal/keywords_controller.rb
+++ b/app/furniture/journal/keywords_controller.rb
@@ -9,6 +9,9 @@ class Journal
     expose(:journal, -> { Journal.find(params[:journal_id]) })
     def show
       authorize(keyword)
+      if polymorphic_path(keyword.location) != request.path
+        redirect_to(polymorphic_path(keyword.location))
+      end
     end
   end
 end

--- a/spec/furniture/journal/keywords_controller_request_spec.rb
+++ b/spec/furniture/journal/keywords_controller_request_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Journal::KeywordsController, type: :request do
       response
     end
 
-    let(:keyword) { create(:journal_keyword) }
+    let(:keyword) { create(:journal_keyword, aliases: ["pony"]) }
     let(:journal) { keyword.journal }
 
     it { is_expected.to be_ok }
@@ -18,7 +18,16 @@ RSpec.describe Journal::KeywordsController, type: :request do
         response
       end
 
-      it { is_expected.to be_ok }
+      it { is_expected.to redirect_to polymorphic_path(keyword.location) }
+    end
+
+    context "when the keyword is an alias" do
+      subject(:perform_request) do
+        get polymorphic_path(journal.location(child: :keyword), id: "Pony")
+        response
+      end
+
+      it { is_expected.to redirect_to polymorphic_path(keyword.location) }
     end
 
     context "when the keyword doesn't exist" do


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1754

This makes `Keyword`  browsing a bit tighter; in that:

- It's more generous in accepting aliases keywords
- It redirects to the Canonical location for the Keyword
- It 404s when a Keyword is not found.

