### PR TITLE
🌸✨ `Marketplace`: `Shopper` chooses `DeliveryArea`

### DIFF
--- a/app/furniture/marketplace/breadcrumbs.rb
+++ b/app/furniture/marketplace/breadcrumbs.rb
@@ -12,6 +12,16 @@ crumb :edit_marketplace do |marketplace|
   link t("marketplace.marketplace.edit.link_to"), marketplace.location(:edit)
 end
 
+crumb :marketplace_cart_delivery_area do |cart|
+  parent :room, cart.room
+  link t("marketplace.cart.delivery_areas.show.link_to"), cart.location(child: :delivery_area)
+end
+
+crumb :edit_marketplace_cart_delivery_area do |cart|
+  parent :room, cart.room
+  link t("marketplace.cart.delivery_areas.edit.link_to"), cart.location(:edit, child: :delivery_area)
+end
+
 crumb :marketplace_checkout do |checkout|
   parent :marketplace, checkout.cart.marketplace
   link "Checkout", checkout.location

--- a/app/furniture/marketplace/cart/delivery_area_component.html.erb
+++ b/app/furniture/marketplace/cart/delivery_area_component.html.erb
@@ -1,0 +1,16 @@
+<%= render CardComponent.new do %>
+  <h3 class="w-full">Delivering To</h3>
+  <%= turbo_frame_tag(dom_id, class: "flex flex-wrap justify-between") do %>
+    <%- if delivery_area.present? %>
+      <div>
+        <%= delivery_area.label %>
+      </div>
+
+      <div class="text-right">
+        <%= link_to(t('marketplace.cart.delivery_areas.edit.link_to'), cart.location(:edit, child: :delivery_area)) %>
+      </div>
+    <%- else %>
+      <%= render "marketplace/cart/delivery_areas/form", cart: cart %>
+    <%- end %>
+  <%- end %>
+<%- end %>

--- a/app/furniture/marketplace/cart/delivery_area_component.rb
+++ b/app/furniture/marketplace/cart/delivery_area_component.rb
@@ -1,0 +1,15 @@
+class Marketplace
+  class Cart::DeliveryAreaComponent < ApplicationComponent
+    attr_accessor :cart
+    delegate :delivery_area, to: :cart
+
+    def initialize(*args, cart:, **kwargs)
+      self.cart = cart
+      super(*args, **kwargs)
+    end
+
+    def dom_id
+      super(cart, :delivery_area)
+    end
+  end
+end

--- a/app/furniture/marketplace/cart/delivery_areas/_form.html.erb
+++ b/app/furniture/marketplace/cart/delivery_areas/_form.html.erb
@@ -1,0 +1,4 @@
+<%= form_with model: cart.location, url: cart.location(child: :delivery_area) do |form| %>
+  <%= render "select", options: cart.marketplace.delivery_areas.pluck(:label, :id), include_blank: true, attribute: :delivery_area_id, form: form, skip_label: true %>
+  <%= form.submit %>
+<%- end %>

--- a/app/furniture/marketplace/cart/delivery_areas/edit.html.erb
+++ b/app/furniture/marketplace/cart/delivery_areas/edit.html.erb
@@ -1,0 +1,6 @@
+<%- breadcrumb :edit_marketplace_cart_delivery_area, cart %>
+<%= render CardComponent.new do %>
+  <%= turbo_frame_tag(dom_id(cart, :delivery_area)) do %>
+    <%= render "form", cart: cart %>
+  <%- end %>
+<%- end %>

--- a/app/furniture/marketplace/cart/delivery_areas/show.html.erb
+++ b/app/furniture/marketplace/cart/delivery_areas/show.html.erb
@@ -1,0 +1,2 @@
+<%- breadcrumb :marketplace_cart_delivery_area, cart %>
+<%= render Marketplace::Cart::DeliveryAreaComponent.new(cart: cart) %>

--- a/app/furniture/marketplace/cart/delivery_areas_controller.rb
+++ b/app/furniture/marketplace/cart/delivery_areas_controller.rb
@@ -1,0 +1,24 @@
+class Marketplace
+  class Cart::DeliveryAreasController < Controller
+    expose :cart, scope: -> { carts }, model: Cart
+    expose :carts, -> { policy_scope(marketplace.carts) }
+
+    def show
+      authorize(cart)
+    end
+
+    def edit
+      authorize(cart)
+    end
+
+    def update
+      authorize(cart)
+      cart.update(cart_params)
+      redirect_to cart.location(child: :delivery_area)
+    end
+
+    def cart_params
+      params.require(:cart).permit(:delivery_area_id)
+    end
+  end
+end

--- a/app/furniture/marketplace/locales/en.yml
+++ b/app/furniture/marketplace/locales/en.yml
@@ -12,6 +12,8 @@ en:
   marketplace:
     cart:
       delivery_areas:
+        show:
+          link_to: "Delivery Area"
         edit:
           link_to: "Change"
       deliveries:

--- a/app/furniture/marketplace/locales/en.yml
+++ b/app/furniture/marketplace/locales/en.yml
@@ -11,6 +11,9 @@ en:
               required: "can't be blank"
   marketplace:
     cart:
+      delivery_areas:
+        edit:
+          link_to: "Change"
       deliveries:
         edit:
           header: "Delivery Details"

--- a/app/furniture/marketplace/marketplace_component.html.erb
+++ b/app/furniture/marketplace/marketplace_component.html.erb
@@ -1,6 +1,9 @@
 
 <%= render onboarding_component %>
 
+
+<%= render delivery_area_component %>
+
 <%= render cart %>
 
 <%- if policy(marketplace).edit? %>

--- a/app/furniture/marketplace/marketplace_component.rb
+++ b/app/furniture/marketplace/marketplace_component.rb
@@ -16,6 +16,10 @@ class Marketplace
       @cart ||= carts.create_with(contact_email: shopper.person&.email).find_or_create_by(shopper: shopper, status: :pre_checkout)
     end
 
+    def delivery_area_component
+      @delivery_area_component ||= Cart::DeliveryAreaComponent.new(cart: cart)
+    end
+
     def onboarding_component
       OnboardingComponent.new(marketplace: marketplace, current_person: current_person)
     end

--- a/app/furniture/marketplace/routes.rb
+++ b/app/furniture/marketplace/routes.rb
@@ -6,6 +6,7 @@ class Marketplace
           router.resources :cart_products
           router.resource :checkout, only: [:show, :create]
           router.resource :delivery, controller: "cart/deliveries"
+          router.resource :delivery_area, controller: "cart/delivery_areas"
         end
 
         router.resources :delivery_areas

--- a/app/views/application/_select.html.erb
+++ b/app/views/application/_select.html.erb
@@ -1,5 +1,5 @@
 <div>
-  <%= form.label attribute %>
+  <%= form.label attribute unless local_assigns[:skip_label] %>
   <%= form.select attribute, options, include_blank: local_assigns.fetch(:include_blank, true),
       prompt: local_assigns.fetch(:prompt, false) %>
   <%= render partial: "error", locals: { model: form.object, attribute: attribute } %>

--- a/spec/furniture/marketplace/buying_products_system_spec.rb
+++ b/spec/furniture/marketplace/buying_products_system_spec.rb
@@ -64,9 +64,11 @@ describe "Marketplace: Buying Products", type: :system do
   end
 
   def set_delivery_details(delivery_address:, delivery_area:, contact_phone_number:, contact_email:)
+    select(delivery_area.label, from: "cart[delivery_area_id]")
+    click_link_or_button("Save changes")
+
     click_link_or_button("Add delivery details to checkout")
     fill_in("Delivery address", with: delivery_address)
-    select(delivery_area.label, from: "Delivery area")
     fill_in("Contact phone number", with: contact_phone_number)
     fill_in("Contact email", with: contact_email)
     click_link_or_button("Save changes")

--- a/spec/furniture/marketplace/cart/delivery_areas_controller_request_spec.rb
+++ b/spec/furniture/marketplace/cart/delivery_areas_controller_request_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe Marketplace::Cart::DeliveryAreasController, type: :request do
+  subject(:result) do
+    perform_request
+    response
+  end
+
+  before { sign_in(space, person) }
+
+  let(:space) { marketplace.space }
+  let(:marketplace) { create(:marketplace, :with_delivery_areas) }
+  let(:person) { create(:membership, space: space).member }
+  let(:shopper) { create(:marketplace_shopper, person: person) }
+  let(:cart) { create(:marketplace_cart, shopper: shopper) }
+
+  describe "#show" do
+    let(:perform_request) do
+      get polymorphic_path(cart.location(child: :delivery_area))
+      response
+    end
+
+    it { is_expected.to be_ok }
+  end
+
+  describe "#edit" do
+    let(:perform_request) do
+      get polymorphic_path(cart.location(:edit, child: :delivery_area))
+      response
+    end
+
+    it { is_expected.to be_ok }
+
+    specify do
+      perform_request
+      assert_select("select[name='cart[delivery_area_id]']")
+    end
+  end
+
+  describe "#update" do
+    let(:perform_request) do
+      put polymorphic_path(cart.location(child: :delivery_area), params: {cart: {delivery_area_id: marketplace.delivery_areas.first.id}})
+      cart.reload
+      response
+    end
+
+    it { is_expected.to redirect_to(cart.location(child: :delivery_area)) }
+
+    specify do
+      expect { result }.to change(cart, :delivery_area_id).to(marketplace.delivery_areas.first.id)
+    end
+  end
+end


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1672
- https://github.com/zinc-collective/convene/issues/1325
- https://github.com/zinc-collective/convene/issues/1136
- https://github.com/zinc-collective/convene/issues/1326

So, in reviewing a bunch of the delivery app workflows, most of them have:

- Choose Pickup or Delivery
- Enter Address
- Browse Menu
- Tap Item
- Add Item to Order

This lends me to believe we want to switch to gathering the `DeliveryArea` *then* `DeliveryAddress` *then* showing the `Products` that are available.

This uses TurboFrames to replace pieces of the page, rather than relying on TurboStreams. On the one hand, it's lot easier (just respond with html with matching `turbo_frame_tag`s`).

Blerg; anyway, I'm checking this in now; but not sure if I like it enough.

Thoughts? In particular:

- Copy-editing
- Design tweaks?
- Name Collisions: How Undo?

## After!
<img width="376" alt="Screenshot 2023-08-14 at 1 13 28 PM" src="https://github.com/zinc-collective/convene/assets/50284/06d95711-4654-4f72-8bbd-4a0856b37a72">

### Video
https://github.com/zinc-collective/convene/assets/50284/3f645a18-01ca-4318-b54e-2ade59e6a8c6

