### PR TITLE
🧹 `Components`: Add `Turbo` support

### DIFF
--- a/app/components/application_component.rb
+++ b/app/components/application_component.rb
@@ -1,6 +1,7 @@
 class ApplicationComponent < ViewComponent::Base
   attr_accessor :data
   attr_writer :classes, :dom_id
+  include Turbo::FramesHelper
 
   def initialize(data: {}, dom_id: nil, classes: "", current_person: nil)
     self.data = data


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1187

I tried using `helpers.turbo_frame_tag` in a component and it duplicated the content!

Then I found this:
https://github.com/ViewComponent/view_component/issues/1099#issuecomment-996862141

And now we can use
[`turbo_frame_tag`](https://rubydoc.info/gems/turbo-rails/1.4.0/Turbo/FramesHelper#turbo_frame_tag-instance_method) directly.