### PR TITLE
🌸 `Marketplace`: Rename `Events` section to `Timeline`

### DIFF
--- a/app/furniture/marketplace/orders/_order.html.erb
+++ b/app/furniture/marketplace/orders/_order.html.erb
@@ -31,7 +31,7 @@
     <hr class="col-span-6 my-4" />
     <div class="col-span-6 text-xs">
 
-      <h3 class="mb-2 text-sm font-bold">Events</h3>
+      <h3 class="mb-2 text-sm font-bold">Timeline</h3>
       <div class="grid grid-cols-2">
         <%- order.events.each do |event| %>
           <p><%= event.description%></p>


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1331
- https://github.com/zinc-collective/convene/pull/1712#discussion_r1294632293

While either `History` or `Timeline` are way better than `Events`; `Timeline` felt better than `History`; since `Order History` feels like the history of all `Orders`; and `Order Timeline` feels like the `Timeline` for a single `Order`.