### PR TITLE
🐞🔨 `Operators` always see all `Space` `Members`

### DIFF
--- a/app/policies/membership_policy.rb
+++ b/app/policies/membership_policy.rb
@@ -23,7 +23,11 @@ class MembershipPolicy < ApplicationPolicy
 
   class Scope < ApplicationScope
     def resolve
-      scope.where(space: person.spaces)
+      if person.operator?
+        scope.all
+      else
+        scope.where(space: person.spaces)
+      end
     end
   end
 end

--- a/spec/factories/person.rb
+++ b/spec/factories/person.rb
@@ -4,5 +4,9 @@ FactoryBot.define do
   factory :person do
     name { Faker::Name.name }
     email { "#{name.downcase.tr(" ", "-")}@example.com" }
+
+    trait :operator do
+      operator { true }
+    end
   end
 end

--- a/spec/policies/membership_policy_spec.rb
+++ b/spec/policies/membership_policy_spec.rb
@@ -89,5 +89,13 @@ RSpec.describe MembershipPolicy do
     it "does not include memberships from spaces the person is not a member of" do
       expect(scope.resolve).not_to include(other_memberships)
     end
+
+    context "when the person is an Operator" do
+      let(:person) { create(:person, :operator) }
+
+      it "includes all memberships" do
+        expect(scope.resolve).to match_array(Membership.all)
+      end
+    end
   end
 end


### PR DESCRIPTION
Resolves https://github.com/zinc-collective/convene/issues/1659
- https://github.com/zinc-collective/convene/issues/1659

This was the root cause of why I was getting such weird behavior in production, not seeing any members in the Piikup Marketplace Space: it is because I was logged in with an account that is an operator, but not a member of the Piikup Space.