### PR TITLE
🛠️🔐 `Security`: Review Policy objects and constrain default access levels

### DIFF
--- a/app/policies/invitation_policy.rb
+++ b/app/policies/invitation_policy.rb
@@ -21,7 +21,11 @@ class InvitationPolicy < ApplicationPolicy
   class Scope < ApplicationScope
     # All invitations for an accessible space are visible.
     def resolve
-      scope.all
+      if person&.operator?
+        scope.all
+      else
+        scope.where(space: person&.spaces)
+      end
     end
   end
 end

--- a/app/policies/person_policy.rb
+++ b/app/policies/person_policy.rb
@@ -19,7 +19,13 @@ class PersonPolicy < ApplicationPolicy
 
   class Scope < ApplicationScope
     def resolve
-      scope.all
+      return scope.none if person.blank?
+
+      if person.operator?
+        scope.all
+      else
+        scope.where(id: person.id)
+      end
     end
   end
 end

--- a/app/policies/rsvp_policy.rb
+++ b/app/policies/rsvp_policy.rb
@@ -9,7 +9,7 @@ class RsvpPolicy < ApplicationPolicy
     true
   end
 
-  # Guests can Rsvp, as can signed-in users.
+  # Anyone with an RSVP link can RSVP
   def create?
     true
   end

--- a/spec/policies/invitation_policy_spec.rb
+++ b/spec/policies/invitation_policy_spec.rb
@@ -25,4 +25,30 @@ RSpec.describe InvitationPolicy do
     it { is_expected.not_to permit(nil, invitation) }
     it { is_expected.not_to permit(non_member, invitation) }
   end
+
+  describe "Scope" do
+    subject(:scope) { described_class::Scope.new(person, Invitation) }
+
+    let(:membership) { create(:membership) }
+    let(:person) { membership.member }
+    let(:space) { membership.space }
+    let!(:space_invitation) { create(:invitation, space: space) }
+    let!(:other_invitation) { create(:invitation) }
+
+    it "includes invitations for spaces the person is a member of" do
+      expect(scope.resolve).to include(space_invitation)
+    end
+
+    it "does not include memberships from spaces the person is not a member of" do
+      expect(scope.resolve).not_to include(other_invitation)
+    end
+
+    context "when the person is an Operator" do
+      let(:person) { create(:person, :operator) }
+
+      it "includes all invitations" do
+        expect(scope.resolve).to match_array(Invitation.all)
+      end
+    end
+  end
 end

--- a/spec/policies/person_policy_spec.rb
+++ b/spec/policies/person_policy_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe PersonPolicy do
+  describe "Scope" do
+    subject(:scope) { described_class::Scope.new(person, Person) }
+
+    let!(:person) { create(:person) }
+    let!(:other_person) { create(:person) }
+
+    it "includes themselves" do
+      expect(scope.resolve).to include(person)
+    end
+
+    it "does not include anyone else" do
+      expect(scope.resolve).not_to include(other_person)
+    end
+
+    context "when the person is an Operator" do
+      let(:person) { create(:person, :operator) }
+
+      it "includes all persons" do
+        expect(scope.resolve).to match_array(Person.all)
+      end
+    end
+  end
+end

--- a/spec/policies/space_policy_spec.rb
+++ b/spec/policies/space_policy_spec.rb
@@ -16,4 +16,18 @@ RSpec.describe SpacePolicy do
     it { is_expected.not_to permit(non_member, space) }
     it { is_expected.not_to permit(nil, space) }
   end
+
+  describe "Scope" do
+    subject(:scope) { described_class::Scope.new(person, Space) }
+
+    let(:membership) { create(:membership) }
+    let!(:person) { membership.member }
+    let(:space) { membership.space }
+    let!(:other_space) { create(:space) }
+
+    it "includes all Spaces" do
+      expect(scope.resolve).to include(space)
+      expect(scope.resolve).to include(other_space)
+    end
+  end
 end


### PR DESCRIPTION
Working on https://github.com/zinc-collective/convene/pull/1778, I noticed that we have a few Scopes that are defined as `scope.all` for all cases, and probably shouldn't be.

Some of these scopes might not be in use at the moment, but I figured I could fix them all up to prevent future issues.