### PR TITLE
🛠️✨ `Gizmos`: Support nested layouts

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,7 @@
     <%= render 'layouts/header' %>
 
     <main id="<%= current_space.present? ? dom_id(current_space) : nil %>">
-      <%= yield %>
+      <%= content_for?(:content) ? yield(:content) : yield %>
     </main>
 
 


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/709

Hat-tip: @joshmcarthur - https://www.joshmcarthur.com/til/2018/03/26/til-nested-layouts-in-rails.html

In the `Marketplace`, we are starting to wrap the entire UI in Turbo Frames; for maximum snappy-goodness.

However, it was quickly becoming an effort of copypastafarian proportions; so I thought "Hmm, wouldn't it be nice if we could do this using a layout?!"

Unfortunately, we had not set up our Rails view pipeline to support layouts. (Boooo! hiss! Boo!!!)

So now we do!

So long as the layout uses `content_for(:content)` it will support nested layouts!!