### PR TITLE
🧹🛠️ `Marketplace`: Wrap the whole thing in Turbo Frames

### DIFF
--- a/app/furniture/layouts/marketplace.html.erb
+++ b/app/furniture/layouts/marketplace.html.erb
@@ -1,0 +1,6 @@
+<%- content_for :content do %>
+  <%= turbo_frame_tag(marketplace) do %>
+    <%= yield  %>
+  <%- end %>
+<%- end %>
+<%= render template: "layouts/application" %>

--- a/app/furniture/marketplace/controller.rb
+++ b/app/furniture/marketplace/controller.rb
@@ -3,6 +3,7 @@ class Marketplace
     expose :marketplace, scope: -> { policy_scope(Marketplace) }
     delegate :bazaar, to: :marketplace
     helper_method :bazaar
+    layout "marketplace"
 
     helper_method def shopper
       @shopper ||= if current_person.is_a?(Guest)

--- a/app/furniture/marketplace/marketplaces_controller.rb
+++ b/app/furniture/marketplace/marketplaces_controller.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 class Marketplace
-  class MarketplacesController < FurnitureController
-    expose(:marketplace, model: Marketplace)
-
+  class MarketplacesController < Controller
     def show
       authorize(marketplace)
     end

--- a/app/furniture/marketplace/payment_settings_controller.rb
+++ b/app/furniture/marketplace/payment_settings_controller.rb
@@ -1,11 +1,7 @@
 class Marketplace
-  class PaymentSettingsController < FurnitureController
+  class PaymentSettingsController < Controller
     def index
       authorize(marketplace, :edit?)
-    end
-
-    helper_method def marketplace
-      @marketplace ||= policy_scope(Marketplace).find(params[:marketplace_id])
     end
   end
 end


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/831

This may turn out to be a terrrrrrible idea; but it may also be fine.

Essentially, the `Marketplace` now lives within a turbo-frame; which means it's going to be replacing itself inline. Cool? Also, horrifying.

Basically, now every `Marketplace::*Controller` will want to inherit from `Marketplace::Controller`, so when we click a link it will auto-magically swap out the content without requiring us to do anything at all! Cool, huh?