### PR TITLE
🧹 `Marketplace`: Fix deprecation warning in `Order#price_total`

### DIFF
--- a/app/furniture/marketplace/order.rb
+++ b/app/furniture/marketplace/order.rb
@@ -50,7 +50,7 @@ class Marketplace
     end
 
     def price_total
-      [product_total, delivery_fee, tax_total].compact.sum
+      [product_total, delivery_fee, tax_total].compact.sum(0)
     end
 
     def send_to_square_seller_dashboard


### PR DESCRIPTION
Results from `bin/rspec spec/furniture/marketplace/order_spec.rb`

Before:
```
Marketplace::Order
  is expected to have many ordered_products dependent => destroy inverse_of => order
  is expected to have many products through ordered_products inverse_of => orders
  is expected to belong to marketplace class_name => Marketplace::Marketplace required: true inverse_of => orders
  is expected to belong to shopper required: true inverse_of => orders
  is expected to belong to delivery_area inverse_of => orders optional: true
  is expected to have many events inverse_of => regarding dependent => destroy
  #vendors_share
    is expected to eq #<Money fractional:-85157 currency:USD>
  #price_total
DEPRECATION WARNING: Rails 7.0 has deprecated Enumerable.sum in favor of Ruby's native implementation available since 2.4. Sum of non-numeric elements requires an initial argument. (called from price_total at /Users/zee/Projects/zinc-collective/convene/app/furniture/marketplace/order.rb:53)
    is expected to eql #<Money fractional:235458 currency:USD>
  #product_total
    is expected to eql #<Money fractional:208997 currency:USD>
  #taxes_total
    is expected to eql #<Money fractional:1567 currency:USD>

Finished in 1.55 seconds (files took 2.9 seconds to load)
10 examples, 0 failures
```

After:
```
Marketplace::Order
  is expected to have many ordered_products dependent => destroy inverse_of => order
  is expected to have many products through ordered_products inverse_of => orders
  is expected to belong to marketplace class_name => Marketplace::Marketplace required: true inverse_of => orders
  is expected to belong to shopper required: true inverse_of => orders
  is expected to belong to delivery_area inverse_of => orders optional: true
  is expected to have many events inverse_of => regarding dependent => destroy
  #vendors_share
    is expected to eq #<Money fractional:-95040 currency:USD>
  #price_total
    is expected to eql #<Money fractional:212748 currency:USD>
  #product_total
    is expected to eql #<Money fractional:275262 currency:USD>
  #taxes_total
    is expected to eql #<Money fractional:4634 currency:USD>

Finished in 1.55 seconds (files took 8.59 seconds to load)
10 examples, 0 failures
```