### PR TITLE
🥗🐞🔨 `Marketplace`: Test & Fix Setting `Stripe` API Key

### DIFF
--- a/app/components/button_component.rb
+++ b/app/components/button_component.rb
@@ -16,6 +16,7 @@ class ButtonComponent < ApplicationComponent
     confirm: nil,
     disabled: false,
     turbo_stream: false,
+    turbo: true,
     scheme: nil,
     **kwargs
   )
@@ -27,6 +28,7 @@ class ButtonComponent < ApplicationComponent
     @confirm = confirm
     @disabled = disabled
     @turbo_stream = turbo_stream
+    @turbo = turbo
     @scheme = scheme
 
     super(data: data, **kwargs)
@@ -43,7 +45,7 @@ class ButtonComponent < ApplicationComponent
   end
 
   def data
-    data = {turbo_method: @method, turbo: true}
+    data = {turbo_method: @method, turbo: @turbo}
     data[:turbo_stream] = true if @turbo_stream
     if @confirm.present?
       data[:turbo_confirm] = @confirm

--- a/app/components/marketplace/stripe_overview_component.rb
+++ b/app/components/marketplace/stripe_overview_component.rb
@@ -7,6 +7,5 @@ class Marketplace::StripeOverviewComponent < ApplicationComponent
     super(**kwargs)
 
     @marketplace = marketplace
-    @marketplace_stripe_utility = marketplace.stripe_utility
   end
 end

--- a/app/components/marketplace/stripe_overview_component/stripe_overview_component.html.erb
+++ b/app/components/marketplace/stripe_overview_component/stripe_overview_component.html.erb
@@ -1,7 +1,7 @@
 <%= render CardComponent.new(classes: "flex flex-col h-full
 ") do %>
   <header class="flex font-bold">
-    <%= marketplace_stripe_utility.name %>
+    <%= marketplace_stripe_utility&.name %>
   </header>
   <footer class="flex flex-row justify-between mt-3">
     <%= render ButtonComponent.new(

--- a/app/furniture/marketplace/marketplace.rb
+++ b/app/furniture/marketplace/marketplace.rb
@@ -42,12 +42,12 @@ class Marketplace
     end
 
     def stripe_utility
-      @stripe_utility ||= space.utilities.find_by!(utility_slug: :stripe).utility
+      @stripe_utility ||= space.utilities.find_by(utility_slug: :stripe)&.utility
     end
 
     # The Secret Stripe API key belonging to the owner of the Marketplace
     def stripe_api_key
-      stripe_utility.api_token
+      stripe_utility&.api_token
     end
 
     def stripe_api_key?

--- a/app/furniture/marketplace/stripe_accounts/show.html.erb
+++ b/app/furniture/marketplace/stripe_accounts/show.html.erb
@@ -12,6 +12,7 @@
             label: t('.missing_stripe_api_key', space_name: space.name),
             href: space.location(:edit),
             method: :get,
+            turbo: false,
             scheme: :primary ) %>
     <% end %>
   </p>

--- a/spec/furniture/marketplace/collecting_payments_system_spec.rb
+++ b/spec/furniture/marketplace/collecting_payments_system_spec.rb
@@ -4,11 +4,43 @@ require "rails_helper"
 describe "Marketplace: Collecting Payments", type: :system do
   # @see https://github.com/zinc-collective/convene/issues/1622
   describe "via Stripe" do
-    it "connects the Vendor's Stripe Account" do
-      space = create(:space, :with_entrance, :with_members)
-      marketplace = create(:marketplace, :with_stripe_utility, room: space.entrance)
-      sign_in(space.members.first, space)
+    let(:space) { create(:space, :with_entrance, :with_members) }
 
+    before do
+      sign_in(space.members.first, space)
+    end
+
+    it "sets the Distributor's Stripe API Key" do # rubocop:disable RSpec/ExampleLength
+      marketplace = create(:marketplace, room: space.entrance)
+      visit polymorphic_path(marketplace.room.location)
+
+      within("##{dom_id(marketplace, :onboarding)}") do
+        click_on("Manage Marketplace")
+      end
+
+      click_on("Payment Settings")
+      click_on("View Stripe Account")
+      click_on("Add a Stripe API key to #{space.name}")
+      click_on("Add Utility")
+      select("stripe", from: "Type")
+      fill_in("Name", with: "Test Stripe Account")
+      click_on("Create")
+      click_on("Edit stripe 'Test Stripe Account'")
+      fill_in("Api token", with: ENV.fetch("STRIPE_API_KEY", "not-a-real-key"))
+      click_on("Save changes to Stripe Utility")
+
+      expect(page).to have_content("Test Stripe Account")
+      expect(space.utilities).to exist(utility_slug: "stripe")
+      expect(space.utilities.find_by(utility_slug: "stripe").utility.api_token).to eq(ENV.fetch("STRIPE_API_KEY", "not-a-real-key"))
+
+      visit polymorphic_path(marketplace.location(:edit))
+      click_on("Payment Settings")
+      click_on("View Stripe Account")
+      expect(page).to have_content("Connect to Stripe")
+    end
+
+    it "connects the Vendor's Stripe Account" do
+      marketplace = create(:marketplace, :with_stripe_utility, room: space.entrance)
       visit polymorphic_path(marketplace.room.location)
 
       within("##{dom_id(marketplace, :onboarding)}") do


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1806
- https://github.com/zinc-collective/convene/issues/1622

Turns out, there were a number of small bugs here:

- Both `Marketplace::Marketplace` and `Marketplace::StripeOverviewComponent` presumed that there would be a `StripeUtility` for the `Space`; when there may not be.
- The link to `Space#edit` does not have a turbo-frame for the marketplace; so it needed to have turbo disabled
- The `ButtonComponent` did not have a way to disable turbo!

This fixes all of that, and allows `Operators` and `Members` to set the Stripe API key via the `Marketplace#edit` flow.