### PR TITLE
Adds content for Stripe Account settings component when Stripe utility missing

### DIFF
--- a/app/components/marketplace/stripe_overview_component/stripe_overview_component.html.erb
+++ b/app/components/marketplace/stripe_overview_component/stripe_overview_component.html.erb
@@ -1,14 +1,29 @@
 <%= render CardComponent.new(classes: "flex flex-col h-full
 ") do %>
-  <header class="flex font-bold">
-    <%= marketplace_stripe_utility&.name %>
-  </header>
-  <footer class="flex flex-row justify-between mt-3">
-    <%= render ButtonComponent.new(
+  <%- if marketplace.stripe_api_key? %>
+    <header class="flex font-bold">
+      <%= marketplace_stripe_utility.name %>
+    </header>
+    <footer class="flex flex-row justify-between mt-3">
+      <%= render ButtonComponent.new(
       label: "View #{t('marketplace.stripe_accounts.show.link_to')}",
       title: t('marketplace.stripe_accounts.show.link_to'),
       href: marketplace.location(:index, child: :stripe_account),
       method: :get,
       scheme: :secondary) %>
-  </footer>
+    </footer>
+  <%- else %>
+    <header class="flex"
+>To start accepting payments, add your Stripe Account.</header>
+    <footer class="flex flex-row justify-between mt-3
+">
+      <%= render ButtonComponent.new(
+      label: "Add #{t('marketplace.stripe_accounts.show.link_to')}",
+      title: "Add #{t('marketplace.stripe_accounts.show.link_to')}",
+      href: marketplace.location(:index, child: :stripe_account),
+      method: :get,
+      scheme: :secondary)
+      %>
+    </footer>
+  <%- end %>
 <%- end %>

--- a/app/components/marketplace/stripe_overview_component/stripe_overview_component.html.erb
+++ b/app/components/marketplace/stripe_overview_component/stripe_overview_component.html.erb
@@ -1,4 +1,4 @@
-<%= render CardComponent.new(classes: "flex flex-col h-full
+<%= render CardComponent.new(dom_id: "stripe_overview", classes: "flex flex-col h-full
 ") do %>
   <%- if marketplace.stripe_api_key? %>
     <header class="flex font-bold">
@@ -7,7 +7,7 @@
     <footer class="flex flex-row justify-between mt-3">
       <%= render ButtonComponent.new(
       label: "View #{t('marketplace.stripe_accounts.show.link_to')}",
-      title: t('marketplace.stripe_accounts.show.link_to'),
+      title: "View #{t('marketplace.stripe_accounts.show.link_to')}",
       href: marketplace.location(:index, child: :stripe_account),
       method: :get,
       scheme: :secondary) %>
@@ -22,7 +22,8 @@
       title: "Add #{t('marketplace.stripe_accounts.show.link_to')}",
       href: marketplace.location(:index, child: :stripe_account),
       method: :get,
-      scheme: :secondary)
+      scheme: :secondary
+      )
       %>
     </footer>
   <%- end %>

--- a/spec/components/marketplace/stripe_overview_component_spec.rb
+++ b/spec/components/marketplace/stripe_overview_component_spec.rb
@@ -3,13 +3,24 @@
 require "rails_helper"
 
 RSpec.describe Marketplace::StripeOverviewComponent, type: :component do
-  pending "add some examples to (or delete) #{__FILE__}"
+  # pending "add some examples to (or delete) #{__FILE__}"
+  subject(:output) { render_inline(component) }
 
-  # it "renders something useful" do
-  #   expect(
-  #     render_inline(described_class.new(attr: "value")) { "Hello, components!" }.css("p").to_html
-  #   ).to include(
-  #     "Hello, components!"
-  #   )
-  # end
+  let(:component) { described_class.new(marketplace: marketplace) }
+
+  context "when the Marketplace has a Stripe Utility" do
+    let(:marketplace) { create(:marketplace, :with_stripe_utility) }
+
+    it { is_expected.to have_content marketplace.stripe_utility.name }
+
+    it { is_expected.to have_link "View #{I18n.t("marketplace.stripe_accounts.show.link_to")}" }
+  end
+
+  context "when the Marketplace is missing a Stripe Utility" do
+    let(:marketplace) { create(:marketplace) }
+
+    it { is_expected.to have_link "Add #{I18n.t("marketplace.stripe_accounts.show.link_to")}" }
+
+    it { is_expected.to have_content "To start accepting payments, add your Stripe Account." }
+  end
 end

--- a/spec/furniture/marketplace/collecting_payments_system_spec.rb
+++ b/spec/furniture/marketplace/collecting_payments_system_spec.rb
@@ -19,7 +19,7 @@ describe "Marketplace: Collecting Payments", type: :system do
       end
 
       click_on("Payment Settings")
-      click_on("View Stripe Account")
+      click_on("Stripe Account")
       click_on("Add a Stripe API key to #{space.name}")
       click_on("Add Utility")
       select("stripe", from: "Type")
@@ -35,7 +35,7 @@ describe "Marketplace: Collecting Payments", type: :system do
 
       visit polymorphic_path(marketplace.location(:edit))
       click_on("Payment Settings")
-      click_on("View Stripe Account")
+      click_on("Stripe Account")
       expect(page).to have_content("Connect to Stripe")
     end
 
@@ -47,7 +47,7 @@ describe "Marketplace: Collecting Payments", type: :system do
         click_on("Manage Marketplace")
       end
       click_on("Payment Settings")
-      click_on("View Stripe Account")
+      click_on("Stripe Account")
       expect(page).to have_content("Connect to Stripe")
       # @todo actually figure out how to do the connect to stripe bit :X
     end

--- a/spec/furniture/marketplace/collecting_payments_system_spec.rb
+++ b/spec/furniture/marketplace/collecting_payments_system_spec.rb
@@ -19,7 +19,9 @@ describe "Marketplace: Collecting Payments", type: :system do
       end
 
       click_on("Payment Settings")
-      click_on("Stripe Account")
+      within("#stripe_overview") do
+        click_on("Add Stripe Account")
+      end
       click_on("Add a Stripe API key to #{space.name}")
       click_on("Add Utility")
       select("stripe", from: "Type")
@@ -35,7 +37,7 @@ describe "Marketplace: Collecting Payments", type: :system do
 
       visit polymorphic_path(marketplace.location(:edit))
       click_on("Payment Settings")
-      click_on("Stripe Account")
+      click_on("View Stripe Account")
       expect(page).to have_content("Connect to Stripe")
     end
 
@@ -47,7 +49,7 @@ describe "Marketplace: Collecting Payments", type: :system do
         click_on("Manage Marketplace")
       end
       click_on("Payment Settings")
-      click_on("Stripe Account")
+      click_on("View Stripe Account")
       expect(page).to have_content("Connect to Stripe")
       # @todo actually figure out how to do the connect to stripe bit :X
     end


### PR DESCRIPTION
Writing a component view spec encouraged me to "find" the actual conditional cases present here. Generally I prefer unwrapping these cases with separate rendering paths rather than doing more inline cleverness switching on value presence. 