### PR TITLE
🌸 `Themes`: Try a stone?

### DIFF
--- a/app/assets/stylesheets/components/button.scss
+++ b/app/assets/stylesheets/components/button.scss
@@ -19,12 +19,12 @@
     }
 
     &.--danger {
-      @apply bg-danger-500;
+      @apply bg-red-500;
       &:hover {
-        @apply bg-danger-700;
+        @apply bg-red-700;
       }
       &:active {
-        @apply bg-danger-200;
+        @apply bg-red-200;
       }
     }
 

--- a/app/assets/stylesheets/components/button.scss
+++ b/app/assets/stylesheets/components/button.scss
@@ -5,13 +5,13 @@
   [type="submit"],
   button,
   .button {
-    @apply font-bold py-2 px-4 rounded bg-purple-500 text-white text-center transition ease-in-out duration-150;
+    @apply font-bold py-2 px-4 rounded bg-orange-500 text-white text-center transition ease-in-out duration-150;
 
     &:hover {
-      @apply bg-purple-700;
+      @apply bg-orange-700;
     }
     &:active {
-      @apply bg-purple-200;
+      @apply bg-orange-200;
     }
 
     &:focus {

--- a/app/assets/stylesheets/components/button.scss
+++ b/app/assets/stylesheets/components/button.scss
@@ -15,7 +15,7 @@
     }
 
     &:focus {
-      @apply outline-none border-neutral-300  ring-gray-500;
+      @apply outline-none border-gray-300  ring-gray-500;
     }
 
     &.--danger {
@@ -29,12 +29,12 @@
     }
 
     &.--neutral {
-      @apply bg-neutral-500;
+      @apply bg-gray-500;
       &:hover {
-        @apply bg-neutral-700;
+        @apply bg-gray-700;
       }
       &:active {
-        @apply bg-neutral-200;
+        @apply bg-gray-200;
       }
     }
   }

--- a/app/assets/stylesheets/components/button.scss
+++ b/app/assets/stylesheets/components/button.scss
@@ -5,13 +5,13 @@
   [type="submit"],
   button,
   .button {
-    @apply font-bold py-2 px-4 rounded bg-primary-500 text-white text-center transition ease-in-out duration-150;
+    @apply font-bold py-2 px-4 rounded bg-purple-500 text-white text-center transition ease-in-out duration-150;
 
     &:hover {
-      @apply bg-primary-700;
+      @apply bg-purple-700;
     }
     &:active {
-      @apply bg-primary-200;
+      @apply bg-purple-200;
     }
 
     &:focus {

--- a/app/assets/stylesheets/components/button.scss
+++ b/app/assets/stylesheets/components/button.scss
@@ -8,7 +8,7 @@
     @apply font-bold py-2 px-4 rounded bg-orange-500 text-white text-center transition ease-in-out duration-150;
 
     &:hover {
-      @apply bg-orange-700;
+      @apply bg-orange-400;
     }
     &:active {
       @apply bg-orange-200;

--- a/app/assets/stylesheets/components/button.scss
+++ b/app/assets/stylesheets/components/button.scss
@@ -5,13 +5,13 @@
   [type="submit"],
   button,
   .button {
-    @apply font-bold py-2 px-4 rounded bg-orange-500 text-white text-center transition ease-in-out duration-150;
+    @apply font-bold py-2 px-4 rounded bg-stone-500 text-white text-center transition ease-in-out duration-150;
 
     &:hover {
-      @apply bg-orange-400;
+      @apply bg-stone-400;
     }
     &:active {
-      @apply bg-orange-200;
+      @apply bg-stone-200;
     }
 
     &:focus {

--- a/app/assets/stylesheets/components/footer.scss
+++ b/app/assets/stylesheets/components/footer.scss
@@ -1,5 +1,5 @@
 @layer components {
   body > footer {
-    @apply flex items-center justify-between px-2 py-2 bg-primary-900 text-white;
+    @apply flex items-center justify-between px-2 py-2 bg-purple-900 text-white;
   }
 }

--- a/app/assets/stylesheets/components/footer.scss
+++ b/app/assets/stylesheets/components/footer.scss
@@ -1,5 +1,5 @@
 @layer components {
   body > footer {
-    @apply flex items-center justify-between px-2 py-2 bg-orange-900 text-white;
+    @apply flex items-center justify-between px-2 py-2 bg-orange-500 text-white;
   }
 }

--- a/app/assets/stylesheets/components/footer.scss
+++ b/app/assets/stylesheets/components/footer.scss
@@ -1,5 +1,5 @@
 @layer components {
   body > footer {
-    @apply flex items-center justify-between px-2 py-2 bg-purple-900 text-white;
+    @apply flex items-center justify-between px-2 py-2 bg-orange-900 text-white;
   }
 }

--- a/app/assets/stylesheets/components/footer.scss
+++ b/app/assets/stylesheets/components/footer.scss
@@ -1,5 +1,5 @@
 @layer components {
   body > footer {
-    @apply flex items-center justify-between px-2 py-2 bg-orange-500 text-white;
+    @apply flex items-center justify-between px-2 py-2 bg-stone-500 text-white;
   }
 }

--- a/app/assets/stylesheets/components/form.scss
+++ b/app/assets/stylesheets/components/form.scss
@@ -35,7 +35,7 @@
       @apply py-2 px-4
         rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset
         ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset
-        focus:ring-orange-300;
+        focus:ring-stone-300;
 
       @screen sm {
         @apply leading-6 text-sm;

--- a/app/assets/stylesheets/components/form.scss
+++ b/app/assets/stylesheets/components/form.scss
@@ -35,7 +35,7 @@
       @apply py-2 px-4
         rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset
         ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset
-        focus:ring-purple-300;
+        focus:ring-orange-300;
 
       @screen sm {
         @apply leading-6 text-sm;

--- a/app/assets/stylesheets/components/form.scss
+++ b/app/assets/stylesheets/components/form.scss
@@ -3,7 +3,7 @@
     @apply bg-white shadow rounded-lg p-2 mt-2;
 
     legend {
-      @apply text-lg leading-6 font-medium text-neutral-900;
+      @apply text-lg leading-6 font-medium text-gray-900;
     }
   }
 
@@ -19,7 +19,7 @@
       @apply block w-full;
     }
     label {
-      @apply font-medium text-sm leading-6 text-neutral-700 mb-1;
+      @apply font-medium text-sm leading-6 text-gray-700 mb-1;
     }
 
     input[type="email"],
@@ -71,7 +71,7 @@
     select:disabled,
     textarea:disabled,
     input:disabled {
-      @apply bg-neutral-200;
+      @apply bg-gray-200;
     }
     .field_with_errors {
       @apply text-red-500;

--- a/app/assets/stylesheets/components/form.scss
+++ b/app/assets/stylesheets/components/form.scss
@@ -35,7 +35,7 @@
       @apply py-2 px-4
         rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset
         ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset
-        focus:ring-primary-300;
+        focus:ring-purple-300;
 
       @screen sm {
         @apply leading-6 text-sm;

--- a/app/assets/stylesheets/components/header.scss
+++ b/app/assets/stylesheets/components/header.scss
@@ -21,7 +21,7 @@
     }
 
     &.--alert {
-      @apply bg-danger-100 text-danger-900;
+      @apply bg-red-100 text-red-900;
     }
   }
 }

--- a/app/assets/stylesheets/components/header.scss
+++ b/app/assets/stylesheets/components/header.scss
@@ -1,6 +1,6 @@
 @layer components {
   body > header {
-    @apply flex justify-between px-2 py-2 bg-orange-900 text-white place-items-end;
+    @apply flex justify-between px-2 py-2 bg-orange-500 text-white place-items-end;
 
     .profile-menu {
       @apply flex flex-row relative;
@@ -17,7 +17,7 @@
     @apply px-4 py-4;
 
     &.--notice {
-      @apply bg-orange-100 text-orange-900;
+      @apply bg-orange-100 text-orange-500;
     }
 
     &.--alert {

--- a/app/assets/stylesheets/components/header.scss
+++ b/app/assets/stylesheets/components/header.scss
@@ -1,6 +1,6 @@
 @layer components {
   body > header {
-    @apply flex justify-between px-2 py-2 bg-orange-500 text-white place-items-end;
+    @apply flex justify-between px-2 py-2 bg-stone-500 text-white place-items-end;
 
     .profile-menu {
       @apply flex flex-row relative;
@@ -17,7 +17,7 @@
     @apply px-4 py-4;
 
     &.--notice {
-      @apply bg-orange-100 text-orange-500;
+      @apply bg-stone-100 text-stone-500;
     }
 
     &.--alert {

--- a/app/assets/stylesheets/components/header.scss
+++ b/app/assets/stylesheets/components/header.scss
@@ -1,6 +1,6 @@
 @layer components {
   body > header {
-    @apply flex justify-between px-2 py-2 bg-purple-900 text-white place-items-end;
+    @apply flex justify-between px-2 py-2 bg-orange-900 text-white place-items-end;
 
     .profile-menu {
       @apply flex flex-row relative;
@@ -17,7 +17,7 @@
     @apply px-4 py-4;
 
     &.--notice {
-      @apply bg-purple-100 text-purple-900;
+      @apply bg-orange-100 text-orange-900;
     }
 
     &.--alert {

--- a/app/assets/stylesheets/components/header.scss
+++ b/app/assets/stylesheets/components/header.scss
@@ -1,6 +1,6 @@
 @layer components {
   body > header {
-    @apply flex justify-between px-2 py-2 bg-primary-900 text-white place-items-end;
+    @apply flex justify-between px-2 py-2 bg-purple-900 text-white place-items-end;
 
     .profile-menu {
       @apply flex flex-row relative;
@@ -17,7 +17,7 @@
     @apply px-4 py-4;
 
     &.--notice {
-      @apply bg-primary-100 text-primary-900;
+      @apply bg-purple-100 text-purple-900;
     }
 
     &.--alert {

--- a/app/components/alert_component.rb
+++ b/app/components/alert_component.rb
@@ -25,7 +25,7 @@ class AlertComponent < ApplicationComponent
     when :success
       "bg-green-50"
     else
-      "bg-violet-50"
+      "bg-stone-50"
     end
   end
 
@@ -38,7 +38,7 @@ class AlertComponent < ApplicationComponent
     when :success
       "text-green-400"
     else
-      "text-violet-400"
+      "text-stone-400"
     end
   end
 
@@ -51,7 +51,7 @@ class AlertComponent < ApplicationComponent
     when :success
       "text-green-800"
     else
-      "text-violet-800"
+      "text-stone-800"
     end
   end
 
@@ -64,7 +64,7 @@ class AlertComponent < ApplicationComponent
     when :success
       "text-green-700"
     else
-      "text-violet-700"
+      "text-stone-700"
     end
   end
 end

--- a/app/components/button_component.rb
+++ b/app/components/button_component.rb
@@ -69,17 +69,17 @@ class ButtonComponent < ApplicationComponent
       "focus-visible:outline",
       "focus-visible:outline-2",
       "focus-visible:outline-offset-2",
-      "focus-visible:outline-purple-600"
+      "focus-visible:outline-orange-600"
     ]
   end
 
   def secondary_classes
     [
       "bg-white",
-      "text-purple-950",
+      "text-orange-950",
       "ring-gray-300",
-      "hover:bg-purple-100",
-      "hover:text-purple-700"
+      "hover:bg-orange-100",
+      "hover:text-orange-700"
     ]
   end
 
@@ -94,9 +94,9 @@ class ButtonComponent < ApplicationComponent
 
   def primary_classes
     [
-      "bg-purple-600",
+      "bg-orange-600",
       "text-white",
-      "hover:bg-purple-700",
+      "hover:bg-orange-700",
       "hover:text-white"
     ]
   end

--- a/app/components/button_component.rb
+++ b/app/components/button_component.rb
@@ -69,17 +69,17 @@ class ButtonComponent < ApplicationComponent
       "focus-visible:outline",
       "focus-visible:outline-2",
       "focus-visible:outline-offset-2",
-      "focus-visible:outline-orange-400"
+      "focus-visible:outline-stone-400"
     ]
   end
 
   def secondary_classes
     [
       "bg-white",
-      "text-orange-950",
+      "text-stone-950",
       "ring-gray-300",
-      "hover:bg-orange-100",
-      "hover:text-orange-700"
+      "hover:bg-stone-100",
+      "hover:text-stone-700"
     ]
   end
 
@@ -94,9 +94,9 @@ class ButtonComponent < ApplicationComponent
 
   def primary_classes
     [
-      "bg-orange-500",
+      "bg-stone-500",
       "text-white",
-      "hover:bg-orange-400",
+      "hover:bg-stone-400",
       "hover:text-white"
     ]
   end

--- a/app/components/button_component.rb
+++ b/app/components/button_component.rb
@@ -69,7 +69,7 @@ class ButtonComponent < ApplicationComponent
       "focus-visible:outline",
       "focus-visible:outline-2",
       "focus-visible:outline-offset-2",
-      "focus-visible:outline-orange-600"
+      "focus-visible:outline-orange-400"
     ]
   end
 
@@ -94,9 +94,9 @@ class ButtonComponent < ApplicationComponent
 
   def primary_classes
     [
-      "bg-orange-600",
+      "bg-orange-500",
       "text-white",
-      "hover:bg-orange-700",
+      "hover:bg-orange-400",
       "hover:text-white"
     ]
   end

--- a/app/components/button_component.rb
+++ b/app/components/button_component.rb
@@ -85,9 +85,9 @@ class ButtonComponent < ApplicationComponent
 
   def danger_classes
     [
-      "bg-danger-500",
-      "hover:bg-danger-700",
-      "active:bg-danger-200",
+      "bg-red-500",
+      "hover:bg-red-700",
+      "active:bg-red-200",
       "text-white"
     ]
   end

--- a/app/components/card_component.rb
+++ b/app/components/card_component.rb
@@ -20,7 +20,7 @@ class CardComponent < ApplicationComponent
 
   def card_classes_footer
     [
-      "bg-purple-50",
+      "bg-orange-50",
       "p-4",
       "sm:p-6",
       # content? is not always working as described, and is returning a proc in some cases rather than a boolean

--- a/app/components/card_component.rb
+++ b/app/components/card_component.rb
@@ -20,7 +20,7 @@ class CardComponent < ApplicationComponent
 
   def card_classes_footer
     [
-      "bg-orange-50",
+      "bg-stone-50",
       "p-4",
       "sm:p-6",
       # content? is not always working as described, and is returning a proc in some cases rather than a boolean

--- a/app/furniture/journal/entry_component.html.erb
+++ b/app/furniture/journal/entry_component.html.erb
@@ -1,6 +1,6 @@
 <article class="w-full p-2 my-2 bg-white rounded flex flex-col justify-between">
-  <header class="border-b border-purple-500">
-    <h2 class=" text-purple-900"><%= entry.headline %></h2>
+  <header class="border-b border-orange-500">
+    <h2 class=" text-orange-900"><%= entry.headline %></h2>
     <%- if entry.published?%>
       <em>Published on <%= link_to published_at, entry.location %></em>
     <%- else %>

--- a/app/furniture/journal/entry_component.html.erb
+++ b/app/furniture/journal/entry_component.html.erb
@@ -1,6 +1,6 @@
 <article class="w-full p-2 my-2 bg-white rounded flex flex-col justify-between">
-  <header class="border-b border-orange-500">
-    <h2 class=" text-orange-900"><%= entry.headline %></h2>
+  <header class="border-b border-stone-500">
+    <h2 class=" text-stone-900"><%= entry.headline %></h2>
     <%- if entry.published?%>
       <em>Published on <%= link_to published_at, entry.location %></em>
     <%- else %>

--- a/app/furniture/journal/entry_component.html.erb
+++ b/app/furniture/journal/entry_component.html.erb
@@ -1,6 +1,6 @@
 <article class="w-full p-2 my-2 bg-white rounded flex flex-col justify-between">
-  <header class="border-b border-primary-500">
-    <h2 class=" text-primary-900"><%= entry.headline %></h2>
+  <header class="border-b border-purple-500">
+    <h2 class=" text-purple-900"><%= entry.headline %></h2>
     <%- if entry.published?%>
       <em>Published on <%= link_to published_at, entry.location %></em>
     <%- else %>

--- a/app/furniture/marketplace/cart/deliveries/_delivery.html.erb
+++ b/app/furniture/marketplace/cart/deliveries/_delivery.html.erb
@@ -7,7 +7,7 @@
 <%= turbo_frame_tag(delivery) do %>
   <% if delivery.details_filled_in? %>
     <p class="font-bold">Delivering to:</p>
-    <div class="rounded p-2 bg-violet-50">
+    <div class="rounded p-2 bg-stone-50">
       <p>
         <%= delivery.contact_email %><br />
         <%= number_to_phone(delivery.contact_phone_number) %><br />

--- a/app/views/application/_radio_group.html.erb
+++ b/app/views/application/_radio_group.html.erb
@@ -3,7 +3,7 @@
   <%- options.each do |option| %>
     <div class="flex items-center mb-0">
       <%= form.radio_button attribute, option,
-          class: "h-4 w-4 border-gray-300 text-orange-500 focus:ring-orange-600" %>
+          class: "h-4 w-4 border-gray-300 text-stone-500 focus:ring-stone-600" %>
       <%= form.label attribute, option, value: option,
           class: "ml-3 block text-sm leading-6 text-gray-900" %>
     </div>

--- a/app/views/application/_radio_group.html.erb
+++ b/app/views/application/_radio_group.html.erb
@@ -3,7 +3,7 @@
   <%- options.each do |option| %>
     <div class="flex items-center mb-0">
       <%= form.radio_button attribute, option,
-          class: "h-4 w-4 border-gray-300 text-purple-900 focus:ring-purple-600" %>
+          class: "h-4 w-4 border-gray-300 text-orange-900 focus:ring-orange-600" %>
       <%= form.label attribute, option, value: option,
           class: "ml-3 block text-sm leading-6 text-gray-900" %>
     </div>

--- a/app/views/application/_radio_group.html.erb
+++ b/app/views/application/_radio_group.html.erb
@@ -3,7 +3,7 @@
   <%- options.each do |option| %>
     <div class="flex items-center mb-0">
       <%= form.radio_button attribute, option,
-          class: "h-4 w-4 border-gray-300 text-orange-900 focus:ring-orange-600" %>
+          class: "h-4 w-4 border-gray-300 text-orange-500 focus:ring-orange-600" %>
       <%= form.label attribute, option, value: option,
           class: "ml-3 block text-sm leading-6 text-gray-900" %>
     </div>

--- a/app/views/buttons/_minus.html.erb
+++ b/app/views/buttons/_minus.html.erb
@@ -9,7 +9,7 @@
 <%- if !disabled %>
   <%= link_to label, href, title: title, method: method,
                 data: data,
-                class: 'no-underline bg-transparent hover:bg-primary-100 button' %>
+                class: 'no-underline bg-transparent hover:bg-purple-100 button' %>
 <%- else %>
-  <span class='no-underline bg-transparent hover:bg-primary-100 button'><%=label%></span>
+  <span class='no-underline bg-transparent hover:bg-purple-100 button'><%=label%></span>
 <%- end %>

--- a/app/views/buttons/_minus.html.erb
+++ b/app/views/buttons/_minus.html.erb
@@ -9,7 +9,7 @@
 <%- if !disabled %>
   <%= link_to label, href, title: title, method: method,
                 data: data,
-                class: 'no-underline bg-transparent hover:bg-purple-100 button' %>
+                class: 'no-underline bg-transparent hover:bg-orange-100 button' %>
 <%- else %>
-  <span class='no-underline bg-transparent hover:bg-purple-100 button'><%=label%></span>
+  <span class='no-underline bg-transparent hover:bg-orange-100 button'><%=label%></span>
 <%- end %>

--- a/app/views/buttons/_minus.html.erb
+++ b/app/views/buttons/_minus.html.erb
@@ -9,7 +9,7 @@
 <%- if !disabled %>
   <%= link_to label, href, title: title, method: method,
                 data: data,
-                class: 'no-underline bg-transparent hover:bg-orange-100 button' %>
+                class: 'no-underline bg-transparent hover:bg-stone-100 button' %>
 <%- else %>
-  <span class='no-underline bg-transparent hover:bg-orange-100 button'><%=label%></span>
+  <span class='no-underline bg-transparent hover:bg-stone-100 button'><%=label%></span>
 <%- end %>

--- a/app/views/buttons/_plus.html.erb
+++ b/app/views/buttons/_plus.html.erb
@@ -7,4 +7,4 @@
 
 <%= link_to label, href, title: title,
               data: data,
-              class: 'no-underline bg-transparent hover:bg-primary-100 button' %>
+              class: 'no-underline bg-transparent hover:bg-purple-100 button' %>

--- a/app/views/buttons/_plus.html.erb
+++ b/app/views/buttons/_plus.html.erb
@@ -7,4 +7,4 @@
 
 <%= link_to label, href, title: title,
               data: data,
-              class: 'no-underline bg-transparent hover:bg-orange-100 button' %>
+              class: 'no-underline bg-transparent hover:bg-stone-100 button' %>

--- a/app/views/buttons/_plus.html.erb
+++ b/app/views/buttons/_plus.html.erb
@@ -7,4 +7,4 @@
 
 <%= link_to label, href, title: title,
               data: data,
-              class: 'no-underline bg-transparent hover:bg-purple-100 button' %>
+              class: 'no-underline bg-transparent hover:bg-orange-100 button' %>

--- a/app/views/furnitures/_furniture.html.erb
+++ b/app/views/furnitures/_furniture.html.erb
@@ -4,7 +4,7 @@
 
 <section id="<%= dom_id(furniture) %>" class="mt-4 relative">
   <%- if local_assigns[:editing] %>
-    <header class="flex border-b border-dashed border-orange-900 justify-between">
+    <header class="flex border-b border-dashed border-orange-500 justify-between">
       <h4><%= furniture.title %></h4>
       <div>
         <%- if edit_href.present? %>

--- a/app/views/furnitures/_furniture.html.erb
+++ b/app/views/furnitures/_furniture.html.erb
@@ -4,7 +4,7 @@
 
 <section id="<%= dom_id(furniture) %>" class="mt-4 relative">
   <%- if local_assigns[:editing] %>
-    <header class="flex border-b border-dashed border-orange-500 justify-between">
+    <header class="flex border-b border-dashed border-stone-500 justify-between">
       <h4><%= furniture.title %></h4>
       <div>
         <%- if edit_href.present? %>

--- a/app/views/furnitures/_furniture.html.erb
+++ b/app/views/furnitures/_furniture.html.erb
@@ -4,7 +4,7 @@
 
 <section id="<%= dom_id(furniture) %>" class="mt-4 relative">
   <%- if local_assigns[:editing] %>
-    <header class="flex border-b border-dashed border-primary-900 justify-between">
+    <header class="flex border-b border-dashed border-purple-900 justify-between">
       <h4><%= furniture.title %></h4>
       <div>
         <%- if edit_href.present? %>

--- a/app/views/furnitures/_furniture.html.erb
+++ b/app/views/furnitures/_furniture.html.erb
@@ -4,7 +4,7 @@
 
 <section id="<%= dom_id(furniture) %>" class="mt-4 relative">
   <%- if local_assigns[:editing] %>
-    <header class="flex border-b border-dashed border-purple-900 justify-between">
+    <header class="flex border-b border-dashed border-orange-900 justify-between">
       <h4><%= furniture.title %></h4>
       <div>
         <%- if edit_href.present? %>

--- a/app/views/spaces/_room_card.html.erb
+++ b/app/views/spaces/_room_card.html.erb
@@ -1,14 +1,14 @@
 <%= link_to [room.space, room], class: "no-underline" do %>
   <%= render CardComponent.new(
       data: { access_level: room.access_level, slug: room.slug, model: "room", id: room.id },
-      classes: "group self-stretch hover:bg-orange-100"
+      classes: "group self-stretch hover:bg-orange-50"
       ) do %>
     <div class="px-4 py-5 flex items-center justify-between">
-      <h3 class="text-base font-semibold text-orange-900 group-hover:text-orange-700">
+      <h3 class="text-base font-semibold text-orange-500 group-hover:text-orange-400">
         <%= room.name %>
       </h3>
 
-      <button class="rounded-full bg-orange-800 p-1 ml-2 text-white shadow-sm group-hover:bg-orange-700" data-role="enter">
+      <button class="rounded-full bg-orange-500 p-1 ml-2 text-white shadow-sm group-hover:bg-orange-400" data-role="enter">
         <%= render SvgComponent.new(classes: "h-5 w-5") do %>
           <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
         <% end %>

--- a/app/views/spaces/_room_card.html.erb
+++ b/app/views/spaces/_room_card.html.erb
@@ -1,14 +1,14 @@
 <%= link_to [room.space, room], class: "no-underline" do %>
   <%= render CardComponent.new(
       data: { access_level: room.access_level, slug: room.slug, model: "room", id: room.id },
-      classes: "group self-stretch hover:bg-orange-50"
+      classes: "group self-stretch hover:bg-stone-50"
       ) do %>
     <div class="px-4 py-5 flex items-center justify-between">
-      <h3 class="text-base font-semibold text-orange-500 group-hover:text-orange-400">
+      <h3 class="text-base font-semibold text-stone-500 group-hover:text-stone-400">
         <%= room.name %>
       </h3>
 
-      <button class="rounded-full bg-orange-500 p-1 ml-2 text-white shadow-sm group-hover:bg-orange-400" data-role="enter">
+      <button class="rounded-full bg-stone-500 p-1 ml-2 text-white shadow-sm group-hover:bg-stone-400" data-role="enter">
         <%= render SvgComponent.new(classes: "h-5 w-5") do %>
           <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
         <% end %>

--- a/app/views/spaces/_room_card.html.erb
+++ b/app/views/spaces/_room_card.html.erb
@@ -1,14 +1,14 @@
 <%= link_to [room.space, room], class: "no-underline" do %>
   <%= render CardComponent.new(
       data: { access_level: room.access_level, slug: room.slug, model: "room", id: room.id },
-      classes: "group self-stretch hover:bg-purple-100"
+      classes: "group self-stretch hover:bg-orange-100"
       ) do %>
     <div class="px-4 py-5 flex items-center justify-between">
-      <h3 class="text-base font-semibold text-purple-900 group-hover:text-purple-700">
+      <h3 class="text-base font-semibold text-orange-900 group-hover:text-orange-700">
         <%= room.name %>
       </h3>
 
-      <button class="rounded-full bg-purple-800 p-1 ml-2 text-white shadow-sm group-hover:bg-purple-700" data-role="enter">
+      <button class="rounded-full bg-orange-800 p-1 ml-2 text-white shadow-sm group-hover:bg-orange-700" data-role="enter">
         <%= render SvgComponent.new(classes: "h-5 w-5") do %>
           <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
         <% end %>

--- a/spec/components/button_component_spec.rb
+++ b/spec/components/button_component_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe ButtonComponent, type: :component do
     context "when the scheme is `:danger`" do
       let(:component) { described_class.new(**params.merge({scheme: :danger})) }
 
-      it { expect(output.at_css(".bg-danger-500")).to be_present }
+      it { expect(output.at_css(".bg-red-500")).to be_present }
     end
   end
 end

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -14,7 +14,6 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        primary: colors.purple,
         danger: colors.red,
         neutral: colors.gray,
       },

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -11,13 +11,6 @@ module.exports = {
     './app/helpers/**/*.rb',
     './app/javascript/**/*.js'
   ],
-  theme: {
-    extend: {
-      colors: {
-        neutral: colors.gray,
-      },
-    },
-  },
   plugins: [
     require('@tailwindcss/typography'),
     require('@tailwindcss/forms'),

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -14,7 +14,6 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        danger: colors.red,
         neutral: colors.gray,
       },
     },


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/621

OK I'm just futzing about; but I *think* what we can do is pull in most of the places where we use colors into the `ViewComponent` layer; then we could put together pallettes with appropriately balanced colors across the built-in tailwind colors.

From there, we can define custom colors for each client with a particular brand, for example `piikup-orange` in tailwind landia!


Anyway, here's the stoney-version!
![Screenshot 2023-09-30 at 20-13-02 Convene - Zee's Space](https://github.com/zinc-collective/convene/assets/50284/5e36f087-d060-4daf-a817-c6a5224bdf7a)
