### PR TITLE
🧹 `Neighborhood`: Stop telling Sentry about authorization errors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -159,7 +159,6 @@ class ApplicationController < ActionController::Base
   end
 
   def handle_unauthorized(exception)
-    Sentry.capture_exception(exception, level: :warn)
     render_not_found
   end
 


### PR DESCRIPTION
https://github.com/zinc-collective/convene/issues/1844

I think we've reached the point where this is mostly just noise.

It's possible we should doing more; but the 404 page asks them to make sure they are logged in; so I think it should be fine.

Maybe one day we will add an "if you think you've reached this page in error" or something...