### PR TITLE
✨ `Marketplace`: Show `DeliveryFee` when `DeliveryArea` is selected

### DIFF
--- a/app/furniture/marketplace/carts/_total.html.erb
+++ b/app/furniture/marketplace/carts/_total.html.erb
@@ -4,7 +4,7 @@
   <span>
     Taxes:
     <%= humanized_money_with_symbol(cart.tax_total) %></span>
-  <%- if cart.delivery_address.present? %>
+  <%- if cart.delivery_area.present? %>
     <span data-cart-delivery-fee>Delivery Fee:
       <%= humanized_money_with_symbol(cart.delivery_fee) %></span>
   <%- end %>


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1325
- https://github.com/zinc-collective/convene/issues/1136

I think this is leftover from when we collected both the address and the area at the same time.