### PR TITLE
🧹 `Section`: Drop the `publicity_level` column, since it is dead

### DIFF
--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -1,6 +1,5 @@
 # A Room in Convene acts as a gathering place.
 class Room < ApplicationRecord
-  self.ignored_columns += [:publicity_level]
   # The space whose settings govern the default publicity and access controls for the Room.
   belongs_to :space, inverse_of: :rooms
   location(parent: :space)

--- a/db/migrate/20231005005905_drop_publicity_level_from_rooms.rb
+++ b/db/migrate/20231005005905_drop_publicity_level_from_rooms.rb
@@ -1,0 +1,7 @@
+class DropPublicityLevelFromRooms < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      remove_column :rooms, :publicity_level, type: :string, default: :listed
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_14_180326) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_05_005905) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -252,7 +252,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_14_180326) do
     t.string "name"
     t.string "slug"
     t.string "access_level", default: "public", null: false
-    t.string "publicity_level", default: "listed", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "space_id"


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1155