### PR TITLE
🐞🔨 `Authentication`: Don't explode when OTP or OTP secrets are nil

### DIFF
--- a/app/models/authentication_method.rb
+++ b/app/models/authentication_method.rb
@@ -37,6 +37,7 @@ class AuthenticationMethod < ApplicationRecord
   end
 
   def verify?(one_time_password)
+    return false if one_time_password.blank? || one_time_password_secret.blank?
     totp.verify(one_time_password).present?
   end
 

--- a/spec/models/authentication_method_spec.rb
+++ b/spec/models/authentication_method_spec.rb
@@ -41,6 +41,15 @@ RSpec.describe AuthenticationMethod do
 
       expect(authentication_method).not_to be_verify(one_time_password)
     end
+
+    it "is false when the OTP is nil" do
+      expect(authentication_method).not_to be_verify(nil)
+    end
+
+    it "is false when the OTPS is nil" do
+      authentication_method.one_time_password_secret = nil
+      expect(authentication_method).not_to be_verify("an otp")
+    end
   end
 
   describe "#send_one_time_password!(space)" do


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1809

There's a couple things happening, one of which is if an `AuthenticationMethod` does not have a One Time Password Secret, it can't actually do the verification.

So i've added a check to make sure it returns false in cases when the OTP secret has not been set yet; as well as when a nil OTP is provided.