### PR TITLE
🐞🔨`Authentication` Prevent race condition when double-tapping sign-in

### DIFF
--- a/app/models/authenticated_session.rb
+++ b/app/models/authenticated_session.rb
@@ -45,6 +45,16 @@ class AuthenticatedSession
     end
 
     false
+  rescue ActiveRecord::RecordInvalid
+    self.authentication_method = nil
+    if one_time_password.nil?
+      authentication_method.send_one_time_password!(space)
+      false
+    elsif authentication_method.verify?(one_time_password)
+      session[:person_id] = authentication_method.person.id
+      authentication_method.confirm!
+      true
+    end
   end
 
   # If we don't have a OTP _or_ a way of issuing one, there's nothin' we can do.


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1809

OK, so my working assumption is that the bug is caused by two requests being processed at the same time for a new email address, and the first one creates the `AuthenticationMethod` and the second one *tries* to, and fails; resulting in the validation error.

This requeries the database and retries the rest of the work.

Would love to have names for methods to pull this out into, rather than copy-pasting the method body but oh well.