### PR TITLE
🐞🔨 `Section`: Deleting Sections is possible again

### DIFF
--- a/app/views/rooms/_form.html.erb
+++ b/app/views/rooms/_form.html.erb
@@ -8,11 +8,6 @@
     <%= render "radio_group", attribute: :access_level, options: Room::access_levels.values, form: room_form %>
 
     <footer>
-      <%- if policy(room).destroy? && room.persisted? %>
-        <%= room_form.button name: "_method", value: "delete", class: "--danger" do %>
-          <%=t('.destroy')%>
-        <%- end %>
-      <%- end %>
 
       <%= room_form.submit %>
     </footer>

--- a/app/views/rooms/edit.html.erb
+++ b/app/views/rooms/edit.html.erb
@@ -20,3 +20,17 @@
     <%= render "furnitures/new", furniture: new_furniture %>
   <%- end %>
 <% end %>
+
+
+<%- if policy(room).destroy? && room.persisted? && !room.entrance? %>
+  <div class="m-5">
+    <h2>Remove this Section?</h2>
+    <%- data = {} %>
+    <%- if !room.gizmos.reload.empty? %>
+      <p>Warning! Deleting this Section will also delete all Gizmos and their related data. Please be very sure you want to do this! We recommend making the Section "internal" instead.</p>
+      <%- data[:turbo_confirm] = I18n.t("rooms.destroy.confirm", room_name: room.name) %>
+    <%- end %>
+
+    <%= button_to(t('rooms.destroy.link_to'), room.location, data: data, method: :delete, class: "--danger w-full") %>
+  </div>
+<%- end %>

--- a/config/locales/room/en.yml
+++ b/config/locales/room/en.yml
@@ -7,10 +7,10 @@ en:
     update:
       success: You've updated Section '%{room_name}' successfully! 🎉
     destroy:
+      link_to: "Remove Section 🗑️"
+      confirm: "Removing Section '%{room_name}' is permanent and irreversible! Do you still want to proceed?"
       success: You've removed Section '%{room_name}' successfully! 🎉
       failure: We couldn't remove Section '%{room_name}'.
-    form:
-      destroy: "Remove Section 🗑️"
   helpers:
     submit:
       room:

--- a/spec/system/sections_spec.rb
+++ b/spec/system/sections_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe "Sections" do
+  describe "Removing a Section" do
+    let(:space) { create(:space, :with_entrance, :with_members, member_count: 1) }
+
+    before do
+      sign_in(space.members.first, space)
+      visit(polymorphic_path(section.location(:edit)))
+    end
+
+    context "when the section is an entrance" do
+      let(:section) { space.entrance }
+
+      it "doesn't let you delete the entrance" do
+        expect(page).not_to have_content(I18n.t("rooms.destroy.link_to"))
+      end
+    end
+
+    context "when the section is not the entrance" do
+      let(:section) { create(:room, space: space) }
+
+      context "when the Section has no Gizmos" do
+        it "deletes the Section from the Database" do
+          click_on(I18n.t("rooms.destroy.link_to"))
+
+          expect(page).to have_content(I18n.t("rooms.destroy.success", room_name: section.name))
+          expect(space.rooms).not_to be_exist(id: section.id)
+        end
+      end
+
+      context "when the section has Gizmos" do
+        before {
+          create(:furniture, room: section)
+          refresh
+        }
+
+        # Design note: It would be far better for us to have a way to safely undo
+        # the deletion of a Section, or even put the Gizmos into a holding space
+        # or something to be re-assigned; but that is out of scope for me at the
+        # moment - ZS 10/18/23
+        it "requires confirmation" do
+          accept_alert(I18n.t("rooms.destroy.confirm", room_name: section.name)) do
+            click_on(I18n.t("rooms.destroy.link_to"))
+          end
+
+          expect(page).to have_content(I18n.t("rooms.destroy.success", room_name: section.name))
+          expect(space.rooms).not_to be_exist(id: section.id)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1841

So, this was caused by me being FANCY and putting the delete button in the same form as the edit and update. A bad idea.

Now, deleting a Section is handled in it's own independent form, rather than attempting to rewrite the forms hidden `_method` field to trick Rails into doing a destroy.

This is also better from a design perspective because:

A) omg, a delete button so close to the save button is DANGEROUS
B) Deleting a Section is kinda a big deal, and while it would be better  to bubble-wrap the heck out of it so people who *do* delete a  section don't wind up in a sad-mad state; we can at least give them  lots of "DANGER WILL ROBINSON DANGER" messaging. 

This is... irresponsible of us but what we can do now. If a motivated bystander or contributor wanted to design and implement a way for Sections to be Archived instead; I would be Very Happy :tm:
  
  