### PR TITLE
Adds view-level unit specs for `Marketplace::Cart::DeliveryAreaComponent'

### DIFF
--- a/app/furniture/marketplace/cart/delivery_area_component.html.erb
+++ b/app/furniture/marketplace/cart/delivery_area_component.html.erb
@@ -6,6 +6,9 @@
         <%= delivery_area.label %>
         <div class="text-sm text-gray-500">
           <%= render(Marketplace::Cart::DeliveryExpectationsComponent.new(cart: cart)) %>
+          <%- if single_delivery_area? %>
+            <div><small>Orders outside of this location will be subject to cancellation.</small></div>
+          <% end %>
         </div>
       </div>
       <div class="text-right">

--- a/spec/furniture/marketplace/cart/delivery_area_component_spec.rb
+++ b/spec/furniture/marketplace/cart/delivery_area_component_spec.rb
@@ -20,12 +20,16 @@ RSpec.describe Marketplace::Cart::DeliveryAreaComponent, type: :component do
       }
 
       it { is_expected.to have_content "Where are you Ordering from?" }
+      it { is_expected.to have_content "Delivery prices and times vary based upon your location" }
+      it { is_expected.to have_css("option", count: 2) }
     end
   end
 
   context "when a delivery area is not present" do
     let(:marketplace) { create(:marketplace) }
 
-    # it { is_expected.to have_content "How are Orders Delivered?" }
+    it { is_expected.to have_content("Where are you Ordering from?") }
+    it { is_expected.to have_content "Delivery prices and times vary based upon your location" }
+    it { is_expected.not_to have_css("option") }
   end
 end

--- a/spec/furniture/marketplace/cart/delivery_area_component_spec.rb
+++ b/spec/furniture/marketplace/cart/delivery_area_component_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Marketplace::Cart::DeliveryAreaComponent, type: :component do
 
   let(:component) { described_class.new(cart: cart) }
 
-  let(:cart) { create(:marketplace_cart, :with_products, marketplace: marketplace) }
+  let(:cart) { create(:marketplace_cart, marketplace: marketplace) }
 
   context "when a delivery area is present" do
     context "with a single delivery area" do

--- a/spec/furniture/marketplace/cart/delivery_area_component_spec.rb
+++ b/spec/furniture/marketplace/cart/delivery_area_component_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe Marketplace::Cart::DeliveryAreaComponent, type: :component do
+  subject(:output) { render_inline(component) }
+
+  let(:component) { described_class.new(cart: cart) }
+
+  let(:cart) { create(:marketplace_cart, :with_products, marketplace: marketplace) }
+
+  context "when a delivery area is present" do
+    context "with a single delivery area" do
+      let(:marketplace) { create(:marketplace, :with_delivery_areas) }
+
+      it { is_expected.to have_content "Orders outside of this location will be subject to cancellation." }
+    end
+
+    context "with multiple delivery areas" do
+      let(:marketplace) {
+        create(:marketplace, :with_delivery_areas, delivery_area_quantity: 2)
+      }
+
+      it { is_expected.to have_content "Where are you Ordering from?" }
+    end
+  end
+
+  context "when a delivery area is not present" do
+    let(:marketplace) { create(:marketplace) }
+
+    # it { is_expected.to have_content "How are Orders Delivered?" }
+  end
+end


### PR DESCRIPTION
Follow-up to https://github.com/zinc-collective/convene/pull/1920