### PR TITLE
Update `Gemfile` and `schema.rb` files to reflect the version of Rails we're using

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ ruby File.read(".ruby-version").strip
 gem "dotenv-rails", groups: %i[development test]
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem "rails", "~> 7.0"
+gem "rails", "~> 7.1"
 
 # Data Transport
 #

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -553,7 +553,7 @@ DEPENDENCIES
   pry-byebug
   puma (~> 6.4)
   pundit (~> 2.3)
-  rails (~> 7.0)
+  rails (~> 7.1)
   rails-controller-testing
   rails-erd
   ranked-model (~> 0.4.9)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_05_005905) do
+ActiveRecord::Schema[7.1].define(version: 2023_10_05_005905) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"


### PR DESCRIPTION
We upgraded to Rails 7.1 in https://github.com/zinc-collective/convene/pull/1901, but the migrations file was not updated, so if you run all migrations on a clean branch you get this diff to update the schema version in `schema.rb`. This PR fixes things so that there are no schema changes on a clean app install.

Also took the opportunity to tweak the Rails version constraint in the Gemfile, for added clarity.