### PR TITLE
`Marketplace`: Very Rough  `Flyer`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,8 @@ gem "gretel", "~> 4.6"
 # Better UI components
 gem "lookbook", ">= 2.0.0.beta.4"
 gem "view_component", "~> 3.7"
+# QR Code GeneratioN!
+gem "rqrcode", "~> 2.2"
 
 # Pagination!
 gem "pagy", "~> 6.2"

--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem "gretel", "~> 4.6"
 # Better UI components
 gem "lookbook", ">= 2.0.0.beta.4"
 gem "view_component", "~> 3.7"
-# QR Code GeneratioN!
+# QR Code Generation!
 gem "rqrcode", "~> 2.2"
 
 # Pagination!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,6 +149,7 @@ GEM
       xpath (~> 3.2)
     certifi (2018.01.18)
     choice (0.2.0)
+    chunky_png (1.4.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
@@ -372,6 +373,10 @@ GEM
     rexml (3.2.6)
     rotp (6.3.0)
     rouge (4.1.3)
+    rqrcode (2.2.0)
+      chunky_png (~> 1.0)
+      rqrcode_core (~> 1.0)
+    rqrcode_core (1.2.0)
     rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
     rspec-expectations (3.12.3)
@@ -559,6 +564,7 @@ DEPENDENCIES
   ranked-model (~> 0.4.9)
   redcarpet (~> 3.6)
   rotp (~> 6.3)
+  rqrcode (~> 2.2)
   rspec-rails (~> 6.1.0)
   rswag-api
   rswag-specs

--- a/app/furniture/marketplace/flyer.rb
+++ b/app/furniture/marketplace/flyer.rb
@@ -1,0 +1,21 @@
+class Marketplace
+  class Flyer
+    attr_accessor :marketplace
+
+    def initialize(marketplace)
+      self.marketplace = marketplace
+    end
+
+    def vendor_name
+      marketplace.room.name
+    end
+
+    def qr_code(uri)
+      @qr_code ||= RQRCode::QRCode.new(uri)
+    end
+
+    def distributor_name
+      marketplace.space.name
+    end
+  end
+end

--- a/app/furniture/marketplace/flyer_policy.rb
+++ b/app/furniture/marketplace/flyer_policy.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Marketplace
+  class FlyerPolicy < Policy
+    alias_method :marketplace, :object
+    def show?
+      true
+    end
+  end
+end

--- a/app/furniture/marketplace/flyers/show.html.erb
+++ b/app/furniture/marketplace/flyers/show.html.erb
@@ -1,0 +1,12 @@
+<div class="w-96 mr-auto ml-auto">
+  <div class="text-2xl text-center">
+    Catering By <%= flyer.vendor_name %>
+  </div>
+  <div class="inline-block">
+    <%== flyer.qr_code(url_for(marketplace.room.location)).as_svg use_path: true%>
+  </div>
+  <div class="text-2xl text-center">
+    <p>Delivered by <%= flyer.distributor_name %></p>
+    <p><%= link_to(url_for(marketplace.room.location)) %></p>
+  </div>
+</div>

--- a/app/furniture/marketplace/flyers_controller.rb
+++ b/app/furniture/marketplace/flyers_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class Marketplace
+  class FlyersController < Controller
+    layout "nude"
+    expose :flyer, -> { marketplace.flyer }
+
+    def show
+      authorize(flyer)
+    end
+  end
+end

--- a/app/furniture/marketplace/locales/en.yml
+++ b/app/furniture/marketplace/locales/en.yml
@@ -40,6 +40,9 @@ en:
       edit: "Change Phone Number"
     delivery_address:
       edit: "Change Address"
+    flyers:
+      show:
+        link_to: "Flyer"
     marketplace:
       manage_header: "Marketplace"
       configuration_menu: "Configuration"

--- a/app/furniture/marketplace/management_component.html.erb
+++ b/app/furniture/marketplace/management_component.html.erb
@@ -18,6 +18,7 @@
         <%= render button({child: :tax_rates}, icon: :receipt_percent)  if policy(marketplace.tax_rates).index? %>
         <%= render button({child: :orders}, icon: :cart)  if policy(marketplace.orders).index? %>
         <%= render button({child: :notification_methods}, icon: :bell)  if policy(marketplace.notification_methods).index? %>
+        <%= render button({child: :flyer}, icon: :receipt_percent)  if policy(marketplace.flyer).show? %>
       </nav>
     <% end %>
   <% end %>

--- a/app/furniture/marketplace/marketplace.rb
+++ b/app/furniture/marketplace/marketplace.rb
@@ -38,6 +38,10 @@ class Marketplace
       true
     end
 
+    def flyer
+      Flyer.new(self)
+    end
+
     def ready_for_shopping?
       products.present? && stripe_api_key? && delivery_areas.present? && stripe_account_connected?
     end

--- a/app/furniture/marketplace/routes.rb
+++ b/app/furniture/marketplace/routes.rb
@@ -9,6 +9,7 @@ class Marketplace
           router.resource :delivery_area, controller: "cart/delivery_areas"
         end
 
+        router.resource :flyer
         router.resources :delivery_areas
         router.resources :notification_methods
         router.resources :orders, only: [:show, :index]

--- a/app/views/layouts/nude.html.erb
+++ b/app/views/layouts/nude.html.erb
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title><%= page_title %></title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <%# Env variables being made accessible to JavaScript %>
+    <%= tag :meta, name: :sentry_dsn, content: ENV["SENTRY_DSN"] %>
+    <%= tag :meta, name: :release_tag,
+        content: "#{ENV.fetch("APP-BASE", "convene")}@#{ENV.fetch("HEROKU_RELEASE_VERSION", "??")}" %>
+
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+    <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
+    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= render "layouts/hotjar" %>
+    <meta name="turbo-visit-control" content="reload">
+  </head>
+  <body>
+    <%= yield  %>
+  </body>
+</html>


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1956

This gives us a QR-Code Flyer, but we should probably ditch the footer if we can...

I sprouted a "nude" layout (Ok it needs a better name) that gives us an empty page and breaks us out of turbo-frame land.

Anyway, to make pretty we need to:

- Attach a `Vendor`'s logo to the `Space`
- Attach a `Distributor`s logo to the `Marketplace`
- Actually work towards the fancy-pants design that Mari made!

But in the meantime, this is something that could exist and maybe even could get better.

[Zee's Pizza.pdf](https://github.com/zinc-collective/convene/files/13445705/Zee.s.Pizza.pdf)