### PR TITLE
✨ `Gizmo`: `SectionNavigation`

### DIFF
--- a/app/furniture/section_navigation.rb
+++ b/app/furniture/section_navigation.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class SectionNavigation
+  def self.router
+  end
+end

--- a/app/furniture/section_navigation/README.md
+++ b/app/furniture/section_navigation/README.md
@@ -1,0 +1,1 @@
+# SectionNavigation

--- a/app/furniture/section_navigation/section_navigation.rb
+++ b/app/furniture/section_navigation/section_navigation.rb
@@ -1,0 +1,9 @@
+class SectionNavigation
+  class SectionNavigation < Furniture
+    location(parent: :room)
+
+    def rooms
+      space.rooms.where.not(id: space.entrance_id)
+    end
+  end
+end

--- a/app/furniture/section_navigation/section_navigations/_section_navigation.html.erb
+++ b/app/furniture/section_navigation/section_navigations/_section_navigation.html.erb
@@ -1,0 +1,22 @@
+<div class="mt-3 grid grid-cols-1 gap-5 sm:gap-6 sm:grid-cols-2 lg:grid-cols-4 items-center">
+  <% policy_scope(section_navigation.rooms).each do |room| %>
+    <%= link_to [room.space, room], class: "no-underline" do %>
+      <%= render CardComponent.new(
+        data: { access_level: room.access_level, slug: room.slug, model: "room", id: room.id },
+        classes: "group self-stretch hover:bg-orange-50"
+        ) do %>
+        <div class="px-4 py-5 flex items-center justify-between">
+          <h3 class="text-base font-semibold text-orange-500 group-hover:text-orange-400">
+            <%= room.name %>
+          </h3>
+
+          <button class="rounded-full bg-orange-500 p-1 ml-2 text-white shadow-sm group-hover:bg-orange-400" data-role="enter">
+            <%= render SvgComponent.new(classes: "h-5 w-5") do %>
+              <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+            <% end %>
+          </button>
+        </div>
+      <%- end %>
+    <%- end %>
+  <% end %>
+</div>

--- a/app/models/furniture.rb
+++ b/app/models/furniture.rb
@@ -95,6 +95,7 @@ class Furniture < ApplicationRecord
       markdown_text_block: ::MarkdownTextBlock,
       marketplace: ::Marketplace::Marketplace,
       livestream: ::Livestream,
+      section_navigation: SectionNavigation::SectionNavigation,
       embedded_form: EmbeddedForm
     }
   end


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/709

Sprouts a tiny Gizmo for linking to Sections. At some point, we'll want to add a UI for picking which `Sections` to include, preferably an `AllowList` so that adding a `Section` doesn't immediately publish it.