### PR TITLE
🧹 `Marketplace`: eliminate some duplication

### DIFF
--- a/app/furniture/marketplace/marketplaces/show.html.erb
+++ b/app/furniture/marketplace/marketplaces/show.html.erb
@@ -1,4 +1,2 @@
 <%- breadcrumb :marketplace, marketplace %>
-<%= turbo_frame_tag(marketplace, data: { turbo_action: :advance }) do %>
-  <%= render Marketplace::MarketplaceComponent.new(marketplace: marketplace) %>
-<%- end %>
+<%= render marketplace %>


### PR DESCRIPTION
- Follow on for https://github.com/zinc-collective/convene/pull/1981

I noticed this and removed the duplication but forgot to commit it! Anyway, now it's a little tidier.