### PR TITLE
🐞🔨 `Marketplace`: `Checkout` is prevented without a `Cart::DeliveryArea`

### DIFF
--- a/app/furniture/marketplace/cart.rb
+++ b/app/furniture/marketplace/cart.rb
@@ -54,7 +54,7 @@ class Marketplace
     end
 
     def ready_for_checkout?
-      delivery.details_filled_in? && cart_products.present? && cart_products.all?(&:valid?)
+      delivery_area.present? && cart_products.present? && cart_products.all?(&:valid?)
     end
   end
 end

--- a/app/furniture/marketplace/carts/_footer.html.erb
+++ b/app/furniture/marketplace/carts/_footer.html.erb
@@ -12,7 +12,7 @@
   </tr>
   <tr>
     <td class="text-right py-3.5" colspan="8">
-      <%= render ButtonComponent.new(label: "Checkout", href: cart.location(child: :checkout), scheme: :primary, method: :get) %>
+      <%= render ButtonComponent.new(label: "Checkout", href: cart.location(child: :checkout), scheme: :primary, method: :get, disabled: !cart.ready_for_checkout?) %>
     </td>
   </tr>
 </tfoot>

--- a/spec/furniture/marketplace/buying_products_system_spec.rb
+++ b/spec/furniture/marketplace/buying_products_system_spec.rb
@@ -24,6 +24,18 @@ describe "Marketplace: Buying Products", type: :system do
     {host: server_uri.host, port: server_uri.port}
   end
 
+  context "when there is not a DeliveryArea selected" do
+    it "Prevents Checkout unless a DeliveryArea is selected" do
+      create(:marketplace_delivery_area, marketplace: marketplace)
+
+      visit(polymorphic_path(marketplace.room.location))
+
+      add_product_to_cart(marketplace.products.first)
+
+      expect { click_link("Checkout") }.to raise_error(Capybara::ElementNotFound)
+    end
+  end
+
   it "Works for Guests" do # rubocop:disable RSpec/ExampleLength
     visit(polymorphic_path(marketplace.room.location))
 


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1983

Prevents `Shoppers` from visiting the `Checkout` screen until a `DeliveryArea` has been selected; which should prevent the sad bug.