### PR TITLE
🐞🔨 `Marketplace`: Don't clear `Cart` when switching `Marketplaces`

### DIFF
--- a/app/furniture/marketplace/marketplace_component.rb
+++ b/app/furniture/marketplace/marketplace_component.rb
@@ -14,7 +14,7 @@ class Marketplace
 
     def cart
       delivery_area = marketplace.delivery_areas.first if marketplace.delivery_areas.size == 1
-      @cart ||= carts.create_with(contact_email: shopper.person&.email).find_or_create_by(delivery_area: delivery_area, shopper: shopper, status: :pre_checkout)
+      @cart ||= carts.create_with(contact_email: shopper.person&.email, delivery_area: delivery_area).find_or_create_by(shopper: shopper, status: :pre_checkout)
     end
 
     def delivery_area_component

--- a/spec/furniture/marketplace/marketplace_component_spec.rb
+++ b/spec/furniture/marketplace/marketplace_component_spec.rb
@@ -35,4 +35,42 @@ RSpec.describe Marketplace::MarketplaceComponent, type: :component do
       end
     end
   end
+
+  describe "#cart" do
+    let(:current_person) { create(:person) }
+
+    context "when there is not a Cart for the Shopper in the Marketplace" do
+      it "creates a Cart for the Shopper" do
+        expect { component.cart }.to change { marketplace.carts.count }.by(1)
+        expect(component.cart).to be_persisted
+        expect(component.cart.delivery_area).to eql(marketplace.delivery_areas.first)
+      end
+
+      context "when the Marketplace has multiple Delivery Areas" do
+        it "creates a Cart for the Shopper without a Delivery Area" do
+          create(:marketplace_delivery_area, marketplace:)
+          expect { component.cart }.to change { marketplace.carts.count }.by(1)
+          expect(component.cart).to be_persisted
+          expect(component.cart.delivery_area).to be_nil
+        end
+      end
+    end
+
+    context "when there is a Cart for the Shopper in the Marketplace" do
+      before do
+        marketplace.carts.create(shopper: Marketplace::Shopper.create(person: current_person))
+      end
+
+      it "doesn't create another cart" do
+        expect { component.cart }.not_to change { marketplace.carts.count }
+      end
+
+      context "when the Marketplace has multiple DeliveryAreas" do
+        it "doesn't create another cart" do
+          create(:marketplace_delivery_area, marketplace:)
+          expect { component.cart }.not_to change { marketplace.carts.count }
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1962

There was a bug we noticed during the Sutty demo where carts were being cleared.

Turns out, if a `Marketplace` had multiple `DeliveryAreas` we would create a new `Cart` for the shopper every time the page loaded. Womp. Womp.