### PR TITLE
`Marketplace`: `Checkout` includes `Products`, `Taxes`, and `DeliveryFee`

### DIFF
--- a/app/furniture/marketplace/cart/deliveries/_delivery.html.erb
+++ b/app/furniture/marketplace/cart/deliveries/_delivery.html.erb
@@ -1,12 +1,12 @@
-<%- if delivery.delivery_area.present? %>
-  <p class="text-lg font-bold"><%= render(delivery.delivery_area) %></p>
-<%- end %>
-<p class="text-left py-1 text-sm">
-  <%= render(Marketplace::Cart::DeliveryExpectationsComponent.new(cart: delivery.cart)) %>
-</p>
+
 <%= turbo_frame_tag(delivery) do %>
   <% if delivery.details_filled_in? %>
-    <p class="font-bold">Delivering to:</p>
+    <h3 class="font-bold">Delivering to:</h3>
+    <p>
+      <%= render(delivery.delivery_area) %><br />
+      <span class="text-sm font-light italic"><%= render(Marketplace::Cart::DeliveryExpectationsComponent.new(cart: delivery.cart)) %></span>
+    </p>
+
     <div class="rounded p-2 bg-orange-50">
       <p>
         <%= delivery.contact_email %><br />

--- a/app/furniture/marketplace/cart/deliveries/_delivery.html.erb
+++ b/app/furniture/marketplace/cart/deliveries/_delivery.html.erb
@@ -7,7 +7,7 @@
       <span class="text-sm font-light italic"><%= render(Marketplace::Cart::DeliveryExpectationsComponent.new(cart: delivery.cart)) %></span>
     </p>
 
-    <div class="rounded p-2 bg-orange-50">
+    <div class="rounded p-2 bg-orange-50 mb-3">
       <p>
         <%= delivery.contact_email %><br />
         <%= number_to_phone(delivery.contact_phone_number) %><br />
@@ -20,8 +20,7 @@
       </p>
     </div>
 
-    <h2>Payment Details</h2>
-    <%= button_to("Make Payment", delivery.cart.location(child: :checkout), data: { turbo: false }) %>
+    <%= button_to("Place Order", delivery.cart.location(child: :checkout), data: { turbo: false }) %>
   <%- else %>
     <%= render "marketplace/cart/deliveries/form", delivery: delivery %>
   <%- end %>

--- a/app/furniture/marketplace/cart/deliveries/_form.html.erb
+++ b/app/furniture/marketplace/cart/deliveries/_form.html.erb
@@ -7,6 +7,6 @@
 
     <%= render "text_area", attribute: :delivery_notes, form: delivery_form %>
 
-    <%= delivery_form.submit %>
+    <%= delivery_form.submit "Save" %>
   <%- end %>
 <%- end %>

--- a/app/furniture/marketplace/cart/delivery_areas/_form.html.erb
+++ b/app/furniture/marketplace/cart/delivery_areas/_form.html.erb
@@ -7,6 +7,6 @@
       choices: cart.marketplace.delivery_areas.pluck(:label, :id), attribute: :delivery_area_id,
       form: form,
     }) %>
-    <%= form.submit %>
+    <%= form.submit "Save" %>
   <%- end %>
 </div>

--- a/app/furniture/marketplace/checkouts/show.html.erb
+++ b/app/furniture/marketplace/checkouts/show.html.erb
@@ -1,7 +1,26 @@
 <%= turbo_frame_tag(checkout.marketplace, data: { turbo_action: :advance }) do %>
   <%= link_to(t("marketplace.marketplaces.show.link_to"), marketplace.location) %>
-  <h1>Checkout</h2>
+  <h2>Checkout</h2>
   <%= render CardComponent.new do %>
+    <h3>Receipt</h3>
+    <dl class="grid grid-cols-2 gap-3 w-96">
+      <%- cart.cart_products.each do |cart_product| %>
+        <dt class="text-right"><%= cart_product.name %><br />
+        (<%=cart_product.quantity%>) x <%= humanized_money_with_symbol(cart_product.price) %></dt>
+        <dd><%= humanized_money_with_symbol(cart_product.price_total) %></dd>
+      <%- end %>
+      <dt class="font-bold text-right">Sub Total</dt>
+      <dd><%= humanized_money_with_symbol(cart.product_total) %></dd>
+      <dt class="text-right">Delivery Fee <br /> (<%= cart.delivery_area.label %>)</dt>
+      <dd><%= humanized_money_with_symbol(cart.delivery_fee) %></dd>
+      <dt class="text-right">Taxes</dt>
+      <dd><%= humanized_money_with_symbol(cart.tax_total) %></dd>
+      <dt class="text-right font-bold">Total</dt>
+      <dd><%= humanized_money_with_symbol(cart.price_total) %></dd>
+    </dl>
+  <%- end %>
+
+  <%= render CardComponent.new(classes: "mt-3") do %>
     <%= render cart.delivery %>
   <%- end %>
 <%- end %>

--- a/app/furniture/marketplace/checkouts/show.html.erb
+++ b/app/furniture/marketplace/checkouts/show.html.erb
@@ -1,26 +1,28 @@
 <%= turbo_frame_tag(checkout.marketplace, data: { turbo_action: :advance }) do %>
   <%= link_to(t("marketplace.marketplaces.show.link_to"), marketplace.location) %>
   <h2>Checkout</h2>
-  <%= render CardComponent.new do %>
-    <h3>Receipt</h3>
-    <dl class="grid grid-cols-2 gap-3 w-96">
-      <%- cart.cart_products.each do |cart_product| %>
-        <dt class="text-right"><%= cart_product.name %><br />
-        (<%=cart_product.quantity%>) x <%= humanized_money_with_symbol(cart_product.price) %></dt>
-        <dd><%= humanized_money_with_symbol(cart_product.price_total) %></dd>
-      <%- end %>
-      <dt class="font-bold text-right">Sub Total</dt>
-      <dd><%= humanized_money_with_symbol(cart.product_total) %></dd>
-      <dt class="text-right">Delivery Fee <br /> (<%= cart.delivery_area.label %>)</dt>
-      <dd><%= humanized_money_with_symbol(cart.delivery_fee) %></dd>
-      <dt class="text-right">Taxes</dt>
-      <dd><%= humanized_money_with_symbol(cart.tax_total) %></dd>
-      <dt class="text-right font-bold">Total</dt>
-      <dd><%= humanized_money_with_symbol(cart.price_total) %></dd>
-    </dl>
-  <%- end %>
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+    <%= render CardComponent.new do %>
+      <h3>Receipt</h3>
+      <dl class="grid grid-cols-2 gap-3 w-96">
+        <%- cart.cart_products.each do |cart_product| %>
+          <dt class="text-right"><%= cart_product.name %><br />
+          (<%=cart_product.quantity%>) x <%= humanized_money_with_symbol(cart_product.price) %></dt>
+          <dd><%= humanized_money_with_symbol(cart_product.price_total) %></dd>
+        <%- end %>
+        <dt class="font-bold text-right">Sub Total</dt>
+        <dd><%= humanized_money_with_symbol(cart.product_total) %></dd>
+        <dt class="text-right">Delivery Fee <br /> (<%= cart.delivery_area.label %>)</dt>
+        <dd><%= humanized_money_with_symbol(cart.delivery_fee) %></dd>
+        <dt class="text-right">Taxes</dt>
+        <dd><%= humanized_money_with_symbol(cart.tax_total) %></dd>
+        <dt class="text-right font-bold">Total</dt>
+        <dd><%= humanized_money_with_symbol(cart.price_total) %></dd>
+      </dl>
+    <%- end %>
 
-  <%= render CardComponent.new(classes: "mt-3") do %>
-    <%= render cart.delivery %>
-  <%- end %>
+    <%= render CardComponent.new(classes: "mt-3") do %>
+      <%= render cart.delivery %>
+    <%- end %>
+  </div>
 <%- end %>


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1980
- https://github.com/zinc-collective/convene/issues/1326

It's not the prettiest, but it includes each product being purchased,
the quantity, the unit pricer, and the total price as well as the taxes
and delivery fees.

<img width="383" alt="Screenshot 2023-12-04 at 6 25 43 PM" src="https://github.com/zinc-collective/convene/assets/50284/451a0560-c720-43af-89b1-c466467290d1">
<img width="800" alt="Screenshot 2023-12-04 at 6 25 39 PM" src="https://github.com/zinc-collective/convene/assets/50284/c6235a08-5044-4e79-a0b2-5d79fc57aece">
