### PR TITLE
🧹 Don't encourage people to set the SMTP in .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,15 +9,6 @@
 # PGUSER=postgres
 # PGPASSWORD=password
 
-# Action Mailer Configuration
-# SMTP_PORT=1025
-# SMTP_DOMAIN=localhost
-# SMTP_AUTHENTICATION=plain
-# SMTP_ADDRESS=localhost
-# SMTP_ENABLE_TLS=false
-# Only set password and username when authentication is being used
-# SMTP_PASSWORD=SEE_HEROKU_OR_GENERATE_YOUR_OWN
-# SMTP_USERNAME=SEE_HEROKU_OR_GENERATE_YOUR_OWN
 
 PORT=3000
 # Used to build URLs in mailers


### PR DESCRIPTION
`.env` is loaded in `test` environment; so if you uncomment the smtp lines in `.env` the action mailer delivery method gets clobbered; breaking the tests.

We already have `.env.development.example`, which includes the smtp settings; and that only gets loaded in the `development` environment! Hooray!