### PR TITLE
🧹 `Marketplace`: Move logic for finding or creating a cart for a shopper into a factory method

### DIFF
--- a/app/furniture/marketplace/marketplace.rb
+++ b/app/furniture/marketplace/marketplace.rb
@@ -26,6 +26,15 @@ class Marketplace
     # Square order notifications integration
     setting :square_location_id
 
+    def find_or_create_cart(shopper:, delivery_area: nil, cart_status: :pre_checkout)
+      carts.find_by(shopper:, status: cart_status) || carts.create(
+        shopper: shopper,
+        contact_email: shopper.person&.email,
+        delivery_area: delivery_area,
+        status: cart_status
+      )
+    end
+
     def square_access_token=square_access_token
       secrets["square_access_token"] = square_access_token
     end

--- a/app/furniture/marketplace/marketplace.rb
+++ b/app/furniture/marketplace/marketplace.rb
@@ -26,7 +26,7 @@ class Marketplace
     # Square order notifications integration
     setting :square_location_id
 
-    def find_or_create_cart(shopper:, cart_status: :pre_checkout)
+    def cart_for_shopper(shopper:, cart_status: :pre_checkout)
       carts.find_by(shopper:, status: cart_status) || carts.create(
         shopper: shopper,
         contact_email: shopper.person&.email,

--- a/app/furniture/marketplace/marketplace.rb
+++ b/app/furniture/marketplace/marketplace.rb
@@ -26,11 +26,11 @@ class Marketplace
     # Square order notifications integration
     setting :square_location_id
 
-    def find_or_create_cart(shopper:, delivery_area: nil, cart_status: :pre_checkout)
+    def find_or_create_cart(shopper:, cart_status: :pre_checkout)
       carts.find_by(shopper:, status: cart_status) || carts.create(
         shopper: shopper,
         contact_email: shopper.person&.email,
-        delivery_area: delivery_area,
+        delivery_area: default_delivery_area,
         status: cart_status
       )
     end
@@ -126,6 +126,10 @@ class Marketplace
 
     def square_order_notifications_enabled?
       square_location_id.present?
+    end
+
+    def default_delivery_area
+      (delivery_areas.size == 1) ? delivery_areas.first : nil
     end
   end
 end

--- a/app/furniture/marketplace/marketplace_component.rb
+++ b/app/furniture/marketplace/marketplace_component.rb
@@ -14,7 +14,7 @@ class Marketplace
 
     def cart
       delivery_area = marketplace.delivery_areas.first if marketplace.delivery_areas.size == 1
-      @cart ||= carts.create_with(contact_email: shopper.person&.email, delivery_area: delivery_area).find_or_create_by(shopper: shopper, status: :pre_checkout)
+      @cart ||= marketplace.find_or_create_cart(shopper: shopper, delivery_area: delivery_area)
     end
 
     def delivery_area_component

--- a/app/furniture/marketplace/marketplace_component.rb
+++ b/app/furniture/marketplace/marketplace_component.rb
@@ -13,8 +13,7 @@ class Marketplace
     end
 
     def cart
-      delivery_area = marketplace.delivery_areas.first if marketplace.delivery_areas.size == 1
-      @cart ||= marketplace.find_or_create_cart(shopper: shopper, delivery_area: delivery_area)
+      @cart ||= marketplace.find_or_create_cart(shopper: shopper)
     end
 
     def delivery_area_component

--- a/app/furniture/marketplace/marketplace_component.rb
+++ b/app/furniture/marketplace/marketplace_component.rb
@@ -13,7 +13,7 @@ class Marketplace
     end
 
     def cart
-      @cart ||= marketplace.find_or_create_cart(shopper: shopper)
+      @cart ||= marketplace.cart_for_shopper(shopper: shopper)
     end
 
     def delivery_area_component

--- a/spec/furniture/marketplace/marketplace_spec.rb
+++ b/spec/furniture/marketplace/marketplace_spec.rb
@@ -44,10 +44,26 @@ RSpec.describe Marketplace::Marketplace, type: :model do
       end.to change(marketplace.carts, :count).by(1)
     end
 
-    it "sets the delivery area if one is passed" do
-      delivery_area = create(:marketplace_delivery_area, marketplace:)
-      cart = marketplace.find_or_create_cart(shopper:, delivery_area:)
-      expect(cart.delivery_area).to eq(delivery_area)
+    context "when the marketplace has exactly one delivery area" do
+      let!(:delivery_area) { create(:marketplace_delivery_area, marketplace:) }
+
+      it "sets it on the cart as the default one" do
+        expect(marketplace.delivery_areas.size).to eq(1)
+        cart = marketplace.find_or_create_cart(shopper:)
+        expect(cart.delivery_area).to eq(delivery_area)
+      end
+    end
+
+    context "when the marketplace has multiple delivery areas" do
+      before do
+        create_list(:marketplace_delivery_area, 2, marketplace:)
+      end
+
+      it "does not set a default delivery area on the cart" do
+        expect(marketplace.delivery_areas.size).to be > 1
+        cart = marketplace.find_or_create_cart(shopper:)
+        expect(cart.delivery_area).to be_nil
+      end
     end
   end
 

--- a/spec/furniture/marketplace/marketplace_spec.rb
+++ b/spec/furniture/marketplace/marketplace_spec.rb
@@ -30,17 +30,17 @@ RSpec.describe Marketplace::Marketplace, type: :model do
     it { is_expected.to include(marketplace_furniture) }
   end
 
-  describe ".find_or_create_cart" do
+  describe ".cart_for_shopper" do
     let(:shopper) { create(:marketplace_shopper) }
 
     it "finds an existing cart" do
       cart = create(:marketplace_cart, marketplace:, shopper:)
-      expect(marketplace.find_or_create_cart(shopper:)).to eq(cart)
+      expect(marketplace.cart_for_shopper(shopper:)).to eq(cart)
     end
 
     it "makes a new cart if there wasn't already one, defaults to :pre_checkout" do
       expect do
-        expect(marketplace.find_or_create_cart(shopper:).status).to eq("pre_checkout")
+        expect(marketplace.cart_for_shopper(shopper:).status).to eq("pre_checkout")
       end.to change(marketplace.carts, :count).by(1)
     end
 
@@ -49,7 +49,7 @@ RSpec.describe Marketplace::Marketplace, type: :model do
 
       it "sets it on the cart as the default one" do
         expect(marketplace.delivery_areas.size).to eq(1)
-        cart = marketplace.find_or_create_cart(shopper:)
+        cart = marketplace.cart_for_shopper(shopper:)
         expect(cart.delivery_area).to eq(delivery_area)
       end
     end
@@ -61,7 +61,7 @@ RSpec.describe Marketplace::Marketplace, type: :model do
 
       it "does not set a default delivery area on the cart" do
         expect(marketplace.delivery_areas.size).to be > 1
-        cart = marketplace.find_or_create_cart(shopper:)
+        cart = marketplace.cart_for_shopper(shopper:)
         expect(cart.delivery_area).to be_nil
       end
     end

--- a/spec/furniture/marketplace/marketplace_spec.rb
+++ b/spec/furniture/marketplace/marketplace_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Marketplace::Marketplace, type: :model do
+  subject(:marketplace) { create(:marketplace) }
+
   it { is_expected.to have_many(:products).inverse_of(:marketplace).dependent(:destroy) }
   it { is_expected.to have_many(:orders).inverse_of(:marketplace) }
   it { is_expected.to have_many(:notification_methods).inverse_of(:marketplace).dependent(:destroy) }
@@ -26,6 +28,27 @@ RSpec.describe Marketplace::Marketplace, type: :model do
 
     it { is_expected.not_to include(non_marketplace_furniture) }
     it { is_expected.to include(marketplace_furniture) }
+  end
+
+  describe ".find_or_create_cart" do
+    let(:shopper) { create(:marketplace_shopper) }
+
+    it "finds an existing cart" do
+      cart = create(:marketplace_cart, marketplace:, shopper:)
+      expect(marketplace.find_or_create_cart(shopper:)).to eq(cart)
+    end
+
+    it "makes a new cart if there wasn't already one, defaults to :pre_checkout" do
+      expect do
+        expect(marketplace.find_or_create_cart(shopper:).status).to eq("pre_checkout")
+      end.to change(marketplace.carts, :count).by(1)
+    end
+
+    it "sets the delivery area if one is passed" do
+      delivery_area = create(:marketplace_delivery_area, marketplace:)
+      cart = marketplace.find_or_create_cart(shopper:, delivery_area:)
+      expect(cart.delivery_area).to eq(delivery_area)
+    end
   end
 
   describe "#ready_for_shopping?" do


### PR DESCRIPTION
Following up to the convo in https://github.com/zinc-collective/convene/pull/1992#discussion_r1418188891, this PR tightens up the logic for finding or creating a cart for a shopper.