### PR TITLE
🧹  Fix Rails 7.1 deprecation warning: `fixture_paths` are now plural, and an array

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -32,7 +32,7 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  config.fixture_paths = ["#{::Rails.root}/spec/fixtures"]
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false


### PR DESCRIPTION
Resolves this deprecation warning when running tests:
![image](https://github.com/zinc-collective/convene/assets/6729309/b1b609cb-d199-418a-bb4b-49c290e5fcc0)
