### PR TITLE
🐞🔨 `Neighborhood`: Force full page reload on error page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -165,4 +165,12 @@ class ApplicationController < ActionController::Base
   def render_not_found
     render "errors/not_found", status: :not_found
   end
+
+  helper_method def turbo_visit_control?
+    turbo_visit_control.present?
+  end
+
+  helper_method def turbo_visit_control
+    nil
+  end
 end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -3,6 +3,10 @@
 class ErrorsController < ApplicationController
   before_action :skip_authorization
 
+  def turbo_visit_control
+    :reload
+  end
+
   def show
     render error_template, status: status_code
   end

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -4,7 +4,11 @@
   <%# Env variables being made accessible to JavaScript %>
   <%= tag :meta, name: :sentry_dsn, content: ENV["SENTRY_DSN"] %>
   <%= tag :meta, name: :release_tag,
-      content: "#{ENV.fetch("APP-BASE", "convene")}@#{ENV.fetch("HEROKU_RELEASE_VERSION", "??")}" %>
+      content: "#{ENV.fetch("APP_BASE", "convene")}@#{ENV.fetch("HEROKU_RELEASE_VERSION", "??")}" %>
+
+  <%- if turbo_visit_control? %>
+    <%= tag :meta, name: :turbo_visit_control, content: turbo_visit_control %>
+  <%- end %>
 
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/2013

I think this should help with the "No Content" messages; but they'll still be errors.