### PR TITLE
🐞🔨 `Marketplace`: `Flyer` page no longer shows "no content"

### DIFF
--- a/app/furniture/marketplace/flyers/show.html.erb
+++ b/app/furniture/marketplace/flyers/show.html.erb
@@ -1,12 +1,14 @@
-<div class="w-96 mr-auto ml-auto">
-  <div class="text-2xl text-center">
-    Catering By <%= flyer.vendor_name %>
+<%= turbo_frame_tag(flyer.marketplace) do %>
+  <div class="w-96 mr-auto ml-auto">
+    <div class="text-2xl text-center">
+      Catering By <%= flyer.vendor_name %>
+    </div>
+    <div class="inline-block">
+      <%== flyer.qr_code(url_for(marketplace.room.location)).as_svg use_path: true%>
+    </div>
+    <div class="text-2xl text-center">
+      <p>Delivered by <%= flyer.distributor_name %></p>
+      <p><%= link_to(url_for(marketplace.room.location)) %></p>
+    </div>
   </div>
-  <div class="inline-block">
-    <%== flyer.qr_code(url_for(marketplace.room.location)).as_svg use_path: true%>
-  </div>
-  <div class="text-2xl text-center">
-    <p>Delivered by <%= flyer.distributor_name %></p>
-    <p><%= link_to(url_for(marketplace.room.location)) %></p>
-  </div>
-</div>
+<%- end %>

--- a/spec/furniture/marketplace/flyer_system_spec.rb
+++ b/spec/furniture/marketplace/flyer_system_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe "Marketplace: Flyer", type: :system do
+  let(:space) { create(:space, :with_entrance, :with_members) }
+  let(:marketplace) { create(:marketplace, :ready_for_shopping, room: space.entrance) }
+
+  it "is navigable from the Markeplace edit page" do
+    sign_in(space.members.first, space)
+
+    visit(polymorphic_path(marketplace.location(:edit)))
+
+    click_link("Flyer")
+
+    expect(page).to have_content("Delivered by #{space.name}")
+    expect(page).to have_content(polymorphic_path(marketplace.room.location))
+  end
+end


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/2017

I apparently was testing the Flyer page with hard refreshes too much; this adds a system test to actually hit the flyer page and check that it has a URL.

It would be cool if I could figure out a way to check that it has the QR code too; but I don't feel smert enough to figure out how to do that.