### PR TITLE
🥔✨ `Marketplace`: `DeliveryAreas` may be `Archived`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,8 @@ gem "bcrypt", "~> 3.1.20"
 gem "lockbox", "1.3.0"
 gem "rotp", "~> 6.3"
 gem "strong_migrations", "~> 1.6"
+# Soft Deletion
+gem "discard", "~> 1.2"
 
 # ActiveModel extension to remove extra whitespace from attributes
 gem "strip_attributes", "~> 1.13"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,6 +165,8 @@ GEM
     decent_exposure (3.0.4)
       activesupport (>= 4.0)
     diff-lcs (1.5.0)
+    discard (1.3.0)
+      activerecord (>= 4.2, < 8)
     docile (1.4.0)
     dotenv (2.8.1)
     dotenv-rails (2.8.1)
@@ -542,6 +544,7 @@ DEPENDENCIES
   capybara
   cssbundling-rails
   decent_exposure (~> 3.0)
+  discard (~> 1.2)
   dotenv-rails
   factory_bot_rails
   faker

--- a/app/furniture/layouts/marketplace.html.erb
+++ b/app/furniture/layouts/marketplace.html.erb
@@ -1,5 +1,5 @@
 <%- content_for :content do %>
-  <%= turbo_frame_tag(marketplace) do %>
+  <%= turbo_frame_tag(marketplace, data: { turbo_action: :advance }) do %>
     <%= yield  %>
   <%- end %>
 <%- end %>

--- a/app/furniture/marketplace/cart/delivery_area_component.rb
+++ b/app/furniture/marketplace/cart/delivery_area_component.rb
@@ -13,11 +13,11 @@ class Marketplace
     end
 
     def single_delivery_area?
-      cart.marketplace.delivery_areas.size == 1
+      cart.marketplace.delivery_areas.kept.size == 1
     end
 
     def single_delivery_area_label
-      cart.marketplace.delivery_areas.first.label
+      cart.marketplace.delivery_areas.kept.first.label
     end
   end
 end

--- a/app/furniture/marketplace/cart/delivery_areas/_form.html.erb
+++ b/app/furniture/marketplace/cart/delivery_areas/_form.html.erb
@@ -4,7 +4,7 @@
 <div class="mt-2 w-full">
   <%= form_with model: cart.location, url: cart.location(child: :delivery_area), data: { turbo_frame: dom_id(cart.marketplace) }  do |form| %>
     <%= render SelectComponent.new({
-      choices: cart.marketplace.delivery_areas.pluck(:label, :id), attribute: :delivery_area_id,
+      choices: cart.marketplace.delivery_areas.kept.pluck(:label, :id), attribute: :delivery_area_id,
       form: form,
     }) %>
     <%= form.submit "Save" %>

--- a/app/furniture/marketplace/delivery_area.rb
+++ b/app/furniture/marketplace/delivery_area.rb
@@ -16,5 +16,13 @@ class Marketplace
 
     attribute :delivery_window
     monetize :price_cents
+
+    def discardable?
+      persisted? && kept?
+    end
+
+    def destroyable?
+      persisted? && discarded? && orders.empty?
+    end
   end
 end

--- a/app/furniture/marketplace/delivery_area.rb
+++ b/app/furniture/marketplace/delivery_area.rb
@@ -1,11 +1,19 @@
 class Marketplace
   class DeliveryArea < Record
+    include ::Discard::Model
+
     self.table_name = "marketplace_delivery_areas"
     location(parent: :marketplace)
 
     belongs_to :marketplace, inverse_of: :delivery_areas
     has_many :orders, -> { checked_out }, inverse_of: :delivery_area
     has_many :carts, inverse_of: :delivery_area, dependent: :nullify
+    after_discard do
+      # rubocop:disable Rails/SkipsModelValidations
+      carts.update_all(delivery_area_id: nil)
+      # rubocop:enable Rails/SkipsModelValidations
+    end
+
     has_many :deliveries, inverse_of: :delivery_area
 
     attribute :delivery_window

--- a/app/furniture/marketplace/delivery_area.rb
+++ b/app/furniture/marketplace/delivery_area.rb
@@ -9,9 +9,7 @@ class Marketplace
     has_many :orders, -> { checked_out }, inverse_of: :delivery_area
     has_many :carts, inverse_of: :delivery_area, dependent: :nullify
     after_discard do
-      # rubocop:disable Rails/SkipsModelValidations
-      carts.update_all(delivery_area_id: nil)
-      # rubocop:enable Rails/SkipsModelValidations
+      carts.update_all(delivery_area_id: nil) # rubocop:disable Rails/SkipsModelValidations
     end
 
     has_many :deliveries, inverse_of: :delivery_area

--- a/app/furniture/marketplace/delivery_area_component.html.erb
+++ b/app/furniture/marketplace/delivery_area_component.html.erb
@@ -2,6 +2,9 @@
 <%= render CardComponent.new(dom_id: dom_id(delivery_area), classes: "flex flex-col justify-between gap-y-2 w-full") do %>
   <header class="flex font-bold">
     <%= label %>
+    <%- if delivery_area.discarded?%>
+      <span class="italic">(archived)</span>
+    <%- end %>
   </header>
 
   <div class="grow flex flex-col justify-between">

--- a/app/furniture/marketplace/delivery_area_component.html.erb
+++ b/app/furniture/marketplace/delivery_area_component.html.erb
@@ -2,7 +2,7 @@
 <%= render CardComponent.new(dom_id: dom_id(delivery_area), classes: "flex flex-col justify-between gap-y-2 w-full") do %>
   <header class="flex font-bold">
     <%= label %>
-    <%- if delivery_area.discarded?%>
+    <%- if delivery_area.discarded? %>
       <span class="italic">(archived)</span>
     <%- end %>
   </header>

--- a/app/furniture/marketplace/delivery_area_component.html.erb
+++ b/app/furniture/marketplace/delivery_area_component.html.erb
@@ -16,6 +16,7 @@
 
   <footer class="mt-3 flex flex-row justify-between">
     <%= render edit_button if edit_button? %>
+    <%= render discard_button if discard_button?  %>
     <%= render destroy_button if destroy_button?  %>
   </footer>
 <%- end %>

--- a/app/furniture/marketplace/delivery_area_component.rb
+++ b/app/furniture/marketplace/delivery_area_component.rb
@@ -28,6 +28,20 @@ class Marketplace
       delivery_area.persisted? && policy(delivery_area).edit?
     end
 
+    def discard_button
+      return unless discard_button?
+
+      ButtonComponent.new(label: "#{t("icons.discard")} #{t("discard.link_to")}",
+        title: t("marketplace.delivery_areas.discard.link_to", name: delivery_area.label),
+        href: delivery_area.location, turbo_stream: true,
+        method: :delete,
+        scheme: :secondary)
+    end
+
+    def discard_button?
+      delivery_area.persisted? && !delivery_area.discarded? && policy(delivery_area).destroy?
+    end
+
     def destroy_button
       return unless destroy_button?
 
@@ -41,7 +55,7 @@ class Marketplace
 
     def destroy_button?
       delivery_area.persisted? && policy(delivery_area).destroy? &&
-        delivery_area.orders.empty?
+        delivery_area.discarded? && delivery_area.orders.empty?
     end
   end
 end

--- a/app/furniture/marketplace/delivery_area_component.rb
+++ b/app/furniture/marketplace/delivery_area_component.rb
@@ -37,7 +37,7 @@ class Marketplace
     end
 
     def discard_button?
-      delivery_area.persisted? && !delivery_area.discarded? && policy(delivery_area).destroy?
+      delivery_area.persisted? && delivery_area.kept? && policy(delivery_area).destroy?
     end
 
     def destroy_button

--- a/app/furniture/marketplace/delivery_area_component.rb
+++ b/app/furniture/marketplace/delivery_area_component.rb
@@ -37,7 +37,7 @@ class Marketplace
     end
 
     def discard_button?
-      delivery_area.persisted? && delivery_area.kept? && policy(delivery_area).destroy?
+      delivery_area.discardable? && policy(delivery_area).destroy?
     end
 
     def destroy_button
@@ -50,8 +50,7 @@ class Marketplace
     end
 
     def destroy_button?
-      delivery_area.persisted? && policy(delivery_area).destroy? &&
-        delivery_area.discarded? && delivery_area.orders.empty?
+      delivery_area.destroyable? && policy(delivery_area).destroy?
     end
   end
 end

--- a/app/furniture/marketplace/delivery_area_component.rb
+++ b/app/furniture/marketplace/delivery_area_component.rb
@@ -33,9 +33,7 @@ class Marketplace
 
       ButtonComponent.new(label: "#{t("icons.discard")} #{t("discard.link_to")}",
         title: t("marketplace.delivery_areas.discard.link_to", name: delivery_area.label),
-        href: delivery_area.location, turbo_stream: true,
-        method: :delete,
-        scheme: :secondary)
+        href: delivery_area.location, method: :delete, scheme: :secondary)
     end
 
     def discard_button?
@@ -47,9 +45,7 @@ class Marketplace
 
       ButtonComponent.new(label: "#{t("icons.destroy")} #{t("destroy.link_to")}",
         title: t("marketplace.delivery_areas.destroy.link_to", name: delivery_area.label),
-        href: delivery_area.location, turbo_stream: true,
-        method: :delete,
-        confirm: t("destroy.confirm"),
+        href: delivery_area.location, method: :delete, confirm: t("destroy.confirm"),
         scheme: :secondary)
     end
 

--- a/app/furniture/marketplace/delivery_areas/edit.html.erb
+++ b/app/furniture/marketplace/delivery_areas/edit.html.erb
@@ -1,2 +1,4 @@
 <%- breadcrumb :edit_delivery_area, delivery_area %>
-<%= render "form", delivery_area: delivery_area %>
+<%= render Marketplace::ManagementComponent.new(marketplace: marketplace) do %>
+  <%= render "form", delivery_area: delivery_area %>
+<%- end %>

--- a/app/furniture/marketplace/delivery_areas/index.html.erb
+++ b/app/furniture/marketplace/delivery_areas/index.html.erb
@@ -25,9 +25,9 @@
     </div>
     <div class="text-center mt-3">
       <%- if params[:archive] %>
-        <%= link_to "Active", marketplace.location(child: :delivery_areas) %>
+        <%= link_to "Active Delivery Areas", marketplace.location(child: :delivery_areas) %>
       <%- else %>
-        <%= link_to "Archive", marketplace.location(child: :delivery_areas, query_params: { archive: true }) %>
+        <%= link_to "Archived Delivery Areas", marketplace.location(child: :delivery_areas, query_params: { archive: true }) %>
       <%- end %>
     </div>
   </section>

--- a/app/furniture/marketplace/delivery_areas/index.html.erb
+++ b/app/furniture/marketplace/delivery_areas/index.html.erb
@@ -4,19 +4,30 @@
   <section class="mt-3">
     <main>
       <div class="grid grid-cols-1 gap-3 sm:gap-5 sm:grid-cols-3">
-        <%= render Marketplace::DeliveryAreaComponent.with_collection(delivery_areas) %>
+        <%- if params[:archive] %>
+          <%= render Marketplace::DeliveryAreaComponent.with_collection(delivery_areas.discarded) %>
+        <%- else %>
+          <%= render Marketplace::DeliveryAreaComponent.with_collection(delivery_areas.kept) %>
+        <%- end %>
       </div>
     </main>
 
     <div class="text-center mt-3">
       <%- new_delivery_area = marketplace.delivery_areas.new %>
-      <%- if policy(new_delivery_area).create? %>
+      <%- if policy(new_delivery_area).create? && !params[:archive] %>
         <%= render ButtonComponent.new(
           label: "#{t('marketplace.delivery_areas.new.link_to')} #{t('icons.new')}",
           title: t('marketplace.delivery_areas.new.link_to'),
           href: marketplace.location(:new, child: :delivery_area),
           method: :get,
           scheme: :secondary) %>
+      <%- end %>
+    </div>
+    <div class="text-center mt-3">
+      <%- if params[:archive] %>
+        <%= link_to "Active", marketplace.location(child: :delivery_areas) %>
+      <%- else %>
+        <%= link_to "Archive", marketplace.location(child: :delivery_areas, query_params: { archive: true }) %>
       <%- end %>
     </div>
   </section>

--- a/app/furniture/marketplace/delivery_areas/new.html.erb
+++ b/app/furniture/marketplace/delivery_areas/new.html.erb
@@ -1,2 +1,6 @@
 <%- breadcrumb :new_delivery_area, delivery_area %>
-<%= render "form", delivery_area: delivery_area %>
+<%= render Marketplace::ManagementComponent.new(marketplace: marketplace) do %>
+  <div class="mt-3">
+    <%= render "form", delivery_area: delivery_area %>
+  </div>
+<%- end %>

--- a/app/furniture/marketplace/delivery_areas_controller.rb
+++ b/app/furniture/marketplace/delivery_areas_controller.rb
@@ -40,23 +40,7 @@ class Marketplace
         delivery_area.discard
       end
 
-      respond_to do |format|
-        format.turbo_stream do
-          if delivery_area.destroyed? || delivery_area.discarded?
-            render turbo_stream: turbo_stream.remove(delivery_area)
-          else
-            render turbo_stream: turbo_stream.replace(delivery_area)
-          end
-        end
-
-        format.html do
-          if delivery_area.destroyed? || delivery_area.discarded?
-            redirect_to marketplace.location(child: :delivery_areas)
-          else
-            render :show
-          end
-        end
-      end
+      redirect_to marketplace.location(child: :delivery_areas)
     end
 
     def delivery_area_params

--- a/app/furniture/marketplace/locales/en.yml
+++ b/app/furniture/marketplace/locales/en.yml
@@ -32,6 +32,8 @@ en:
         success: "Changed Delivery Area '%{name}'"
       destroy:
         link_to: "Remove Delivery Area '%{name}'"
+      discard:
+        link_to: "Archive Delivery Area '%{name}'"
     delivery_window:
       edit: "Change Delivery Window"
     delivery_info:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,3 +48,5 @@ en:
   destroy:
     link_to: "Remove"
     confirm: "Removal is permanent. Are you sure?"
+  discard:
+    link_to: "Archive"

--- a/config/locales/icon/en.yml
+++ b/config/locales/icon/en.yml
@@ -2,6 +2,7 @@ en:
   icons:
     edit: '⚙️'
     destroy: '🗑️'
+    discard: '🗄️'
     new: '➕'
     plus: '➕'
     minus: '➖'

--- a/db/migrate/20231212003521_marketplace_add_discarded_at_to_delivery_areas.rb
+++ b/db/migrate/20231212003521_marketplace_add_discarded_at_to_delivery_areas.rb
@@ -1,0 +1,8 @@
+class MarketplaceAddDiscardedAtToDeliveryAreas < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_column :marketplace_delivery_areas, :discarded_at, :datetime
+    add_index :marketplace_delivery_areas, :discarded_at, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_10_05_005905) do
+ActiveRecord::Schema[7.1].define(version: 2023_12_12_003521) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -147,6 +147,8 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_05_005905) do
     t.datetime "updated_at", null: false
     t.string "delivery_window"
     t.string "order_by"
+    t.datetime "discarded_at"
+    t.index ["discarded_at"], name: "index_marketplace_delivery_areas_on_discarded_at"
     t.index ["marketplace_id"], name: "index_marketplace_delivery_areas_on_marketplace_id"
   end
 

--- a/spec/factories/furniture/marketplace.rb
+++ b/spec/factories/furniture/marketplace.rb
@@ -195,6 +195,9 @@ FactoryBot.define do
 
     label { Faker::Address.city }
     price { Faker::Commerce.price }
+    trait :discarded do
+      discarded_at { 1.hour.ago }
+    end
   end
 
   factory :marketplace_delivery, class: "Marketplace::Delivery" do

--- a/spec/furniture/marketplace/delivery_area_component_spec.rb
+++ b/spec/furniture/marketplace/delivery_area_component_spec.rb
@@ -11,18 +11,27 @@ RSpec.describe Marketplace::DeliveryAreaComponent, type: :component do
   it { is_expected.to have_content(delivery_area.label) }
   it { is_expected.to have_content(vc_test_controller.view_context.humanized_money_with_symbol(delivery_area.price)) }
 
-  it { is_expected.to have_selector("a[href='#{polymorphic_path(delivery_area.location)}'][data-turbo=true][data-turbo-stream=true][data-turbo-method=delete][data-method=delete][data-confirm='#{I18n.t("destroy.confirm")}']") }
+  it { is_expected.to have_selector("a[href='#{polymorphic_path(delivery_area.location)}'][data-turbo=true][data-turbo-stream=true][data-turbo-method=delete][data-method=delete]") }
+  it { is_expected.to have_link(I18n.t("discard.link_to", href: polymorphic_path(delivery_area.location))) }
 
-  context "when there is a Cart for that Delivery Area" do
-    before { create(:marketplace_cart, delivery_area:, marketplace: delivery_area.marketplace) }
+  context "when the delivery area is Discarded" do
+    let(:delivery_area) { create(:marketplace_delivery_area, :discarded) }
 
     it { is_expected.to have_selector("a[href='#{polymorphic_path(delivery_area.location)}'][data-turbo=true][data-turbo-stream=true][data-turbo-method=delete][data-method=delete][data-confirm='#{I18n.t("destroy.confirm")}']") }
-  end
+    it { is_expected.to have_link(I18n.t("destroy.link_to", href: polymorphic_path(delivery_area.location))) }
 
-  context "when there is an Order for that DeliveryArea" do
-    before { create(:marketplace_order, delivery_area:, marketplace: delivery_area.marketplace) }
+    context "when there is a Cart for that Delivery Area" do
+      before { create(:marketplace_cart, delivery_area:, marketplace: delivery_area.marketplace) }
 
-    it { is_expected.not_to have_selector("a[href='#{polymorphic_path(delivery_area.location)}'][data-method=delete]") }
+      it { is_expected.to have_selector("a[href='#{polymorphic_path(delivery_area.location)}'][data-turbo=true][data-turbo-stream=true][data-turbo-method=delete][data-method=delete][data-confirm='#{I18n.t("destroy.confirm")}']") }
+      it { is_expected.to have_link(I18n.t("destroy.link_to", href: polymorphic_path(delivery_area.location))) }
+    end
+
+    context "when there is an Order for that DeliveryArea" do
+      before { create(:marketplace_order, delivery_area:, marketplace: delivery_area.marketplace) }
+
+      it { is_expected.not_to have_selector("a[href='#{polymorphic_path(delivery_area.location)}'][data-method=delete]") }
+    end
   end
 
   it { is_expected.to have_selector("a[href='#{polymorphic_path(delivery_area.location(:edit))}'][data-turbo=true][data-turbo-method=get][data-turbo-stream=true]") }

--- a/spec/furniture/marketplace/delivery_area_component_spec.rb
+++ b/spec/furniture/marketplace/delivery_area_component_spec.rb
@@ -11,30 +11,30 @@ RSpec.describe Marketplace::DeliveryAreaComponent, type: :component do
   it { is_expected.to have_content(delivery_area.label) }
   it { is_expected.to have_content(vc_test_controller.view_context.humanized_money_with_symbol(delivery_area.price)) }
 
-  it { is_expected.to have_selector("a[href='#{polymorphic_path(delivery_area.location)}'][data-turbo=true][data-turbo-stream=true][data-turbo-method=delete][data-method=delete]") }
+  it { is_expected.to have_selector("a[href='#{polymorphic_path(delivery_area.location)}'][data-turbo-method=delete]") }
   it { is_expected.to have_link(I18n.t("discard.link_to", href: polymorphic_path(delivery_area.location))) }
 
   context "when the delivery area is Discarded" do
     let(:delivery_area) { create(:marketplace_delivery_area, :discarded) }
 
-    it { is_expected.to have_selector("a[href='#{polymorphic_path(delivery_area.location)}'][data-turbo=true][data-turbo-stream=true][data-turbo-method=delete][data-method=delete][data-confirm='#{I18n.t("destroy.confirm")}']") }
+    it { is_expected.to have_selector("a[href='#{polymorphic_path(delivery_area.location)}'][data-turbo-method=delete][data-confirm='#{I18n.t("destroy.confirm")}']") }
     it { is_expected.to have_link(I18n.t("destroy.link_to", href: polymorphic_path(delivery_area.location))) }
 
     context "when there is a Cart for that Delivery Area" do
       before { create(:marketplace_cart, delivery_area:, marketplace: delivery_area.marketplace) }
 
-      it { is_expected.to have_selector("a[href='#{polymorphic_path(delivery_area.location)}'][data-turbo=true][data-turbo-stream=true][data-turbo-method=delete][data-method=delete][data-confirm='#{I18n.t("destroy.confirm")}']") }
+      it { is_expected.to have_selector("a[href='#{polymorphic_path(delivery_area.location)}'][data-turbo-method=delete][data-confirm='#{I18n.t("destroy.confirm")}']") }
       it { is_expected.to have_link(I18n.t("destroy.link_to", href: polymorphic_path(delivery_area.location))) }
     end
 
     context "when there is an Order for that DeliveryArea" do
       before { create(:marketplace_order, delivery_area:, marketplace: delivery_area.marketplace) }
 
-      it { is_expected.not_to have_selector("a[href='#{polymorphic_path(delivery_area.location)}'][data-method=delete]") }
+      it { is_expected.not_to have_selector("a[href='#{polymorphic_path(delivery_area.location)}'][data-turbo-method=delete]") }
     end
   end
 
-  it { is_expected.to have_selector("a[href='#{polymorphic_path(delivery_area.location(:edit))}'][data-turbo=true][data-turbo-method=get][data-turbo-stream=true]") }
+  it { is_expected.to have_selector("a[href='#{polymorphic_path(delivery_area.location(:edit))}']") }
 
   context "when `#delivery_window` is empty" do
     it { is_expected.to have_content "at your chosen time" }

--- a/spec/furniture/marketplace/delivery_area_spec.rb
+++ b/spec/furniture/marketplace/delivery_area_spec.rb
@@ -5,4 +5,48 @@ RSpec.describe Marketplace::DeliveryArea, type: :model do
   it { is_expected.to have_many(:orders).inverse_of(:delivery_area) }
   it { is_expected.to have_many(:carts).inverse_of(:delivery_area) }
   it { is_expected.to have_many(:deliveries).inverse_of(:delivery_area) }
+
+  describe "#discardable?" do
+    subject(:delivery_area) { build(:marketplace_delivery_area) }
+
+    it { is_expected.not_to be_discardable }
+
+    context "when the delivery area is persisted" do
+      subject(:delivery_area) { create(:marketplace_delivery_area) }
+
+      it { is_expected.to be_discardable }
+
+      context "when the delivery area is discarded already" do
+        subject(:delivery_area) { create(:marketplace_delivery_area, :discarded) }
+
+        it { is_expected.not_to be_discardable }
+      end
+    end
+  end
+
+  describe "#destroyable?" do
+    subject(:delivery_area) { build(:marketplace_delivery_area) }
+
+    it { is_expected.not_to be_destroyable }
+
+    context "when a delivery area is persisted" do
+      subject(:delivery_area) { create(:marketplace_delivery_area) }
+
+      it { is_expected.not_to be_destroyable }
+
+      context "when the delivery area is discarded" do
+        subject(:delivery_area) { create(:marketplace_delivery_area, :discarded) }
+
+        it { is_expected.to be_destroyable }
+
+        context "when the delivery area has orders" do
+          subject(:delivery_area) { create(:marketplace_delivery_area, :discarded) }
+
+          before { create(:marketplace_order, delivery_area:) }
+
+          it { is_expected.not_to be_destroyable }
+        end
+      end
+    end
+  end
 end

--- a/spec/furniture/marketplace/delivery_areas_controller_request_spec.rb
+++ b/spec/furniture/marketplace/delivery_areas_controller_request_spec.rb
@@ -69,9 +69,8 @@ RSpec.describe Marketplace::DeliveryAreasController, type: :request do
   end
 
   describe "#destroy" do
-    let(:as) { :html }
     let(:perform_request) do
-      delete polymorphic_path(delivery_area.location), as: as
+      delete polymorphic_path(delivery_area.location)
     end
 
     let(:delivery_area) { create(:marketplace_delivery_area, marketplace: marketplace) }
@@ -107,11 +106,5 @@ RSpec.describe Marketplace::DeliveryAreasController, type: :request do
     end
 
     it { is_expected.to redirect_to(marketplace.location(child: :delivery_areas)) }
-
-    context "when a turbo_stream" do
-      let(:as) { :turbo_stream }
-
-      it { is_expected.to have_rendered_turbo_stream(:remove, delivery_area) }
-    end
   end
 end

--- a/spec/furniture/marketplace/delivery_areas_system_spec.rb
+++ b/spec/furniture/marketplace/delivery_areas_system_spec.rb
@@ -19,7 +19,7 @@ describe "Marketplace: Delivery Areas", type: :system do
       it "clears the Delivery Area from Carts" do
         cart = create(:marketplace_cart, delivery_area:, marketplace:)
         visit(polymorphic_path(marketplace.location(child: :delivery_areas)))
-        click_link("Archive")
+        click_link("Archived Delivery Areas")
         within("##{dom_id(delivery_area)}") do
           accept_confirm { click_link("Remove") }
         end
@@ -34,7 +34,7 @@ describe "Marketplace: Delivery Areas", type: :system do
 
         create(:marketplace_order, delivery_area:, marketplace:)
         visit(polymorphic_path(marketplace.location(child: :delivery_areas)))
-        click_link("Archive")
+        click_link("Archived Delivery Areas")
 
         within("##{dom_id(delivery_area)}") do
           expect(page).not_to have_content("Remove")

--- a/spec/furniture/marketplace/delivery_areas_system_spec.rb
+++ b/spec/furniture/marketplace/delivery_areas_system_spec.rb
@@ -10,29 +10,34 @@ describe "Marketplace: Delivery Areas", type: :system do
   end
 
   describe "Deleting Delivery Areas" do
-    it "clears the Delivery Area from Carts" do
-      delivery_area = create(:marketplace_delivery_area, marketplace:, label: "Oakland",
-        price_cents: 10_00)
-      cart = create(:marketplace_cart, delivery_area:, marketplace:)
-      visit(polymorphic_path(marketplace.location(child: :delivery_areas)))
-
-      within("##{dom_id(delivery_area)}") do
-        accept_confirm { click_link("Remove") }
+    context "when the Delivery Area is Discarded" do
+      let(:delivery_area) do
+        create(:marketplace_delivery_area, :discarded, marketplace:,
+          label: "Oakland", price_cents: 10_00)
       end
 
-      expect(page).not_to have_content(delivery_area.label)
-      expect(cart.reload.delivery_area).to be_nil
-    end
+      it "clears the Delivery Area from Carts" do
+        cart = create(:marketplace_cart, delivery_area:, marketplace:)
+        visit(polymorphic_path(marketplace.location(child: :delivery_areas)))
 
-    it "is impossible when there is an Order" do
-      delivery_area = create(:marketplace_delivery_area, marketplace:, label: "Oakland",
-        price_cents: 10_00)
+        within("##{dom_id(delivery_area)}") do
+          accept_confirm { click_link("Remove") }
+        end
 
-      create(:marketplace_order, delivery_area:, marketplace:)
-      visit(polymorphic_path(marketplace.location(child: :delivery_areas)))
+        expect(page).not_to have_content(delivery_area.label)
+        expect(cart.reload.delivery_area).to be_nil
+      end
 
-      within("##{dom_id(delivery_area)}") do
-        expect(page).not_to have_content("Remove")
+      it "is impossible when there is an Order" do
+        delivery_area = create(:marketplace_delivery_area, marketplace:, label: "Oakland",
+          price_cents: 10_00)
+
+        create(:marketplace_order, delivery_area:, marketplace:)
+        visit(polymorphic_path(marketplace.location(child: :delivery_areas)))
+
+        within("##{dom_id(delivery_area)}") do
+          expect(page).not_to have_content("Remove")
+        end
       end
     end
   end

--- a/spec/furniture/marketplace/delivery_areas_system_spec.rb
+++ b/spec/furniture/marketplace/delivery_areas_system_spec.rb
@@ -19,7 +19,7 @@ describe "Marketplace: Delivery Areas", type: :system do
       it "clears the Delivery Area from Carts" do
         cart = create(:marketplace_cart, delivery_area:, marketplace:)
         visit(polymorphic_path(marketplace.location(child: :delivery_areas)))
-
+        click_link("Archive")
         within("##{dom_id(delivery_area)}") do
           accept_confirm { click_link("Remove") }
         end
@@ -29,11 +29,12 @@ describe "Marketplace: Delivery Areas", type: :system do
       end
 
       it "is impossible when there is an Order" do
-        delivery_area = create(:marketplace_delivery_area, marketplace:, label: "Oakland",
+        delivery_area = create(:marketplace_delivery_area, :discarded, marketplace:, label: "Oakland",
           price_cents: 10_00)
 
         create(:marketplace_order, delivery_area:, marketplace:)
         visit(polymorphic_path(marketplace.location(child: :delivery_areas)))
+        click_link("Archive")
 
         within("##{dom_id(delivery_area)}") do
           expect(page).not_to have_content("Remove")


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/2014

This adds the `discard` gem so that we can archive objects. It also updates the workflow for removing DeliveryArea to have an `Archive` step first.

Once a `DeliveryArea` is archived, it can not yet be restored; but it can be removed if there are no `Orders` associated with the `DeliveryArea`