### PR TITLE
🧹 `Neighborhood`: Drop extraneous icons

### DIFF
--- a/app/views/furnitures/_furniture.html.erb
+++ b/app/views/furnitures/_furniture.html.erb
@@ -18,7 +18,7 @@
         <%- end %>
 
         <%= render ButtonComponent.new(
-                      label: t('icons.remove'),
+                      label: t('icons.destroy'),
                       href: [furniture.room.space, furniture.room, furniture],
                       title: t('.remove_title', name: furniture.furniture.model_name.human.titleize),
                       method: :delete,

--- a/app/views/invitations/_invitation.html.erb
+++ b/app/views/invitations/_invitation.html.erb
@@ -28,7 +28,7 @@
   <td class="py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
     <%- if !invitation.revoked? && policy(invitation).destroy?  %>
       <%= render ButtonComponent.new(
-                   label: t('icons.remove'),
+                   label: t('icons.destroy'),
                    href: [space, invitation],
                    title: t('invitation.destroy'),
                    method: :delete,

--- a/app/views/memberships/_membership.html.erb
+++ b/app/views/memberships/_membership.html.erb
@@ -34,7 +34,7 @@
   <td class="py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
     <%- if policy(membership).destroy?  %>
       <%= render ButtonComponent.new(
-                   label: t('icons.remove'),
+                   label: t('icons.destroy'),
                    href: [space, membership],
                    title: t('memberships.delete'),
                    method: :delete,

--- a/config/locales/icon/en.yml
+++ b/config/locales/icon/en.yml
@@ -1,8 +1,6 @@
 en:
   icons:
     edit: '⚙️'
-    pencil: '✏️'
-    remove: '🗑️'
     destroy: '🗑️'
     new: '➕'
     plus: '➕'


### PR DESCRIPTION
We don't need both a `remove` and `destroy` icon; and we use `destroy` in more places.

We also don't need an `edit` and `pencil`, so I dropped `pencil` since it was unused.