### PR TITLE
🧹 `Marketplace`: `DeliveryArea` Strip TurboStreams

### DIFF
--- a/app/furniture/layouts/marketplace.html.erb
+++ b/app/furniture/layouts/marketplace.html.erb
@@ -1,5 +1,5 @@
 <%- content_for :content do %>
-  <%= turbo_frame_tag(marketplace) do %>
+  <%= turbo_frame_tag(marketplace, data: { turbo_action: :advance }) do %>
     <%= yield  %>
   <%- end %>
 <%- end %>

--- a/app/furniture/marketplace/delivery_area_component.rb
+++ b/app/furniture/marketplace/delivery_area_component.rb
@@ -33,9 +33,7 @@ class Marketplace
 
       ButtonComponent.new(label: "#{t("icons.discard")} #{t("discard.link_to")}",
         title: t("marketplace.delivery_areas.discard.link_to", name: delivery_area.label),
-        href: delivery_area.location, turbo_stream: true,
-        method: :delete,
-        scheme: :secondary)
+        href: delivery_area.location, method: :delete, scheme: :secondary)
     end
 
     def discard_button?
@@ -47,9 +45,7 @@ class Marketplace
 
       ButtonComponent.new(label: "#{t("icons.destroy")} #{t("destroy.link_to")}",
         title: t("marketplace.delivery_areas.destroy.link_to", name: delivery_area.label),
-        href: delivery_area.location, turbo_stream: true,
-        method: :delete,
-        confirm: t("destroy.confirm"),
+        href: delivery_area.location, method: :delete, confirm: t("destroy.confirm"),
         scheme: :secondary)
     end
 

--- a/app/furniture/marketplace/delivery_areas/edit.html.erb
+++ b/app/furniture/marketplace/delivery_areas/edit.html.erb
@@ -1,2 +1,4 @@
 <%- breadcrumb :edit_delivery_area, delivery_area %>
-<%= render "form", delivery_area: delivery_area %>
+<%= render Marketplace::ManagementComponent.new(marketplace: marketplace) do %>
+  <%= render "form", delivery_area: delivery_area %>
+<%- end %>

--- a/app/furniture/marketplace/delivery_areas/new.html.erb
+++ b/app/furniture/marketplace/delivery_areas/new.html.erb
@@ -1,2 +1,6 @@
 <%- breadcrumb :new_delivery_area, delivery_area %>
-<%= render "form", delivery_area: delivery_area %>
+<%= render Marketplace::ManagementComponent.new(marketplace: marketplace) do %>
+  <div class="mt-3">
+    <%= render "form", delivery_area: delivery_area %>
+  </div>
+<%- end %>

--- a/app/furniture/marketplace/delivery_areas_controller.rb
+++ b/app/furniture/marketplace/delivery_areas_controller.rb
@@ -40,23 +40,7 @@ class Marketplace
         delivery_area.discard
       end
 
-      respond_to do |format|
-        format.turbo_stream do
-          if delivery_area.destroyed? || delivery_area.discarded?
-            render turbo_stream: turbo_stream.remove(delivery_area)
-          else
-            render turbo_stream: turbo_stream.replace(delivery_area)
-          end
-        end
-
-        format.html do
-          if delivery_area.destroyed? || delivery_area.discarded?
-            redirect_to marketplace.location(child: :delivery_areas)
-          else
-            render :show
-          end
-        end
-      end
+      redirect_to marketplace.location(child: :delivery_areas)
     end
 
     def delivery_area_params

--- a/spec/furniture/marketplace/delivery_area_component_spec.rb
+++ b/spec/furniture/marketplace/delivery_area_component_spec.rb
@@ -11,30 +11,30 @@ RSpec.describe Marketplace::DeliveryAreaComponent, type: :component do
   it { is_expected.to have_content(delivery_area.label) }
   it { is_expected.to have_content(vc_test_controller.view_context.humanized_money_with_symbol(delivery_area.price)) }
 
-  it { is_expected.to have_selector("a[href='#{polymorphic_path(delivery_area.location)}'][data-turbo=true][data-turbo-stream=true][data-turbo-method=delete][data-method=delete]") }
+  it { is_expected.to have_selector("a[href='#{polymorphic_path(delivery_area.location)}'][data-turbo-method=delete]") }
   it { is_expected.to have_link(I18n.t("discard.link_to", href: polymorphic_path(delivery_area.location))) }
 
   context "when the delivery area is Discarded" do
     let(:delivery_area) { create(:marketplace_delivery_area, :discarded) }
 
-    it { is_expected.to have_selector("a[href='#{polymorphic_path(delivery_area.location)}'][data-turbo=true][data-turbo-stream=true][data-turbo-method=delete][data-method=delete][data-confirm='#{I18n.t("destroy.confirm")}']") }
+    it { is_expected.to have_selector("a[href='#{polymorphic_path(delivery_area.location)}'][data-turbo-method=delete][data-confirm='#{I18n.t("destroy.confirm")}']") }
     it { is_expected.to have_link(I18n.t("destroy.link_to", href: polymorphic_path(delivery_area.location))) }
 
     context "when there is a Cart for that Delivery Area" do
       before { create(:marketplace_cart, delivery_area:, marketplace: delivery_area.marketplace) }
 
-      it { is_expected.to have_selector("a[href='#{polymorphic_path(delivery_area.location)}'][data-turbo=true][data-turbo-stream=true][data-turbo-method=delete][data-method=delete][data-confirm='#{I18n.t("destroy.confirm")}']") }
+      it { is_expected.to have_selector("a[href='#{polymorphic_path(delivery_area.location)}'][data-turbo-method=delete][data-confirm='#{I18n.t("destroy.confirm")}']") }
       it { is_expected.to have_link(I18n.t("destroy.link_to", href: polymorphic_path(delivery_area.location))) }
     end
 
     context "when there is an Order for that DeliveryArea" do
       before { create(:marketplace_order, delivery_area:, marketplace: delivery_area.marketplace) }
 
-      it { is_expected.not_to have_selector("a[href='#{polymorphic_path(delivery_area.location)}'][data-method=delete]") }
+      it { is_expected.not_to have_selector("a[href='#{polymorphic_path(delivery_area.location)}'][data-turbo-method=delete]") }
     end
   end
 
-  it { is_expected.to have_selector("a[href='#{polymorphic_path(delivery_area.location(:edit))}'][data-turbo=true][data-turbo-method=get][data-turbo-stream=true]") }
+  it { is_expected.to have_selector("a[href='#{polymorphic_path(delivery_area.location(:edit))}']") }
 
   context "when `#delivery_window` is empty" do
     it { is_expected.to have_content "at your chosen time" }

--- a/spec/furniture/marketplace/delivery_areas_controller_request_spec.rb
+++ b/spec/furniture/marketplace/delivery_areas_controller_request_spec.rb
@@ -69,9 +69,8 @@ RSpec.describe Marketplace::DeliveryAreasController, type: :request do
   end
 
   describe "#destroy" do
-    let(:as) { :html }
     let(:perform_request) do
-      delete polymorphic_path(delivery_area.location), as: as
+      delete polymorphic_path(delivery_area.location)
     end
 
     let(:delivery_area) { create(:marketplace_delivery_area, marketplace: marketplace) }
@@ -107,11 +106,5 @@ RSpec.describe Marketplace::DeliveryAreasController, type: :request do
     end
 
     it { is_expected.to redirect_to(marketplace.location(child: :delivery_areas)) }
-
-    context "when a turbo_stream" do
-      let(:as) { :turbo_stream }
-
-      it { is_expected.to have_rendered_turbo_stream(:remove, delivery_area) }
-    end
   end
 end


### PR DESCRIPTION
Now that we have a better idea how to use TurboFrames, the Streams seem pretty unnecessary.

This also makes it so following links within the
`Marketplace::ManagementComponent` update the browser URL.