### PR TITLE
✨ `Marketplace`: Put Archived `DeliveryAreas` behind the `Archive` link

### DIFF
--- a/app/furniture/layouts/marketplace.html.erb
+++ b/app/furniture/layouts/marketplace.html.erb
@@ -1,5 +1,5 @@
 <%- content_for :content do %>
-  <%= turbo_frame_tag(marketplace) do %>
+  <%= turbo_frame_tag(marketplace, data: { turbo_action: :advance }) do %>
     <%= yield  %>
   <%- end %>
 <%- end %>

--- a/app/furniture/marketplace/delivery_area_component.html.erb
+++ b/app/furniture/marketplace/delivery_area_component.html.erb
@@ -2,6 +2,9 @@
 <%= render CardComponent.new(dom_id: dom_id(delivery_area), classes: "flex flex-col justify-between gap-y-2 w-full") do %>
   <header class="flex font-bold">
     <%= label %>
+    <%- if delivery_area.discarded?%>
+      <span class="italic">(archived)</span>
+    <%- end %>
   </header>
 
   <div class="grow flex flex-col justify-between">

--- a/app/furniture/marketplace/delivery_area_component.rb
+++ b/app/furniture/marketplace/delivery_area_component.rb
@@ -33,9 +33,7 @@ class Marketplace
 
       ButtonComponent.new(label: "#{t("icons.discard")} #{t("discard.link_to")}",
         title: t("marketplace.delivery_areas.discard.link_to", name: delivery_area.label),
-        href: delivery_area.location, turbo_stream: true,
-        method: :delete,
-        scheme: :secondary)
+        href: delivery_area.location, method: :delete, scheme: :secondary)
     end
 
     def discard_button?
@@ -47,9 +45,7 @@ class Marketplace
 
       ButtonComponent.new(label: "#{t("icons.destroy")} #{t("destroy.link_to")}",
         title: t("marketplace.delivery_areas.destroy.link_to", name: delivery_area.label),
-        href: delivery_area.location, turbo_stream: true,
-        method: :delete,
-        confirm: t("destroy.confirm"),
+        href: delivery_area.location, method: :delete, confirm: t("destroy.confirm"),
         scheme: :secondary)
     end
 

--- a/app/furniture/marketplace/delivery_areas/edit.html.erb
+++ b/app/furniture/marketplace/delivery_areas/edit.html.erb
@@ -1,2 +1,4 @@
 <%- breadcrumb :edit_delivery_area, delivery_area %>
-<%= render "form", delivery_area: delivery_area %>
+<%= render Marketplace::ManagementComponent.new(marketplace: marketplace) do %>
+  <%= render "form", delivery_area: delivery_area %>
+<%- end %>

--- a/app/furniture/marketplace/delivery_areas/index.html.erb
+++ b/app/furniture/marketplace/delivery_areas/index.html.erb
@@ -4,19 +4,30 @@
   <section class="mt-3">
     <main>
       <div class="grid grid-cols-1 gap-3 sm:gap-5 sm:grid-cols-3">
-        <%= render Marketplace::DeliveryAreaComponent.with_collection(delivery_areas) %>
+        <%- if params[:archive] %>
+          <%= render Marketplace::DeliveryAreaComponent.with_collection(delivery_areas.discarded) %>
+        <%- else %>
+          <%= render Marketplace::DeliveryAreaComponent.with_collection(delivery_areas.kept) %>
+        <%- end %>
       </div>
     </main>
 
     <div class="text-center mt-3">
       <%- new_delivery_area = marketplace.delivery_areas.new %>
-      <%- if policy(new_delivery_area).create? %>
+      <%- if policy(new_delivery_area).create? && !params[:archive] %>
         <%= render ButtonComponent.new(
           label: "#{t('marketplace.delivery_areas.new.link_to')} #{t('icons.new')}",
           title: t('marketplace.delivery_areas.new.link_to'),
           href: marketplace.location(:new, child: :delivery_area),
           method: :get,
           scheme: :secondary) %>
+      <%- end %>
+    </div>
+    <div class="text-center mt-3">
+      <%- if params[:archive] %>
+        <%= link_to "Active", marketplace.location(child: :delivery_areas) %>
+      <%- else %>
+        <%= link_to "Archive", marketplace.location(child: :delivery_areas, query_params: { archive: true }) %>
       <%- end %>
     </div>
   </section>

--- a/app/furniture/marketplace/delivery_areas/new.html.erb
+++ b/app/furniture/marketplace/delivery_areas/new.html.erb
@@ -1,2 +1,6 @@
 <%- breadcrumb :new_delivery_area, delivery_area %>
-<%= render "form", delivery_area: delivery_area %>
+<%= render Marketplace::ManagementComponent.new(marketplace: marketplace) do %>
+  <div class="mt-3">
+    <%= render "form", delivery_area: delivery_area %>
+  </div>
+<%- end %>

--- a/app/furniture/marketplace/delivery_areas_controller.rb
+++ b/app/furniture/marketplace/delivery_areas_controller.rb
@@ -40,23 +40,7 @@ class Marketplace
         delivery_area.discard
       end
 
-      respond_to do |format|
-        format.turbo_stream do
-          if delivery_area.destroyed? || delivery_area.discarded?
-            render turbo_stream: turbo_stream.remove(delivery_area)
-          else
-            render turbo_stream: turbo_stream.replace(delivery_area)
-          end
-        end
-
-        format.html do
-          if delivery_area.destroyed? || delivery_area.discarded?
-            redirect_to marketplace.location(child: :delivery_areas)
-          else
-            render :show
-          end
-        end
-      end
+      redirect_to marketplace.location(child: :delivery_areas)
     end
 
     def delivery_area_params

--- a/spec/furniture/marketplace/delivery_area_component_spec.rb
+++ b/spec/furniture/marketplace/delivery_area_component_spec.rb
@@ -11,30 +11,30 @@ RSpec.describe Marketplace::DeliveryAreaComponent, type: :component do
   it { is_expected.to have_content(delivery_area.label) }
   it { is_expected.to have_content(vc_test_controller.view_context.humanized_money_with_symbol(delivery_area.price)) }
 
-  it { is_expected.to have_selector("a[href='#{polymorphic_path(delivery_area.location)}'][data-turbo=true][data-turbo-stream=true][data-turbo-method=delete][data-method=delete]") }
+  it { is_expected.to have_selector("a[href='#{polymorphic_path(delivery_area.location)}'][data-turbo-method=delete]") }
   it { is_expected.to have_link(I18n.t("discard.link_to", href: polymorphic_path(delivery_area.location))) }
 
   context "when the delivery area is Discarded" do
     let(:delivery_area) { create(:marketplace_delivery_area, :discarded) }
 
-    it { is_expected.to have_selector("a[href='#{polymorphic_path(delivery_area.location)}'][data-turbo=true][data-turbo-stream=true][data-turbo-method=delete][data-method=delete][data-confirm='#{I18n.t("destroy.confirm")}']") }
+    it { is_expected.to have_selector("a[href='#{polymorphic_path(delivery_area.location)}'][data-turbo-method=delete][data-confirm='#{I18n.t("destroy.confirm")}']") }
     it { is_expected.to have_link(I18n.t("destroy.link_to", href: polymorphic_path(delivery_area.location))) }
 
     context "when there is a Cart for that Delivery Area" do
       before { create(:marketplace_cart, delivery_area:, marketplace: delivery_area.marketplace) }
 
-      it { is_expected.to have_selector("a[href='#{polymorphic_path(delivery_area.location)}'][data-turbo=true][data-turbo-stream=true][data-turbo-method=delete][data-method=delete][data-confirm='#{I18n.t("destroy.confirm")}']") }
+      it { is_expected.to have_selector("a[href='#{polymorphic_path(delivery_area.location)}'][data-turbo-method=delete][data-confirm='#{I18n.t("destroy.confirm")}']") }
       it { is_expected.to have_link(I18n.t("destroy.link_to", href: polymorphic_path(delivery_area.location))) }
     end
 
     context "when there is an Order for that DeliveryArea" do
       before { create(:marketplace_order, delivery_area:, marketplace: delivery_area.marketplace) }
 
-      it { is_expected.not_to have_selector("a[href='#{polymorphic_path(delivery_area.location)}'][data-method=delete]") }
+      it { is_expected.not_to have_selector("a[href='#{polymorphic_path(delivery_area.location)}'][data-turbo-method=delete]") }
     end
   end
 
-  it { is_expected.to have_selector("a[href='#{polymorphic_path(delivery_area.location(:edit))}'][data-turbo=true][data-turbo-method=get][data-turbo-stream=true]") }
+  it { is_expected.to have_selector("a[href='#{polymorphic_path(delivery_area.location(:edit))}']") }
 
   context "when `#delivery_window` is empty" do
     it { is_expected.to have_content "at your chosen time" }

--- a/spec/furniture/marketplace/delivery_areas_controller_request_spec.rb
+++ b/spec/furniture/marketplace/delivery_areas_controller_request_spec.rb
@@ -69,9 +69,8 @@ RSpec.describe Marketplace::DeliveryAreasController, type: :request do
   end
 
   describe "#destroy" do
-    let(:as) { :html }
     let(:perform_request) do
-      delete polymorphic_path(delivery_area.location), as: as
+      delete polymorphic_path(delivery_area.location)
     end
 
     let(:delivery_area) { create(:marketplace_delivery_area, marketplace: marketplace) }
@@ -107,11 +106,5 @@ RSpec.describe Marketplace::DeliveryAreasController, type: :request do
     end
 
     it { is_expected.to redirect_to(marketplace.location(child: :delivery_areas)) }
-
-    context "when a turbo_stream" do
-      let(:as) { :turbo_stream }
-
-      it { is_expected.to have_rendered_turbo_stream(:remove, delivery_area) }
-    end
   end
 end

--- a/spec/furniture/marketplace/delivery_areas_system_spec.rb
+++ b/spec/furniture/marketplace/delivery_areas_system_spec.rb
@@ -19,7 +19,7 @@ describe "Marketplace: Delivery Areas", type: :system do
       it "clears the Delivery Area from Carts" do
         cart = create(:marketplace_cart, delivery_area:, marketplace:)
         visit(polymorphic_path(marketplace.location(child: :delivery_areas)))
-
+        click_link("Archive")
         within("##{dom_id(delivery_area)}") do
           accept_confirm { click_link("Remove") }
         end
@@ -29,11 +29,12 @@ describe "Marketplace: Delivery Areas", type: :system do
       end
 
       it "is impossible when there is an Order" do
-        delivery_area = create(:marketplace_delivery_area, marketplace:, label: "Oakland",
+        delivery_area = create(:marketplace_delivery_area, :discarded, marketplace:, label: "Oakland",
           price_cents: 10_00)
 
         create(:marketplace_order, delivery_area:, marketplace:)
         visit(polymorphic_path(marketplace.location(child: :delivery_areas)))
+        click_link("Archive")
 
         within("##{dom_id(delivery_area)}") do
           expect(page).not_to have_content("Remove")


### PR DESCRIPTION
Figure once a `DeliveryArea` is archived, we don't want it clogging up the main page. So now it goes behind an `archive` flag. 