### PR TITLE
🐞 `Marketplace`: Fixes missing argument for translation string interpolation

### DIFF
--- a/app/views/rooms/edit.html.erb
+++ b/app/views/rooms/edit.html.erb
@@ -1,12 +1,8 @@
 <% breadcrumb :edit_room, room %>
-
 <h1>Configure <%= room.name %></h1>
-
 <%= render partial: 'form', locals: { room: room } %>
-
 <%= render CardComponent.new(classes: "mt-3 gap-y-3") do %>
   <h2>Gizmos</h2>
-
   <div id="furnitures">
     <% if room.gizmos.present? %>
       <%= render room.gizmos.rank(:slot), editing: true %>
@@ -14,21 +10,19 @@
       <p class="text-gray-500"><%= t('rooms.no_furniture_notice') %></p>
     <% end %>
   </div>
-
   <%- new_furniture = room.gizmos.new %>
   <%- if policy(new_furniture).new? %>
     <%= render "furnitures/new", furniture: new_furniture %>
   <%- end %>
 <% end %>
-
-
 <%- if policy(room).destroy? && room.persisted? %>
   <div class="m-5">
     <h2><%= t("rooms.destroy.prompt")%></h2>
     <%- if !room.gizmos.reload.empty? %>
-      <%= t('rooms.destroy.blocked_by_gizmos') %>
+      <%= t('rooms.destroy.blocked_by_gizmos', room_name: room.name) %>
     <%- elsif room.entrance? %>
-      <%= t('rooms.destroy.blocked_by_entrance') %>
+      <%= t('rooms.destroy.blocked_by_entrance', room_name: room.name
+) %>
     <%- else %>
       <%= button_to(t('rooms.destroy.link_to'), room.location, method: :delete, class: "--danger w-full") %>
     <%- end %>

--- a/spec/system/sections_system_spec.rb
+++ b/spec/system/sections_system_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Sections" do
       let(:section) { space.entrance }
 
       it "doesn't let you delete the entrance" do
-        expect(page).to have_content(I18n.t("rooms.destroy.blocked_by_entrance"))
+        expect(page).to have_content(I18n.t("rooms.destroy.blocked_by_entrance", room_name: section.name))
         expect(page).not_to have_content(I18n.t("rooms.destroy.link_to"))
       end
     end
@@ -41,7 +41,7 @@ RSpec.describe "Sections" do
         # or something to be re-assigned; but that is out of scope for me at the
         # moment - ZS 10/18/23
         it "does not allow deletion of the Section" do
-          expect(page).to have_content(I18n.t("rooms.destroy.blocked_by_gizmos"))
+          expect(page).to have_content(I18n.t("rooms.destroy.blocked_by_gizmos", room_name: section.name))
           expect(page).not_to have_content(I18n.t("rooms.destroy.link_to"))
         end
       end


### PR DESCRIPTION
🙈

![image](https://github.com/zinc-collective/convene/assets/5185/76ebfc84-fbf2-4a48-a5c8-76f94d319ddf)

