### PR TITLE
🥗🌸✨ `Marketplace`: Hide `archived` `Products` from `Products#index`

### DIFF
--- a/app/furniture/marketplace/archivable/index_link_component.html.erb
+++ b/app/furniture/marketplace/archivable/index_link_component.html.erb
@@ -1,0 +1,1 @@
+<%= link_to text, location %>

--- a/app/furniture/marketplace/archivable/index_link_component.rb
+++ b/app/furniture/marketplace/archivable/index_link_component.rb
@@ -1,0 +1,24 @@
+class Marketplace
+  class Archivable::IndexLinkComponent < Component
+    attr_accessor :marketplace, :resource, :to_archive
+
+    def initialize(marketplace:, resource:, to_archive:, **kwargs)
+      self.marketplace = marketplace
+      self.resource = resource
+      self.to_archive = to_archive
+      super(**kwargs)
+    end
+
+    def location
+      if to_archive
+        marketplace.location(child: resource, query_params: {archive: true})
+      else
+        marketplace.location(child: resource)
+      end
+    end
+
+    def text
+      t(".#{resource}.#{to_archive ? :archive : :active}")
+    end
+  end
+end

--- a/app/furniture/marketplace/archivable/index_link_component.yml
+++ b/app/furniture/marketplace/archivable/index_link_component.yml
@@ -1,0 +1,7 @@
+en:
+  delivery_areas:
+    archive: "Archived Delivery Areas"
+    active: "Active Delivery Areas"
+  products:
+    archive: "Archived Products"
+    active: "Active Products"

--- a/app/furniture/marketplace/component.rb
+++ b/app/furniture/marketplace/component.rb
@@ -1,0 +1,4 @@
+class Marketplace
+  class Component < ApplicationComponent
+  end
+end

--- a/app/furniture/marketplace/delivery_areas/index.html.erb
+++ b/app/furniture/marketplace/delivery_areas/index.html.erb
@@ -24,11 +24,7 @@
       <%- end %>
     </div>
     <div class="text-center mt-3">
-      <%- if params[:archive] %>
-        <%= link_to "Active Delivery Areas", marketplace.location(child: :delivery_areas) %>
-      <%- else %>
-        <%= link_to "Archived Delivery Areas", marketplace.location(child: :delivery_areas, query_params: { archive: true }) %>
-      <%- end %>
+      <%= render Marketplace::Archivable::IndexLinkComponent.new(marketplace: marketplace, resource: :products) %>
     </div>
   </section>
 <% end %>

--- a/app/furniture/marketplace/delivery_areas/index.html.erb
+++ b/app/furniture/marketplace/delivery_areas/index.html.erb
@@ -24,7 +24,7 @@
       <%- end %>
     </div>
     <div class="text-center mt-3">
-      <%= render Marketplace::Archivable::IndexLinkComponent.new(marketplace: marketplace, resource: :products) %>
+      <%= render Marketplace::Archivable::IndexLinkComponent.new(marketplace: marketplace, resource: :delivery_areas, to_archive: !params[:archive]) %>
     </div>
   </section>
 <% end %>

--- a/app/furniture/marketplace/product_component.html.erb
+++ b/app/furniture/marketplace/product_component.html.erb
@@ -1,6 +1,9 @@
 <%= render CardComponent.new(dom_id: dom_id(product), classes: "flex flex-col justify-between max-w-prose") do %>
   <header>
     <h3 class="py-2"><%= name %></h3>
+    <%- if product.archived? %>
+      <span class="italic">(archived)</span>
+    <%- end %>
   </header>
 
   <div class="grow flex flex-col justify-between">

--- a/app/furniture/marketplace/product_component.rb
+++ b/app/furniture/marketplace/product_component.rb
@@ -49,7 +49,7 @@ class Marketplace
     end
 
     def destroy_button?
-      product.persisted? && policy(product).destroy? && product.orders.blank?
+      product.destroyable? && policy(product).destroy?
     end
   end
 end

--- a/app/furniture/marketplace/products/index.html.erb
+++ b/app/furniture/marketplace/products/index.html.erb
@@ -2,7 +2,11 @@
 
 <%= render Marketplace::ManagementComponent.new(marketplace: marketplace) do %>
   <div class="grid grid-cols-1 md:grid-cols-3 gap-3 sm:gap-5 mt-3 mx-auto">
-    <%= render Marketplace::ProductComponent.with_collection(marketplace.products) %>
+    <%- if params[:archive] %>
+      <%= render Marketplace::ProductComponent.with_collection(marketplace.products.archived) %>
+    <%- else %>
+      <%= render Marketplace::ProductComponent.with_collection(marketplace.products.unarchived) %>
+    <%- end %>
   </div>
 
   <div class="text-center mt-3">
@@ -15,5 +19,9 @@
         method: :get,
         scheme: :secondary) %>
     <%- end %>
+  </div>
+
+  <div class="text-center mt-3">
+    <%= render Marketplace::Archivable::IndexLinkComponent.new(marketplace: marketplace, resource: :products) %>
   </div>
 <% end %>

--- a/app/furniture/marketplace/products/index.html.erb
+++ b/app/furniture/marketplace/products/index.html.erb
@@ -22,6 +22,6 @@
   </div>
 
   <div class="text-center mt-3">
-    <%= render Marketplace::Archivable::IndexLinkComponent.new(marketplace: marketplace, resource: :products) %>
+    <%= render Marketplace::Archivable::IndexLinkComponent.new(marketplace: marketplace, resource: :products, to_archive: !params[:archive]) %>
   </div>
 <% end %>

--- a/spec/furniture/marketplace/archivable/index_link_component_spec.rb
+++ b/spec/furniture/marketplace/archivable/index_link_component_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe Marketplace::Archivable::IndexLinkComponent, type: :component do
+  subject(:output) { render_inline(component) }
+
+  let(:component) { described_class.new(marketplace:, resource:, to_archive: to_archive) }
+  let(:to_archive) { false }
+  let(:marketplace) { create(:marketplace) }
+
+  context "when the resource is products" do
+    let(:resource) { :products }
+
+    it { is_expected.to have_link("Active Products", href: polymorphic_path(marketplace.location(child: :products))) }
+
+    context "when to_archive" do
+      let(:to_archive) { true }
+
+      it { is_expected.to have_link("Archived Products", href: polymorphic_path(marketplace.location(child: :products), {archive: true})) }
+    end
+  end
+
+  context "when the resource is delivery_areas" do
+    let(:resource) { :delivery_areas }
+
+    it { is_expected.to have_link("Active Delivery Areas", href: polymorphic_path(marketplace.location(child: :delivery_areas))) }
+
+    context "when to_archive" do
+      let(:to_archive) { true }
+
+      it { is_expected.to have_link("Archived Delivery Areas", href: polymorphic_path(marketplace.location(child: :delivery_areas), {archive: true})) }
+    end
+  end
+end

--- a/spec/furniture/marketplace/product_component_spec.rb
+++ b/spec/furniture/marketplace/product_component_spec.rb
@@ -13,6 +13,14 @@ RSpec.describe Marketplace::ProductComponent, type: :component do
   it { is_expected.to have_content(tax_rate.label) }
   it { is_expected.to have_content(vc_test_controller.view_context.number_to_percentage(tax_rate.tax_rate, precision: 2)) }
   it { is_expected.to have_content(vc_test_controller.view_context.humanized_money_with_symbol(product.price)) }
-  it { is_expected.to have_selector("a[href='#{polymorphic_path(product.location)}'][data-turbo=true][data-turbo-method=delete][data-method=delete][data-confirm='#{I18n.t("destroy.confirm")}']") }
+
   it { is_expected.to have_selector("a[href='#{polymorphic_path(product.location(:edit))}'][data-turbo=true][data-turbo-method=get]") }
+  it { is_expected.not_to have_link(I18n.t("destroy.link_to")) }
+  it { is_expected.to have_link(I18n.t("archive.link_to")) }
+
+  context "when the Product is destroyable" do
+    let(:product) { create(:marketplace_product, :archived, marketplace:) }
+
+    it { is_expected.to have_selector("a[href='#{polymorphic_path(product.location)}'][data-turbo=true][data-turbo-method=delete][data-method=delete][data-confirm='#{I18n.t("destroy.confirm")}']") }
+  end
 end

--- a/spec/furniture/marketplace/selling_products_system_spec.rb
+++ b/spec/furniture/marketplace/selling_products_system_spec.rb
@@ -43,6 +43,7 @@ describe "Marketplace: Selling Products", type: :system do
 
     it "Deletes the Product from the Database" do
       visit(polymorphic_path(marketplace.location(child: :products)))
+      click_link("Archived Products")
 
       within("##{dom_id(product)}") do
         accept_confirm { click_link(I18n.t("destroy.link_to")) }
@@ -60,6 +61,7 @@ describe "Marketplace: Selling Products", type: :system do
 
       it "cannot be Removed" do
         visit(polymorphic_path(marketplace.location(child: :products)))
+        click_link("Archived Products")
 
         within("##{dom_id(product)}") do
           expect(page).not_to have_content(I18n.t("destroy.link_to"))


### PR DESCRIPTION
 - https://github.com/zinc-collective/convene/issues/2023

This makes `Products` more consistent with `DeliveryAreas` by:
- Removing the `Remove` link from the `ProductComponent` unless the `Product` is already `archived?` 
- Adding a visual indicator that `Products` have been `archived` to the `ProductComponent`
- Moving the `archived` `Products` to another page.


## Nerd Notes:
 
 I'm not convinced this Component is the right component to extract. Maybe a `DeliveryArea::ManagementComponent` and `Product::ManagementComponent` are the right step instead? 
 
