### PR TITLE
🌸 `Marketplace`: `NotificationMethods` is framed by ManagementComponent

### DIFF
--- a/app/furniture/marketplace/notification_methods/edit.html.erb
+++ b/app/furniture/marketplace/notification_methods/edit.html.erb
@@ -1,2 +1,4 @@
 <%- breadcrumb :edit_marketplace_notification_method, notification_method %>
-<%= render "form", notification_method: notification_method %>
+<%= render Marketplace::ManagementComponent.new(marketplace: marketplace) do %>
+  <%= render "form", notification_method: notification_method %>
+<%- end %>

--- a/app/furniture/marketplace/notification_methods/new.html.erb
+++ b/app/furniture/marketplace/notification_methods/new.html.erb
@@ -1,2 +1,5 @@
+
 <%- breadcrumb :new_marketplace_notification_method, notification_method %>
-<%= render "form", notification_method: notification_method %>
+<%= render Marketplace::ManagementComponent.new(marketplace: marketplace) do %>
+  <%= render "form", notification_method: notification_method %>
+<%- end %>


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1331

I noticed this while setting up [Zee's
Pizza](https://marketplace-sandbox.zinc.coop/rooms/zee-s-pizza)

Now it's prurty