### PR TITLE
🌸 `Marketplace`: All `Member` pages are in the `ManagementComponent`

### DIFF
--- a/app/furniture/layouts/marketplace.html.erb
+++ b/app/furniture/layouts/marketplace.html.erb
@@ -1,6 +1,12 @@
 <%- content_for :content do %>
   <%= turbo_frame_tag(marketplace, data: { turbo_action: :advance }) do %>
-    <%= yield  %>
+    <%- if policy(marketplace).edit? %>
+      <%= render Marketplace::ManagementComponent.new(marketplace: marketplace) do %>
+        <%= yield  %>
+      <%- end %>
+    <%- else %>
+      <%= yield  %>
+    <%- end %>
   <%- end %>
 <%- end %>
 <%= render template: "layouts/application" %>

--- a/app/furniture/marketplace/delivery_areas/edit.html.erb
+++ b/app/furniture/marketplace/delivery_areas/edit.html.erb
@@ -1,4 +1,2 @@
 <%- breadcrumb :edit_delivery_area, delivery_area %>
-<%= render Marketplace::ManagementComponent.new(marketplace: marketplace) do %>
-  <%= render "form", delivery_area: delivery_area %>
-<%- end %>
+<%= render "form", delivery_area: delivery_area %>

--- a/app/furniture/marketplace/delivery_areas/index.html.erb
+++ b/app/furniture/marketplace/delivery_areas/index.html.erb
@@ -1,30 +1,27 @@
 <%- breadcrumb(:marketplace_delivery_areas, marketplace) %>
-
-<%= render Marketplace::ManagementComponent.new(marketplace: marketplace) do %>
-  <section class="mt-3">
-    <main>
-      <div class="grid grid-cols-1 gap-3 sm:gap-5 sm:grid-cols-3">
-        <%- if params[:archive] %>
-          <%= render Marketplace::DeliveryAreaComponent.with_collection(delivery_areas.archived) %>
-        <%- else %>
-          <%= render Marketplace::DeliveryAreaComponent.with_collection(delivery_areas.unarchived) %>
-        <%- end %>
-      </div>
-    </main>
-
-    <div class="text-center mt-3">
-      <%- new_delivery_area = marketplace.delivery_areas.new %>
-      <%- if policy(new_delivery_area).create? && !params[:archive] %>
-        <%= render ButtonComponent.new(
-          label: "#{t('marketplace.delivery_areas.new.link_to')} #{t('icons.new')}",
-          title: t('marketplace.delivery_areas.new.link_to'),
-          href: marketplace.location(:new, child: :delivery_area),
-          method: :get,
-          scheme: :secondary) %>
+<section class="mt-3">
+  <main>
+    <div class="grid grid-cols-1 gap-3 sm:gap-5 sm:grid-cols-3">
+      <%- if params[:archive] %>
+        <%= render Marketplace::DeliveryAreaComponent.with_collection(delivery_areas.archived) %>
+      <%- else %>
+        <%= render Marketplace::DeliveryAreaComponent.with_collection(delivery_areas.unarchived) %>
       <%- end %>
     </div>
-    <div class="text-center mt-3">
-      <%= render Marketplace::Archivable::IndexLinkComponent.new(marketplace: marketplace, resource: :delivery_areas, to_archive: !params[:archive]) %>
-    </div>
-  </section>
-<% end %>
+  </main>
+
+  <div class="text-center mt-3">
+    <%- new_delivery_area = marketplace.delivery_areas.new %>
+    <%- if policy(new_delivery_area).create? && !params[:archive] %>
+      <%= render ButtonComponent.new(
+        label: "#{t('marketplace.delivery_areas.new.link_to')} #{t('icons.new')}",
+        title: t('marketplace.delivery_areas.new.link_to'),
+        href: marketplace.location(:new, child: :delivery_area),
+        method: :get,
+        scheme: :secondary) %>
+    <%- end %>
+  </div>
+  <div class="text-center mt-3">
+    <%= render Marketplace::Archivable::IndexLinkComponent.new(marketplace: marketplace, resource: :delivery_areas, to_archive: !params[:archive]) %>
+  </div>
+</section>

--- a/app/furniture/marketplace/delivery_areas/new.html.erb
+++ b/app/furniture/marketplace/delivery_areas/new.html.erb
@@ -1,6 +1,5 @@
 <%- breadcrumb :new_delivery_area, delivery_area %>
-<%= render Marketplace::ManagementComponent.new(marketplace: marketplace) do %>
-  <div class="mt-3">
-    <%= render "form", delivery_area: delivery_area %>
-  </div>
-<%- end %>
+
+<div class="mt-3">
+  <%= render "form", delivery_area: delivery_area %>
+</div>

--- a/app/furniture/marketplace/marketplaces/edit.html.erb
+++ b/app/furniture/marketplace/marketplaces/edit.html.erb
@@ -1,3 +1,1 @@
 <%- breadcrumb :edit_marketplace, marketplace %>
-
-<%= render Marketplace::ManagementComponent.new(marketplace: marketplace) %>

--- a/app/furniture/marketplace/notification_methods/index.html.erb
+++ b/app/furniture/marketplace/notification_methods/index.html.erb
@@ -1,23 +1,21 @@
 <%- breadcrumb(:marketplace_notification_methods, marketplace) %>
 
-<%= render Marketplace::ManagementComponent.new(marketplace: marketplace) do %>
-  <section class="mt-3">
-    <main>
+<section class="mt-3">
+  <main>
 
-      <%= render Marketplace::NotificationMethodComponent.with_collection(notification_methods) %>
+    <%= render Marketplace::NotificationMethodComponent.with_collection(notification_methods) %>
 
-    </main>
+  </main>
 
-    <div class="text-center mt-3">
-      <%- notification_methods = marketplace.notification_methods.new %>
-      <%- if policy(notification_methods).create? %>
-        <%= render ButtonComponent.new(
-          label: "#{t('marketplace.notification_methods.new.link_to')} #{t('icons.new')}",
-          title: t('marketplace.notification_methods.new.link_to'),
-          href: marketplace.location(:new, child: :notification_method),
-          method: :get,
-          scheme: :secondary) %>
-      <%- end %>
-    </div>
-  </section>
-<% end %>
+  <div class="text-center mt-3">
+    <%- notification_methods = marketplace.notification_methods.new %>
+    <%- if policy(notification_methods).create? %>
+      <%= render ButtonComponent.new(
+        label: "#{t('marketplace.notification_methods.new.link_to')} #{t('icons.new')}",
+        title: t('marketplace.notification_methods.new.link_to'),
+        href: marketplace.location(:new, child: :notification_method),
+        method: :get,
+        scheme: :secondary) %>
+    <%- end %>
+  </div>
+</section>

--- a/app/furniture/marketplace/payment_settings/index.html.erb
+++ b/app/furniture/marketplace/payment_settings/index.html.erb
@@ -1,24 +1,22 @@
 <%- breadcrumb :payment_settings, marketplace %>
-<%= render Marketplace::ManagementComponent.new(marketplace: marketplace) do %>
-  <h1>Payment Settings</h1>
-  <main>
-    <div class="grid grid-cols-1 gap-3 sm:gap-5 sm:grid-cols-3">
-      <%= render Marketplace::StripeOverviewComponent.new(marketplace: marketplace) %>
-      <%= render CardComponent.new(classes: "flex flex-col h-full") do %>
-        <header class="flex font-bold">
-          Did we miss something?
-        </header>
-        <div class="grow flex flex-col justify-between">
-          Let us know about other payment service options that will help your marketplace to thrive.
-        </div>
-        <footer class="flex flex-row justify-between mt-3">
-          <%= render ButtonComponent.new(
-            label: "Contact Us",
-            title: "Contact Us",
-            href: "mailto:#{ApplicationMailer::DEFAULT_FROM}",
-            scheme: :secondary) %>
-        </footer>
-      <% end %>
-    </div>
-  </main>
-<% end %>
+<h1>Payment Settings</h1>
+<main>
+  <div class="grid grid-cols-1 gap-3 sm:gap-5 sm:grid-cols-3">
+    <%= render Marketplace::StripeOverviewComponent.new(marketplace: marketplace) %>
+    <%= render CardComponent.new(classes: "flex flex-col h-full") do %>
+      <header class="flex font-bold">
+        Did we miss something?
+      </header>
+      <div class="grow flex flex-col justify-between">
+        Let us know about other payment service options that will help your marketplace to thrive.
+      </div>
+      <footer class="flex flex-row justify-between mt-3">
+        <%= render ButtonComponent.new(
+          label: "Contact Us",
+          title: "Contact Us",
+          href: "mailto:#{ApplicationMailer::DEFAULT_FROM}",
+          scheme: :secondary) %>
+      </footer>
+    <% end %>
+  </div>
+</main>

--- a/app/furniture/marketplace/products/edit.html.erb
+++ b/app/furniture/marketplace/products/edit.html.erb
@@ -1,4 +1,3 @@
 <%- breadcrumb :edit_marketplace_product, product %>
-<%= render Marketplace::ManagementComponent.new(marketplace: marketplace) do %>
-  <%= render "form", product: product %>
-<%- end %>
+
+<%= render "form", product: product %>

--- a/app/furniture/marketplace/products/index.html.erb
+++ b/app/furniture/marketplace/products/index.html.erb
@@ -1,27 +1,25 @@
 <%- breadcrumb :marketplace_products, marketplace%>
 
-<%= render Marketplace::ManagementComponent.new(marketplace: marketplace) do %>
-  <div class="grid grid-cols-1 md:grid-cols-3 gap-3 sm:gap-5 mt-3 mx-auto">
-    <%- if params[:archive] %>
-      <%= render Marketplace::ProductComponent.with_collection(marketplace.products.archived) %>
-    <%- else %>
-      <%= render Marketplace::ProductComponent.with_collection(marketplace.products.unarchived) %>
-    <%- end %>
-  </div>
+<div class="grid grid-cols-1 md:grid-cols-3 gap-3 sm:gap-5 mt-3 mx-auto">
+  <%- if params[:archive] %>
+    <%= render Marketplace::ProductComponent.with_collection(marketplace.products.archived) %>
+  <%- else %>
+    <%= render Marketplace::ProductComponent.with_collection(marketplace.products.unarchived) %>
+  <%- end %>
+</div>
 
-  <div class="text-center mt-3">
-    <%- new_product = marketplace.products.new %>
-    <%- if policy(new_product).create? %>
-      <%= render ButtonComponent.new(
-        label: "#{t('marketplace.products.new.link_to')} #{t('icons.new')}",
-        title: t('marketplace.products.new.link_to'),
-        href: marketplace.location(:new, child: :product),
-        method: :get,
-        scheme: :secondary) %>
-    <%- end %>
-  </div>
+<div class="text-center mt-3">
+  <%- new_product = marketplace.products.new %>
+  <%- if policy(new_product).create? %>
+    <%= render ButtonComponent.new(
+      label: "#{t('marketplace.products.new.link_to')} #{t('icons.new')}",
+      title: t('marketplace.products.new.link_to'),
+      href: marketplace.location(:new, child: :product),
+      method: :get,
+      scheme: :secondary) %>
+  <%- end %>
+</div>
 
-  <div class="text-center mt-3">
-    <%= render Marketplace::Archivable::IndexLinkComponent.new(marketplace: marketplace, resource: :products, to_archive: !params[:archive]) %>
-  </div>
-<% end %>
+<div class="text-center mt-3">
+  <%= render Marketplace::Archivable::IndexLinkComponent.new(marketplace: marketplace, resource: :products, to_archive: !params[:archive]) %>
+</div>

--- a/app/furniture/marketplace/products/new.html.erb
+++ b/app/furniture/marketplace/products/new.html.erb
@@ -1,4 +1,3 @@
 <%- breadcrumb :new_marketplace_product, product %>
-<%= render Marketplace::ManagementComponent.new(marketplace: marketplace) do %>
-  <%= render "form", product: product %>
-<%- end %>
+
+<%= render "form", product: product %>

--- a/app/furniture/marketplace/stripe_accounts/show.html.erb
+++ b/app/furniture/marketplace/stripe_accounts/show.html.erb
@@ -1,19 +1,17 @@
 <%- breadcrumb :show_marketplace_stripe_account, marketplace %>
-<%= render Marketplace::ManagementComponent.new(marketplace: marketplace) do %>
-  <p class="flex justify-between my-5 flex-wrap">
-    <%- if marketplace.stripe_api_key? %>
-      <%- if marketplace.stripe_account_connected? %>
-        <%= t('.stripe_connected') %>
-      <%- end %>
-      <%= button_to t('.connect_stripe'),
-          marketplace.location(child: :stripe_account), method: :post, data: { turbo: false } %>
-    <% else %>
-      <%= render ButtonComponent.new(
-            label: t('.missing_stripe_api_key', space_name: space.name),
-            href: space.location(:edit),
-            method: :get,
-            turbo: false,
-            scheme: :primary ) %>
-    <% end %>
-  </p>
-<% end %>
+<p class="flex justify-between my-5 flex-wrap">
+  <%- if marketplace.stripe_api_key? %>
+    <%- if marketplace.stripe_account_connected? %>
+      <%= t('.stripe_connected') %>
+    <%- end %>
+    <%= button_to t('.connect_stripe'),
+        marketplace.location(child: :stripe_account), method: :post, data: { turbo: false } %>
+  <% else %>
+    <%= render ButtonComponent.new(
+          label: t('.missing_stripe_api_key', space_name: space.name),
+          href: space.location(:edit),
+          method: :get,
+          turbo: false,
+          scheme: :primary ) %>
+  <% end %>
+</p>

--- a/app/furniture/marketplace/tax_rates/index.html.erb
+++ b/app/furniture/marketplace/tax_rates/index.html.erb
@@ -1,23 +1,21 @@
 <%- breadcrumb(:marketplace_tax_rates, marketplace) %>
 
-<%= render Marketplace::ManagementComponent.new(marketplace: marketplace) do %>
-  <section class="mt-3">
-    <main>
-      <div class="grid grid-cols-1 gap-3 sm:gap-5 sm:grid-cols-3">
-        <%= render Marketplace::TaxRateComponent.with_collection(tax_rates) %>
-      </div>
-    </main>
-
-    <div class="text-center mt-3">
-      <%- new_product = marketplace.tax_rates.new %>
-      <%- if policy(tax_rate).create? %>
-        <%= render ButtonComponent.new(
-          label: "#{t('marketplace.tax_rates.new.link_to')} #{t('icons.new')}",
-          title: t('marketplace.tax_rates.new.link_to'),
-          href: marketplace.location(:new, child: :tax_rate),
-          method: :get,
-          scheme: :secondary) %>
-      <%- end %>
+<section class="mt-3">
+  <main>
+    <div class="grid grid-cols-1 gap-3 sm:gap-5 sm:grid-cols-3">
+      <%= render Marketplace::TaxRateComponent.with_collection(tax_rates) %>
     </div>
-  </section>
-<% end %>
+  </main>
+
+  <div class="text-center mt-3">
+    <%- new_product = marketplace.tax_rates.new %>
+    <%- if policy(tax_rate).create? %>
+      <%= render ButtonComponent.new(
+        label: "#{t('marketplace.tax_rates.new.link_to')} #{t('icons.new')}",
+        title: t('marketplace.tax_rates.new.link_to'),
+        href: marketplace.location(:new, child: :tax_rate),
+        method: :get,
+        scheme: :secondary) %>
+    <%- end %>
+  </div>
+</section>


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/831

- While working on https://github.com/zinc-collective/convene/pull/2053, I thought to myself "Wait, what if... What if we didn't have to remember to wrap things in the `ManagementComponent` at all?! What if all that could be eliminated from the `new`/`edit`/`index`/`show` pages entirely?

  So I did! Hooray!