### PR TITLE
✨ `Section`: Allow `description` to be set for SEO

### DIFF
--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -28,7 +28,7 @@ class Room < ApplicationRecord
   has_many :gizmos, dependent: :destroy, inverse_of: :room, class_name: :Furniture
   accepts_nested_attributes_for :gizmos
 
-  validates :description, length: {maximum: 300}
+  validates :description, length: {maximum: 300, allow_blank: true}
 
   def full_slug
     "#{space.slug}--#{slug}"

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -28,6 +28,8 @@ class Room < ApplicationRecord
   has_many :gizmos, dependent: :destroy, inverse_of: :room, class_name: :Furniture
   accepts_nested_attributes_for :gizmos
 
+  validates :description, length: {maximum: 160}
+
   def full_slug
     "#{space.slug}--#{slug}"
   end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -28,7 +28,7 @@ class Room < ApplicationRecord
   has_many :gizmos, dependent: :destroy, inverse_of: :room, class_name: :Furniture
   accepts_nested_attributes_for :gizmos
 
-  validates :description, length: {maximum: 160}
+  validates :description, length: {maximum: 300}
 
   def full_slug
     "#{space.slug}--#{slug}"

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -10,9 +10,10 @@
     <%= tag :meta, name: :turbo_visit_control, content: turbo_visit_control %>
   <%- end %>
 
-  <%- if defined?(room) %>
-    <%= tag :meta, name: :description, content: room.description %>
+  <%- if current_room&.description %>
+    <%= tag :meta, name: :description, content: current_room.description %>
   <%- end %>
+
 
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -10,6 +10,10 @@
     <%= tag :meta, name: :turbo_visit_control, content: turbo_visit_control %>
   <%- end %>
 
+  <%- if defined?(room) %>
+    <%= tag :meta, name: :description, content: room.description %>
+  <%- end %>
+
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>
   <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>

--- a/app/views/rooms/_form.html.erb
+++ b/app/views/rooms/_form.html.erb
@@ -3,6 +3,8 @@
     <%= render "text_field", attribute: :name, form: room_form %>
     <%= render "text_field", attribute: :slug, form: room_form %>
 
+    <%= render "text_area", attribute: :description, form: room_form %>
+
     <h3>Privacy and Security</h3>
 
     <%= render "radio_group", attribute: :access_level, options: Room::access_levels.values, form: room_form %>

--- a/db/migrate/20231221025246_add_section_description.rb
+++ b/db/migrate/20231221025246_add_section_description.rb
@@ -1,0 +1,5 @@
+class AddSectionDescription < ActiveRecord::Migration[7.1]
+  def change
+    add_column :rooms, :description, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_12_13_043812) do
+ActiveRecord::Schema[7.1].define(version: 2023_12_21_025246) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -259,6 +259,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_13_043812) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "space_id"
+    t.string "description"
     t.index ["slug", "space_id"], name: "index_rooms_on_slug_and_space_id", unique: true
     t.index ["space_id"], name: "index_rooms_on_space_id"
   end

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Room do
   it { is_expected.to belong_to(:space).inverse_of(:rooms) }
 
   describe "#description" do
-    it { is_expected.to validate_length_of(:description).is_at_most(300) }
+    it { is_expected.to validate_length_of(:description).is_at_most(300).allow_blank }
   end
 
   describe ".slug" do

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Room do
   it { is_expected.to belong_to(:space).inverse_of(:rooms) }
 
   describe "#description" do
-    it { is_expected.to validate_length_of(:description).is_at_most(160) }
+    it { is_expected.to validate_length_of(:description).is_at_most(300) }
   end
 
   describe ".slug" do

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe Room do
   it { is_expected.to have_many(:gizmos).inverse_of(:room).dependent(:destroy) }
   it { is_expected.to belong_to(:space).inverse_of(:rooms) }
 
+  describe "#description" do
+    it { is_expected.to validate_length_of(:description).is_at_most(160) }
+  end
+
   describe ".slug" do
     it "creates unique slugs by space scope" do
       space_1 = Space.create(name: "space1")


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1155

- Meta description tags are useful for SEO; and maybe even useful for https://github.com/zinc-collective/convene/issues/1988

- I would love if we allowed `Section#title` to be set as well