### PR TITLE
🥔✨ `SectionNavigation`: Include `Section#description` in SectionLink

### DIFF
--- a/app/components/card_component.rb
+++ b/app/components/card_component.rb
@@ -14,6 +14,7 @@ class CardComponent < ApplicationComponent
     [
       "shadow",
       "rounded-lg",
+      "h-full",
       "bg-white"
     ].compact.join(" ")
   end

--- a/app/components/card_component.rb
+++ b/app/components/card_component.rb
@@ -14,7 +14,6 @@ class CardComponent < ApplicationComponent
     [
       "shadow",
       "rounded-lg",
-      "h-full",
       "bg-white"
     ].compact.join(" ")
   end

--- a/app/components/card_component.rb
+++ b/app/components/card_component.rb
@@ -15,7 +15,8 @@ class CardComponent < ApplicationComponent
       "shadow",
       "rounded-lg",
       "h-full",
-      "bg-white"
+      "bg-white",
+      "group-hover:bg-slate-50"
     ].compact.join(" ")
   end
 

--- a/app/furniture/section_navigation/section_navigations/_section_navigation.html.erb
+++ b/app/furniture/section_navigation/section_navigations/_section_navigation.html.erb
@@ -1,19 +1,13 @@
-<div class="mt-3 grid grid-cols-1 gap-5 sm:gap-6 sm:grid-cols-2 lg:grid-cols-4 items-center">
+<div class="mt-3 grid grid-cols-1 gap-5 sm:gap-6 sm:grid-cols-2 lg:grid-cols-4">
   <% policy_scope(section_navigation.rooms).each do |room| %>
-    <div id="<%= dom_id(room, :link_to) %>">
-      <%= link_to polymorphic_path(room.location), class: "no-underline" do %>
-        <%= render CardComponent.new(classes: "group self-stretch hover:bg-orange-50") do %>
-          <div class="flex flex-col space-between">
-            <h3 class="text-lg font-semibold">
-              <%= room.name %>
-            </h3>
+    <%= link_to polymorphic_path(room.location), class: "group no-underline" do %>
+      <%= render CardComponent.new(classes: "flex flex-col") do %>
+        <h3 class="text-2xl font-semibold">
+          <%= room.name %>
+        </h3>
 
-            <%- if room.description.present? %>
-              <p><%= room.description %></p>
-            <%- end %>
-          </div>
-        <%- end %>
+        <p><%= room.description %></p>
       <%- end %>
-    </div>
+    <%- end %>
   <% end %>
 </div>

--- a/app/furniture/section_navigation/section_navigations/_section_navigation.html.erb
+++ b/app/furniture/section_navigation/section_navigations/_section_navigation.html.erb
@@ -1,7 +1,8 @@
 <div class="mt-3 grid grid-cols-1 gap-5 sm:gap-6 sm:grid-cols-2 lg:grid-cols-4">
   <% policy_scope(section_navigation.rooms).each do |room| %>
-    <%= link_to polymorphic_path(room.location), class: "group no-underline" do %>
-      <%= render CardComponent.new(classes: "flex flex-col") do %>
+    <%= link_to polymorphic_path(room.location), id: dom_id(room, :link_to), class: "no-underline" do %>
+      <%= render CardComponent.new(classes:
+       "flex flex-col") do %>
         <h3 class="text-2xl font-semibold">
           <%= room.name %>
         </h3>

--- a/app/furniture/section_navigation/section_navigations/_section_navigation.html.erb
+++ b/app/furniture/section_navigation/section_navigations/_section_navigation.html.erb
@@ -3,20 +3,14 @@
     <div id="<%= dom_id(room, :link_to) %>">
       <%= link_to polymorphic_path(room.location), class: "no-underline" do %>
         <%= render CardComponent.new(classes: "group self-stretch hover:bg-orange-50") do %>
-          <div class="px-4 py-5 flex items-center justify-between">
-            <h3 class="text-base font-semibold text-orange-500 group-hover:text-orange-400">
+          <div class="flex flex-col space-between">
+            <h3 class="text-lg font-semibold">
               <%= room.name %>
             </h3>
 
             <%- if room.description.present? %>
               <p><%= room.description %></p>
             <%- end %>
-
-            <button class="rounded-full bg-orange-500 p-1 ml-2 text-white shadow-sm group-hover:bg-orange-400" data-role="enter">
-              <%= render SvgComponent.new(classes: "h-5 w-5") do %>
-                <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
-              <% end %>
-            </button>
           </div>
         <%- end %>
       <%- end %>

--- a/app/furniture/section_navigation/section_navigations/_section_navigation.html.erb
+++ b/app/furniture/section_navigation/section_navigations/_section_navigation.html.erb
@@ -1,19 +1,25 @@
 <div class="mt-3 grid grid-cols-1 gap-5 sm:gap-6 sm:grid-cols-2 lg:grid-cols-4 items-center">
   <% policy_scope(section_navigation.rooms).each do |room| %>
-    <%= link_to polymorphic_path(room.location), class: "no-underline" do %>
-      <%= render CardComponent.new(classes: "group self-stretch hover:bg-orange-50") do %>
-        <div class="px-4 py-5 flex items-center justify-between">
-          <h3 class="text-base font-semibold text-orange-500 group-hover:text-orange-400">
-            <%= room.name %>
-          </h3>
+    <div id="<%= dom_id(room, :link_to) %>">
+      <%= link_to polymorphic_path(room.location), class: "no-underline" do %>
+        <%= render CardComponent.new(classes: "group self-stretch hover:bg-orange-50") do %>
+          <div class="px-4 py-5 flex items-center justify-between">
+            <h3 class="text-base font-semibold text-orange-500 group-hover:text-orange-400">
+              <%= room.name %>
+            </h3>
 
-          <button class="rounded-full bg-orange-500 p-1 ml-2 text-white shadow-sm group-hover:bg-orange-400" data-role="enter">
-            <%= render SvgComponent.new(classes: "h-5 w-5") do %>
-              <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
-            <% end %>
-          </button>
-        </div>
+            <%- if room.description.present? %>
+              <p><%= room.description %></p>
+            <%- end %>
+
+            <button class="rounded-full bg-orange-500 p-1 ml-2 text-white shadow-sm group-hover:bg-orange-400" data-role="enter">
+              <%= render SvgComponent.new(classes: "h-5 w-5") do %>
+                <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+              <% end %>
+            </button>
+          </div>
+        <%- end %>
       <%- end %>
-    <%- end %>
+    </div>
   <% end %>
 </div>

--- a/app/furniture/section_navigation/section_navigations/_section_navigation.html.erb
+++ b/app/furniture/section_navigation/section_navigations/_section_navigation.html.erb
@@ -1,4 +1,4 @@
-<div class="mt-3 grid grid-cols-1 gap-5 sm:gap-6 sm:grid-cols-2 lg:grid-cols-4">
+<div class="grid grid-cols-1 gap-5 sm:gap-6 sm:grid-cols-2 lg:grid-cols-4">
   <% policy_scope(section_navigation.rooms).each do |room| %>
     <%= link_to polymorphic_path(room.location), id: dom_id(room, :link_to), class: "no-underline" do %>
       <%= render CardComponent.new(classes:

--- a/app/furniture/section_navigation/section_navigations/_section_navigation.html.erb
+++ b/app/furniture/section_navigation/section_navigations/_section_navigation.html.erb
@@ -1,13 +1,21 @@
 <div class="grid grid-cols-1 gap-5 sm:gap-6 sm:grid-cols-2 lg:grid-cols-4">
   <% policy_scope(section_navigation.rooms).each do |room| %>
-    <%= link_to polymorphic_path(room.location), id: dom_id(room, :link_to), class: "no-underline" do %>
+    <%= link_to polymorphic_path(room.location), id: dom_id(room, :link_to), class: "group no-underline" do %>
       <%= render CardComponent.new(classes:
-       "flex flex-col") do %>
-        <h3 class="text-2xl font-semibold">
-          <%= room.name %>
-        </h3>
+       "flex flex-col h-full justify-between") do |card| %>
+
 
         <p><%= room.description %></p>
+
+
+        <footer class="text-2xl text-justify font-semibold flex justify-between items-baseline">
+          <h3>
+            <%= room.name %>
+          </h3>
+          <%= render SvgComponent.new(classes: "h-5 w-5") do %>
+            <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+          <% end %>
+        </footer>
       <%- end %>
     <%- end %>
   <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,7 @@
   <body>
     <%= render 'layouts/header' %>
 
-    <main id="<%= current_space.present? ? dom_id(current_space) : nil %>" class="gap-3">
+    <main id="<%= current_space.present? ? dom_id(current_space) : nil %>">
       <%= content_for?(:content) ? yield(:content) : yield %>
     </main>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,7 @@
   <body>
     <%= render 'layouts/header' %>
 
-    <main id="<%= current_space.present? ? dom_id(current_space) : nil %>">
+    <main id="<%= current_space.present? ? dom_id(current_space) : nil %>" class="gap-3">
       <%= content_for?(:content) ? yield(:content) : yield %>
     </main>
 

--- a/spec/furniture/section_navigation/section_navigation_system_spec.rb
+++ b/spec/furniture/section_navigation/section_navigation_system_spec.rb
@@ -2,15 +2,21 @@ require "rails_helper"
 require_relative "factories"
 
 RSpec.describe SectionNavigation, type: :system do
+  let(:space) { create(:space, :with_entrance) }
+  let(:rooms) { create_list(:room, 2, space:) }
+
   it "includes a link to every section except the entrance" do
-    space = create(:space, :with_entrance)
-    rooms = create_list(:room, 2, space:)
     create(:section_navigation, room: space.entrance)
 
     visit polymorphic_path(space.entrance.location)
 
-    expect(page).to have_link(rooms.first.name, href: polymorphic_path(rooms.first.location))
-    expect(page).to have_link(rooms.last.name, href: polymorphic_path(rooms.last.location))
+    rooms.each do |room|
+      within("##{dom_id(room, :link_to)}") do
+        expect(page).to have_link(room.name, href: polymorphic_path(room.location))
+        expect(page).to have_content(rooms.description)
+      end
+    end
+
     expect(page).not_to have_link(space.entrance.name, href: polymorphic_path(space.entrance.location))
   end
 end

--- a/spec/furniture/section_navigation/section_navigation_system_spec.rb
+++ b/spec/furniture/section_navigation/section_navigation_system_spec.rb
@@ -3,9 +3,10 @@ require_relative "factories"
 
 RSpec.describe SectionNavigation, type: :system do
   let(:space) { create(:space, :with_entrance) }
-  let!(:rooms) { create_list(:room, 2, :with_description, space:) }
 
   it "includes a link to every section except the entrance" do
+    rooms = create_list(:room, 2, :with_description, space:)
+
     create(:section_navigation, room: space.entrance)
 
     visit polymorphic_path(space.entrance.location)

--- a/spec/furniture/section_navigation/section_navigation_system_spec.rb
+++ b/spec/furniture/section_navigation/section_navigation_system_spec.rb
@@ -3,7 +3,7 @@ require_relative "factories"
 
 RSpec.describe SectionNavigation, type: :system do
   let(:space) { create(:space, :with_entrance) }
-  let(:rooms) { create_list(:room, 2, space:) }
+  let!(:rooms) { create_list(:room, 2, :with_description, space:) }
 
   it "includes a link to every section except the entrance" do
     create(:section_navigation, room: space.entrance)
@@ -11,9 +11,9 @@ RSpec.describe SectionNavigation, type: :system do
     visit polymorphic_path(space.entrance.location)
 
     rooms.each do |room|
+      expect(page).to have_link(room.name, href: polymorphic_path(room.location))
       within("##{dom_id(room, :link_to)}") do
-        expect(page).to have_link(room.name, href: polymorphic_path(room.location))
-        expect(page).to have_content(rooms.description)
+        expect(page).to have_content(room.description)
       end
     end
 


### PR DESCRIPTION
 - https://github.com/zinc-collective/convene/issues/1988
 
 ## TODO
- [x] Make Pretty
- [x] Fix tests?
- [x] Split the `CardComponent` changes out?

## After
<img width="853" alt="Screenshot 2023-12-26 at 8 39 41 PM" src="https://github.com/zinc-collective/convene/assets/50284/9d82d0e4-a549-498b-921a-c3d3431a63af">
<img width="849" alt="Screenshot 2023-12-26 at 8 39 34 PM" src="https://github.com/zinc-collective/convene/assets/50284/06264b85-f18f-4937-9b85-61c8c88f1829">
