### PR TITLE
Adds section description hint and makes styling consistent

### DIFF
--- a/app/views/application/_text_area.html.erb
+++ b/app/views/application/_text_area.html.erb
@@ -1,5 +1,8 @@
 <div class="<%= local_assigns[:container_classes]%>">
   <%= form.label attribute %>
+  <% if local_assigns[:label_hint] %>
+    <small><%= local_assigns[:label_hint] %></small>
+  <% end %>
   <%= form.text_area attribute, class: local_assigns[:field_classes] %>
   <%= render partial: "error", locals: { model: form.object, attribute: attribute } %>
 </div>

--- a/app/views/rooms/_form.html.erb
+++ b/app/views/rooms/_form.html.erb
@@ -1,17 +1,12 @@
-<%= form_with model: room.location do |room_form| %>
-  <fieldset>
+<%= render CardComponent.new do %>
+  <%= form_with model: room.location do |room_form| %>
     <%= render "text_field", attribute: :name, form: room_form %>
     <%= render "text_field", attribute: :slug, form: room_form %>
-
-    <%= render "text_area", attribute: :description, form: room_form %>
-
+    <%= render "text_area", attribute: :description, form: room_form, label_hint: 'Add brief summary of your section for search engines to display as snippets in results' %>
     <h3>Privacy and Security</h3>
-
     <%= render "radio_group", attribute: :access_level, options: Room::access_levels.values, form: room_form %>
-
     <footer>
-
       <%= room_form.submit %>
     </footer>
-  </fieldset>
+  <% end %>
 <% end %>

--- a/app/views/rooms/edit.html.erb
+++ b/app/views/rooms/edit.html.erb
@@ -1,20 +1,24 @@
 <% breadcrumb :edit_room, room %>
 <h1>Configure <%= room.name %></h1>
-<%= render partial: 'form', locals: { room: room } %>
-<%= render CardComponent.new(classes: "mt-3 gap-y-3") do %>
-  <h2>Gizmos</h2>
-  <div id="furnitures">
-    <% if room.gizmos.present? %>
-      <%= render room.gizmos.rank(:slot), editing: true %>
-    <% else %>
-      <p class="text-gray-500"><%= t('rooms.no_furniture_notice') %></p>
-    <% end %>
-  </div>
-  <%- new_furniture = room.gizmos.new %>
-  <%- if policy(new_furniture).new? %>
-    <%= render "furnitures/new", furniture: new_furniture %>
-  <%- end %>
-<% end %>
+<div class="mt-3 gap-y-3">
+  <%= render partial: 'form', locals: { room: room } %>
+</div>
+<div class="mt-3 gap-y-3">
+  <%= render CardComponent.new do %>
+    <h2>Gizmos</h2>
+    <div id="furnitures">
+      <% if room.gizmos.present? %>
+        <%= render room.gizmos.rank(:slot), editing: true %>
+      <% else %>
+        <p class="text-gray-500"><%= t('rooms.no_furniture_notice') %></p>
+      <% end %>
+    </div>
+    <%- new_furniture = room.gizmos.new %>
+    <%- if policy(new_furniture).new? %>
+      <%= render "furnitures/new", furniture: new_furniture %>
+    <%- end %>
+  <% end %>
+</div>
 <%- if policy(room).destroy? && room.persisted? %>
   <div class="m-5">
     <h2><%= t("rooms.destroy.prompt")%></h2>

--- a/app/views/rooms/edit.html.erb
+++ b/app/views/rooms/edit.html.erb
@@ -20,15 +20,17 @@
   <% end %>
 </div>
 <%- if policy(room).destroy? && room.persisted? %>
-  <div class="m-5">
-    <h2><%= t("rooms.destroy.prompt")%></h2>
-    <%- if !room.gizmos.reload.empty? %>
-      <%= t('rooms.destroy.blocked_by_gizmos', room_name: room.name) %>
-    <%- elsif room.entrance? %>
-      <%= t('rooms.destroy.blocked_by_entrance', room_name: room.name
+  <%= render CardComponent.new(dom_id: "furniture_destroy") do %>
+    <div class="m-5">
+      <h2><%= t("rooms.destroy.prompt")%></h2>
+      <%- if !room.gizmos.reload.empty? %>
+        <%= t('rooms.destroy.blocked_by_gizmos', room_name: room.name) %>
+      <%- elsif room.entrance? %>
+        <%= t('rooms.destroy.blocked_by_entrance', room_name: room.name
 ) %>
-    <%- else %>
-      <%= button_to(t('rooms.destroy.link_to'), room.location, method: :delete, class: "--danger w-full") %>
-    <%- end %>
-  </div>
+      <%- else %>
+        <%= button_to(t('rooms.destroy.link_to'), room.location, method: :delete, class: "--danger w-full") %>
+      <%- end %>
+    </div>
+  <% end %>
 <%- end %>


### PR DESCRIPTION
While reviewing https://github.com/zinc-collective/convene/pull/2055 I felt Space managers might be interested to know how `Description` would be used. 

Before: 

![image](https://github.com/zinc-collective/convene/assets/5185/5dd106ea-f661-411d-aaf0-de2da50eae78)


After: 
![image](https://github.com/zinc-collective/convene/assets/5185/4b2adbe3-a20a-45f0-8c36-60b866f8821d)
