### PR TITLE
🧹 `CardComponent`: Cards fill as much space as they can

### DIFF
--- a/app/components/card_component.rb
+++ b/app/components/card_component.rb
@@ -14,6 +14,7 @@ class CardComponent < ApplicationComponent
     [
       "shadow",
       "rounded-lg",
+      "h-full",
       "bg-white"
     ].compact.join(" ")
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,7 @@
   <body>
     <%= render 'layouts/header' %>
 
-    <main id="<%= current_space.present? ? dom_id(current_space) : nil %>">
+    <main id="<%= current_space.present? ? dom_id(current_space) : nil %>" class="gap-3">
       <%= content_for?(:content) ? yield(:content) : yield %>
     </main>
 


### PR DESCRIPTION

- https://github.com/zinc-collective/convene/issues/1187

This won't do anything in most cases; but if a `CardComponent` is inside of an element with height, such as a `grid`; it will take up the entire thing.

It's possible that we should be using `items-stretch` or something?

Anyway, here's a few places where cards are:

<img width="851" alt="Screenshot 2023-12-26 at 8 39 59 PM" src="https://github.com/zinc-collective/convene/assets/50284/e83efbb6-c5d7-4446-944a-6162eea0b120">
<img width="853" alt="Screenshot 2023-12-26 at 8 39 51 PM" src="https://github.com/zinc-collective/convene/assets/50284/9bffd34c-02fc-4943-a1c5-f866882cd8c6">
<img width="853" alt="Screenshot 2023-12-26 at 8 39 41 PM" src="https://github.com/zinc-collective/convene/assets/50284/62871662-807a-4f53-95ef-5d36fcc5cf50">
<img width="849" alt="Screenshot 2023-12-26 at 8 39 34 PM" src="https://github.com/zinc-collective/convene/assets/50284/df7a070e-e3b4-42a5-90a9-70eed5daf1d6">
