### PR TITLE
Improve sign-in UI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -135,9 +135,11 @@ end
 group :development do
   gem "better_errors"
   gem "binding_of_caller"
-  # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
+  # Outputs i18n lookup key debug logs
+  gem "i18n-debug"
   gem "listen", "~> 3.8"
   gem "rails-erd"
+  # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem "web-console", "~> 4.2"
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem "spring"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,6 +214,8 @@ GEM
     htmlentities (4.3.4)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
+    i18n-debug (1.2.0)
+      i18n (< 2)
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
@@ -550,6 +552,7 @@ DEPENDENCIES
   faker
   friendly_id (~> 5.5.1)
   gretel (~> 4.6)
+  i18n-debug
   image_processing
   jbuilder (~> 2.11)
   jsbundling-rails

--- a/app/assets/stylesheets/components/form.scss
+++ b/app/assets/stylesheets/components/form.scss
@@ -12,12 +12,13 @@
     div {
       @apply mb-3;
     }
+
     label,
-    input,
     select,
     textarea {
       @apply block w-full;
     }
+
     label {
       @apply font-medium text-sm leading-6 text-gray-700 mb-1;
     }
@@ -40,6 +41,8 @@
       @screen sm {
         @apply leading-6 text-sm;
       }
+
+      @apply block w-full;
     }
     input {
       @apply appearance-none;

--- a/app/controllers/authenticated_sessions_controller.rb
+++ b/app/controllers/authenticated_sessions_controller.rb
@@ -13,7 +13,7 @@ class AuthenticatedSessionsController < ApplicationController
     if authenticated_session.save
       redirect_to(current_space.presence || :root)
     else
-      render :create, status: :unprocessable_entity
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/views/authenticated_sessions/_form.html.erb
+++ b/app/views/authenticated_sessions/_form.html.erb
@@ -1,5 +1,5 @@
 <%= form_with model: [current_space, authenticated_session] do |form| %>
-  <fieldset>
+  <fieldset class="p-4">
     <%- if form.object.contact_location.blank? %>
       <%= form.hidden_field :contact_method, value: :email %>
       <%= render "email_field", form: form, attribute: :contact_location %>
@@ -7,10 +7,8 @@
       <p>Check your email for a one-time password to complete the sign in process</p>
       <%= form.hidden_field :contact_method %>
       <%= form.hidden_field :contact_location %>
-      <%= form.label :one_time_password %>
-      <%= form.text_field :one_time_password %>
-      <%= render partial: "error", locals: { model: form.object, attribute: :one_time_password } %>
+      <%= render "text_field", form: form, attribute: :one_time_password %>
     <% end %>
-    <%= form.submit %>
+    <p><%= form.submit %></p>
   </fieldset>
 <% end %>

--- a/app/views/authenticated_sessions/create.html.erb
+++ b/app/views/authenticated_sessions/create.html.erb
@@ -1,1 +1,0 @@
-<%= render partial: 'form', locals: { authenticated_session: authenticated_session } %>

--- a/app/views/authenticated_sessions/new.html.erb
+++ b/app/views/authenticated_sessions/new.html.erb
@@ -1,1 +1,3 @@
-<%= render partial: 'form', locals: { authenticated_session: authenticated_session } %>
+<div class="md:w-4/12 sm:w-auto m-auto mt-8">
+  <%= render partial: 'form', locals: { authenticated_session: authenticated_session } %>
+</div>

--- a/config/locales/authenticated_session/en.yml
+++ b/config/locales/authenticated_session/en.yml
@@ -2,7 +2,7 @@ en:
   helpers:
     submit:
       authenticated_session:
-        create: "Sign in"
+        update: "Sign in"
   activemodel:
     errors:
       models:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,8 +32,8 @@
 en:
   helpers:
     submit:
-      update: "Save changes ✔️"
-      create: "Create ➕"
+      update: "Save changes️"
+      create: "Create"
   home:
     title: "Home"
   time:


### PR DESCRIPTION
This PR:
* improves the look of our sign-in form
* updates our default submit button style throughout the site to not be 100% wide
* removes the emojis from the default "save" and "create" button strings
* adds the i18n-debug gem to help with figuring out which i18n keys are being looked up

### Screenshots
#### Before
##### Mobile
![image](https://github.com/zinc-collective/convene/assets/6729309/f5fef050-e33f-49b4-af83-5e0f64f9c2c5)

![image](https://github.com/zinc-collective/convene/assets/6729309/122eb91a-89a3-4765-bcf1-ffb69691e882)

##### Desktop
![image](https://github.com/zinc-collective/convene/assets/6729309/de4db92c-1440-483b-9488-116b46683b75)

![image](https://github.com/zinc-collective/convene/assets/6729309/edb66975-4ba0-4363-8f23-5b9588b01122)

![image](https://github.com/zinc-collective/convene/assets/6729309/06851ea7-681e-460c-baf4-65ce8f948a7e)

#### After
##### Mobile
![image](https://github.com/zinc-collective/convene/assets/6729309/7360b0b4-77f8-46b7-91dc-43d809c3cf10)
![image](https://github.com/zinc-collective/convene/assets/6729309/bb01f60c-4d26-4287-a751-527236a601c1)

##### Desktop
![image](https://github.com/zinc-collective/convene/assets/6729309/82b241fd-dd11-470f-902b-4d08f781af55)

![image](https://github.com/zinc-collective/convene/assets/6729309/6c8b2261-8e37-44ee-a296-c88ba34dfa2a)

![image](https://github.com/zinc-collective/convene/assets/6729309/8d277a79-521d-41c7-a782-1ae8cf756224)



