### PR TITLE
🥔✨ `Marketplace`: `#restore` `Products` and `DeliveryAreas`

### DIFF
--- a/app/furniture/marketplace/archivable.rb
+++ b/app/furniture/marketplace/archivable.rb
@@ -19,6 +19,10 @@ class Marketplace
       orders.present?
     end
 
+    def restore=(restore)
+      unarchive
+    end
+
     def archivable?
       persisted? && unarchived?
     end

--- a/app/furniture/marketplace/delivery_area_policy.rb
+++ b/app/furniture/marketplace/delivery_area_policy.rb
@@ -9,7 +9,7 @@ class Marketplace
     alias_method :update?, :create?
 
     def permitted_attributes(_)
-      [:label, :price, :order_by, :delivery_window]
+      [:label, :price, :order_by, :delivery_window, :restore]
     end
 
     class Scope < ApplicationScope

--- a/app/furniture/marketplace/delivery_areas/_form.html.erb
+++ b/app/furniture/marketplace/delivery_areas/_form.html.erb
@@ -1,8 +1,10 @@
-<%= form_with(model: delivery_area.location) do |delivery_area_form| %>
-  <%= render "text_field", attribute: :label, form: delivery_area_form %>
-  <%= render "money_field", attribute: :price, form: delivery_area_form, required: true, step: 0.01, min: 0 %>
-  <%= render "text_field", attribute: :order_by, form: delivery_area_form %>
-  <%= render "text_field", attribute: :delivery_window, form: delivery_area_form %>
+<%= render CardComponent.new(dom_id: dom_id(delivery_area), classes: "mt-3") do %>
+  <%= form_with(model: delivery_area.location) do |delivery_area_form| %>
+    <%= render "text_field", attribute: :label, form: delivery_area_form %>
+    <%= render "money_field", attribute: :price, form: delivery_area_form, required: true, step: 0.01, min: 0 %>
+    <%= render "text_field", attribute: :order_by, form: delivery_area_form %>
+    <%= render "text_field", attribute: :delivery_window, form: delivery_area_form %>
 
-  <%= delivery_area_form.submit %>
+    <%= delivery_area_form.submit %>
+  <%- end %>
 <%- end %>

--- a/app/furniture/marketplace/delivery_areas/edit.html.erb
+++ b/app/furniture/marketplace/delivery_areas/edit.html.erb
@@ -1,2 +1,9 @@
 <%- breadcrumb :edit_delivery_area, delivery_area %>
 <%= render "form", delivery_area: delivery_area %>
+
+
+<%- if delivery_area.archived? %>
+  <%= render CardComponent.new(classes: "mt-6") do %>
+    <%= button_to("Restore", delivery_area.location, method: :put, params: { delivery_area: { restore: true } }, class: "w-full") %>
+  <%- end %>
+<%- end %>

--- a/app/furniture/marketplace/product_policy.rb
+++ b/app/furniture/marketplace/product_policy.rb
@@ -4,7 +4,7 @@ class Marketplace
   class ProductPolicy < Policy
     alias_method :product, :object
     def permitted_attributes(_params = nil)
-      %i[name description price_cents price_currency price photo] + [tax_rate_ids: []]
+      %i[name description price_cents price_currency price photo restore] + [tax_rate_ids: []]
     end
 
     def update?

--- a/app/furniture/marketplace/products/edit.html.erb
+++ b/app/furniture/marketplace/products/edit.html.erb
@@ -1,3 +1,10 @@
 <%- breadcrumb :edit_marketplace_product, product %>
 
 <%= render "form", product: product %>
+
+
+<%- if product.archived? %>
+  <%= render CardComponent.new(classes: "mt-6") do %>
+    <%= button_to("Restore", product.location, method: :put, params: { product: { restore: true } }, class: "w-full") %>
+  <%- end %>
+<%- end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,3 +50,5 @@ en:
     confirm: "Removal is permanent. Are you sure?"
   archive:
     link_to: "Archive"
+  restore:
+    link_to: "Restore"

--- a/spec/furniture/marketplace/delivery_areas_system_spec.rb
+++ b/spec/furniture/marketplace/delivery_areas_system_spec.rb
@@ -9,6 +9,26 @@ describe "Marketplace: Delivery Areas", type: :system do
     sign_in(space.members.first, space)
   end
 
+  describe "Restoring Delivery Areas" do
+    let!(:delivery_area) do
+      create(:marketplace_delivery_area, :archived, marketplace:,
+        label: "Oakland", price_cents: 10_00)
+    end
+
+    it "Makes the DeliveryArea selectable" do
+      visit(polymorphic_path(marketplace.location(child: :delivery_areas)))
+      click_link("Archived Delivery Areas")
+      within("##{dom_id(delivery_area)}") do
+        click_link("Edit")
+      end
+
+      click_button(I18n.t("restore.link_to"))
+
+      expect(page).to have_content(delivery_area.label)
+      expect(delivery_area.reload).not_to be_archived
+    end
+  end
+
   describe "Deleting Delivery Areas" do
     context "when the Delivery Area is Discarded" do
       let(:delivery_area) do

--- a/spec/furniture/marketplace/selling_products_system_spec.rb
+++ b/spec/furniture/marketplace/selling_products_system_spec.rb
@@ -34,6 +34,23 @@ describe "Marketplace: Selling Products", type: :system do
     end
   end
 
+  describe "Restoring Products" do
+    let!(:product) { create(:marketplace_product, :archived, marketplace:) }
+
+    it "Allows the Product to be added to Carts again" do
+      visit(polymorphic_path(marketplace.location(child: :products)))
+      click_link("Archived Products")
+      within("##{dom_id(product)}") do
+        click_link(I18n.t("edit.link_to"))
+      end
+
+      click_button(I18n.t("restore.link_to"))
+
+      expect(page).to have_content(product.name)
+      expect(product.reload).not_to be_archived
+    end
+  end
+
   describe "Removing Products" do
     let(:product) { create(:marketplace_product, :archived, marketplace:) }
 


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/2014
- https://github.com/zinc-collective/convene/issues/2023

This allows a `Product` and `DeliveryArea` to be Restored; and also makes their forms look the same.