### PR TITLE
Remove redundant edit icon from site footer

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,13 +14,6 @@
 
       <%= render partial: "breadcrumbs" %>
 
-      <div>
-        <%- if current_room && policy(current_room).edit? %>
-          <%= link_to t('icons.edit'), [:edit, current_space, current_room], class: 'no-underline', aria: { label: "Configure Section"} %>
-        <%- end %>
-
-      </div>
-
       <nav class="text-sm w-full flex flex-wrap justify-center" aria-label="Profile Menu" data-person-email="<%= current_person.email %>">
         <%- if current_person.authenticated? %>
           <%- if current_membership.present? %>


### PR DESCRIPTION
#### Before
![image](https://github.com/zinc-collective/convene/assets/6729309/1986ce02-2296-495d-b98e-27e628f475bc)

#### After
![image](https://github.com/zinc-collective/convene/assets/6729309/e57956a9-ea46-461a-9a23-adb90d6a70be)
