### PR TITLE
🐛🔨 `Section`: Shorten Factory Generated `Room#description`

### DIFF
--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -28,7 +28,8 @@ class Room < ApplicationRecord
   has_many :gizmos, dependent: :destroy, inverse_of: :room, class_name: :Furniture
   accepts_nested_attributes_for :gizmos
 
-  validates :description, length: {maximum: 300, allow_blank: true}
+  DESCRIPTION_MAX_LENGTH = 300
+  validates :description, length: {maximum: DESCRIPTION_MAX_LENGTH, allow_blank: true}
 
   def full_slug
     "#{space.slug}--#{slug}"

--- a/spec/factories/room.rb
+++ b/spec/factories/room.rb
@@ -16,7 +16,7 @@ FactoryBot.define do
     end
 
     trait :with_description do
-      description { Faker::TvShows::TheExpanse.quote.truncate(300) }
+      description { Faker::TvShows::TheExpanse.quote.truncate(Room::DESCRIPTION_MAX_LENGTH) }
     end
 
     trait :with_furniture do

--- a/spec/factories/room.rb
+++ b/spec/factories/room.rb
@@ -16,7 +16,7 @@ FactoryBot.define do
     end
 
     trait :with_description do
-      description { Faker::TvShows::TheExpanse.quote }
+      description { Faker::TvShows::TheExpanse.quote.truncate(300) }
     end
 
     trait :with_furniture do


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1155
- https://github.com/zinc-collective/convene/issues/1988

Apparently, some of the Expanse Quotes are quite long; making them [ill-suited for a 300 character limited
field](https://github.com/zinc-collective/convene/actions/runs/7403679313/job/20145303706?pr=2079).

This shortens those down so they don't explode.