### PR TITLE
Make all buttons look uniform, no matter if they use the `ButtonComponent` or not

### DIFF
--- a/app/assets/stylesheets/components/button.scss
+++ b/app/assets/stylesheets/components/button.scss
@@ -1,21 +1,20 @@
-/* @todo DELETE ME */
 @layer components {
   [type="reset"],
   [type="button"],
   [type="submit"],
   button,
   .button {
-    @apply font-bold py-2 px-4 rounded bg-orange-500 text-white text-center transition ease-in-out duration-150;
+    @apply rounded-md px-3.5 py-2.5 text-sm font-semibold shadow-sm ring-1 ring-inset text-center no-underline;
 
     &:hover {
-      @apply bg-orange-400;
+      @apply bg-orange-100 text-orange-700;
     }
     &:active {
       @apply bg-orange-200;
     }
 
     &:focus {
-      @apply outline-none border-gray-300  ring-gray-500;
+      @apply outline outline-2 outline-offset-2 outline-orange-400;
     }
 
     &.--danger {
@@ -35,6 +34,22 @@
       }
       &:active {
         @apply bg-gray-200;
+      }
+    }
+
+    &.--primary {
+      @apply bg-orange-500 text-white;
+
+      &:hover {
+        @apply bg-orange-400 text-white;
+      }
+    }
+
+    &.--secondary {
+      @apply bg-white text-orange-950 ring-gray-300;
+
+      &:hover {
+        @apply bg-orange-100 text-orange-700;
       }
     }
   }

--- a/app/components/button_component.html.erb
+++ b/app/components/button_component.html.erb
@@ -1,5 +1,5 @@
 <%- if @disabled %>
-  <span class="<%= classes %>"><%= @label %></span>
+  <span class="<%= classes %>"><%= @label || @title %></span>
 <%- else %>
   <%= link_to @href,
               title: @title || @label,

--- a/app/components/button_component.rb
+++ b/app/components/button_component.rb
@@ -55,49 +55,18 @@ class ButtonComponent < ApplicationComponent
   end
 
   def base_classes
-    [
-      "rounded-md",
-      "px-3.5",
-      "py-2.5",
-      "text-sm",
-      "font-semibold",
-      "shadow-sm",
-      "ring-1",
-      "ring-inset",
-      "text-center",
-      "no-underline",
-      "focus-visible:outline",
-      "focus-visible:outline-2",
-      "focus-visible:outline-offset-2",
-      "focus-visible:outline-orange-400"
-    ]
+    ["button"]
   end
 
   def secondary_classes
-    [
-      "bg-white",
-      "text-orange-950",
-      "ring-gray-300",
-      "hover:bg-orange-100",
-      "hover:text-orange-700"
-    ]
+    ["--secondary"]
   end
 
   def danger_classes
-    [
-      "bg-red-500",
-      "hover:bg-red-700",
-      "active:bg-red-200",
-      "text-white"
-    ]
+    ["--danger"]
   end
 
   def primary_classes
-    [
-      "bg-orange-500",
-      "text-white",
-      "hover:bg-orange-400",
-      "hover:text-white"
-    ]
+    ["--primary"]
   end
 end

--- a/app/components/svg_component.rb
+++ b/app/components/svg_component.rb
@@ -1,17 +1,24 @@
 class SvgComponent < ApplicationComponent
-  # { symbol: method returning path for symbol }
+  # Mapping of icon name symbols to methods returning the SVG path for that icon.
+  #
+  # We've been getting these SVG paths from https://heroicons.com/, using
+  # the "Outline" style.
+  # Feel free to add more as needed, from other libraries as appropriate,
+  # as long as they match the intended aesthetic and are appropriately licensed.
+  #
+  # Format: { symbol: method returning path for symbol }
   ICON_MAPPINGS = {
     cart: :cart,
-    # @todo I don't know where we have been getting the SVG icons;
-    #       and I am hesitant to add one unless it's coming from
-    #       a library we are already using... - ZS
-    money: :cart,
+    money: :money,
     exclamation_triangle: :exclamation_triangle,
     gear: :gear,
     map: :map,
     receipt_percent: :receipt_percent,
     bell: :ringing_bell,
-    tag: :tag
+    tag: :tag,
+    plus: :plus,
+    trash: :trash,
+    pencil: :pencil
   }.with_indifferent_access.freeze
 
   attr_reader :icon
@@ -86,6 +93,30 @@ class SvgComponent < ApplicationComponent
   def ringing_bell
     <<~SVG
       <path stroke-linecap="round" stroke-linejoin="round" d="M14.857 17.082a23.848 23.848 0 005.454-1.31A8.967 8.967 0 0118 9.75v-.7V9A6 6 0 006 9v.75a8.967 8.967 0 01-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 01-5.714 0m5.714 0a3 3 0 11-5.714 0M3.124 7.5A8.969 8.969 0 015.292 3m13.416 0a8.969 8.969 0 012.168 4.5" />
+    SVG
+  end
+
+  def money
+    <<~SVG
+      <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 18.75a60.07 60.07 0 0 1 15.797 2.101c.727.198 1.453-.342 1.453-1.096V18.75M3.75 4.5v.75A.75.75 0 0 1 3 6h-.75m0 0v-.375c0-.621.504-1.125 1.125-1.125H20.25M2.25 6v9m18-10.5v.75c0 .414.336.75.75.75h.75m-1.5-1.5h.375c.621 0 1.125.504 1.125 1.125v9.75c0 .621-.504 1.125-1.125 1.125h-.375m1.5-1.5H21a.75.75 0 0 0-.75.75v.75m0 0H3.75m0 0h-.375a1.125 1.125 0 0 1-1.125-1.125V15m1.5 1.5v-.75A.75.75 0 0 0 3 15h-.75M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm3 0h.008v.008H18V10.5Zm-12 0h.008v.008H6V10.5Z" />
+    SVG
+  end
+
+  def plus
+    <<~SVG
+      <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+    SVG
+  end
+
+  def trash
+    <<~SVG
+      <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+    SVG
+  end
+
+  def pencil
+    <<~SVG
+      <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125" />
     SVG
   end
 end

--- a/app/views/spaces/_agreements.html.erb
+++ b/app/views/spaces/_agreements.html.erb
@@ -7,20 +7,22 @@
     <%- space.agreements.each do |agreement| %>
       <span class="flex justify-between w-full">
           <span class="grow"><%= agreement.name %></span>
-          <span>
+          <span class="flex gap-x-3">
             <%- if policy(agreement).edit? %>
               <%= render ButtonComponent.new(href: agreement.location(:edit),
-                                            title: t('space.agreements.edit.link_to', name: agreement.name),
-                                            label: t('icons.edit'),
-                                            method: :get,
-                                            scheme: :secondary) %>
+                                             title: t('space.agreements.edit.link_to', name: agreement.name),
+                                             label: "",
+                                             icon: :pencil,
+                                             method: :get,
+                                             scheme: :secondary) %>
             <%- end %>
             <%- if policy(agreement).destroy? %>
               <%= render ButtonComponent.new(href: agreement.location,
-                                            title: t('space.agreements.destroy.link_to', name: agreement.name),
-                                            label: t('icons.destroy'),
-                                            method: :delete,
-                                            scheme: :secondary) %>
+                                             title: t('space.agreements.destroy.link_to', name: agreement.name),
+                                             label: "",
+                                             icon: :trash,
+                                             method: :delete,
+                                             scheme: :secondary) %>
             <%- end %>
           </span>
       </span>
@@ -30,9 +32,10 @@
     <%- new_agreement = space.agreements.build %>
     <%- if policy(new_agreement).create? %>
       <%= render ButtonComponent.new(
-        label: "#{t('space.agreements.new.link_to')} #{t('icons.new')}",
+        label: t('space.agreements.new.link_to'),
         title: t('space.agreements.new.link_to'),
         href: space.location(:new, child: :agreement),
+        icon: :plus,
         method: :get,
         scheme: :secondary) %>
     <%- end %>

--- a/app/views/spaces/_website_settings.html.erb
+++ b/app/views/spaces/_website_settings.html.erb
@@ -11,6 +11,6 @@
       <%= web_settings_form.check_box :enforce_ssl %>
         Enforce SSL - Automatically redirects all Visitor traffic to this Space to https.
       <% end %>
-    <%= web_settings_form.submit %>
+    <%= web_settings_form.submit class: "--secondary" %>
   <% end %>
 <% end %>

--- a/config/locales/agreement/en.yml
+++ b/config/locales/agreement/en.yml
@@ -9,9 +9,9 @@ en:
       create:
         success: "Added Agreement '%{name}'"
       edit:
-        link_to: "Edit Agreement '%{name}'"
+        link_to: "Edit '%{name}'"
       update:
         success: "Changed Agreement '%{name}'"
       destroy:
-        link_to: "Remove Agreement '%{name}'"
-        success: "Removed Agreement '%{name}'"
+        link_to: "Delete '%{name}'"
+        success: "Deleted Agreement '%{name}'"

--- a/spec/components/button_component_spec.rb
+++ b/spec/components/button_component_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe ButtonComponent, type: :component do
     context "when the scheme is `:danger`" do
       let(:component) { described_class.new(**params.merge({scheme: :danger})) }
 
-      it { expect(output.at_css(".bg-red-500")).to be_present }
+      it { expect(a_el.attributes["class"].value).to eq("button --danger") }
     end
   end
 end


### PR DESCRIPTION
This makes it possible for form buttons to look the same as buttons created via the `ButtonComponent`, by using the same CSS classes.

It also:
* updates the look of the buttons in the Agreements section of space management, so that they use SVG icons
* adds the missing `:money` SVG icon
* documents where we've been getting the icons from 

#### Before
![image](https://github.com/zinc-collective/convene/assets/6729309/3993f593-ecb3-4a94-94ab-34fa5e65613c)

![image](https://github.com/zinc-collective/convene/assets/6729309/da53b3bd-4269-4382-b551-bb923486b19e)


#### After
![image](https://github.com/zinc-collective/convene/assets/6729309/b0e725b3-9faf-48f2-a46f-2328486d3750)

![image](https://github.com/zinc-collective/convene/assets/6729309/97b8c877-4515-4fe6-b742-ae6f38e60fb4)

