### PR TITLE
Displays flash messages on the Marketplace

### DIFF
--- a/app/furniture/marketplace/management_component.html.erb
+++ b/app/furniture/marketplace/management_component.html.erb
@@ -8,6 +8,7 @@
 </div>
 <div class="flex flex-col space-y-3">
   <%= render onboarding_component %>
+  <%= render "flash_messages" , flash: flash %>
   <%= render CardComponent.new do |card| %>
     <%= content %>
     <% card.with_footer do %>

--- a/app/furniture/marketplace/marketplaces_controller.rb
+++ b/app/furniture/marketplace/marketplaces_controller.rb
@@ -18,7 +18,6 @@ class Marketplace
           flash.notice = "Square notification settings updated succesfully!"
         end
       else
-        flash.alert = "Square notification settings were not upated. Please try again or contact your site administrator."
         render :edit
       end
     end

--- a/spec/furniture/marketplace/configuring_square_system_spec.rb
+++ b/spec/furniture/marketplace/configuring_square_system_spec.rb
@@ -25,6 +25,7 @@ describe "Marketplace: Configuring Square", type: :system do
 
       click_button("Save changes")
 
+      expect(page).to have_content("Square notification settings updated succesfully!")
       expect(page).to have_content("Sync is active")
       expect(page).to have_css("details:not([open])")
     end
@@ -40,6 +41,7 @@ describe "Marketplace: Configuring Square", type: :system do
       fill_in :marketplace_square_location_id, with: ""
       click_button("Save changes")
 
+      expect(page).to have_content("Square notification settings updated succesfully!")
       expect(page).to have_content("Add your credentials")
       expect(page).to have_css("details[open]")
     end


### PR DESCRIPTION
After: 

<img width="1093" alt="Ross Dev Coop 2024-01-03 19-55-01" src="https://github.com/zinc-collective/convene/assets/5185/dee1de07-703e-4d04-a995-26789fb4dacf">
<img width="1055" alt="Ross Dev Coop 2024-01-03 19-55-31" src="https://github.com/zinc-collective/convene/assets/5185/f143780a-06ba-4a23-9305-2bad4eaae18f">
