### PR TITLE
🥗 `Marketplace`: The `Square` Test is failings on `Dependabot` PRs

### DIFF
--- a/spec/furniture/marketplace/buying_products_system_spec.rb
+++ b/spec/furniture/marketplace/buying_products_system_spec.rb
@@ -8,7 +8,7 @@ describe "Marketplace: Buying Products", type: :system do
   include Spec::StripeCLI::Helpers
 
   let(:space) { create(:space, :with_entrance, :with_members) }
-  let(:marketplace) { create(:marketplace, :ready_for_shopping, :with_square, room: space.entrance) }
+  let(:marketplace) { create(:marketplace, :ready_for_shopping, room: space.entrance) }
 
   around do |ex|
     visit root_path


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1500
- https://github.com/zinc-collective/convene/pull/2034

Tests seem to be broken when on PRs that come in from Dependabot.

I'm not quite sure what the reason is; and didn't want to tinker too much since @RossChapman and @AnaUlin know more about how this works.

My current theory is we need to update the [`Dependabot` Secrets](https://github.com/zinc-collective/convene/settings/secrets/dependabot) with the Square credentials and Locations that they set up last Wednesday.

I think we used the operations@zinc.coop account, but the phone number for that is not tied to the Google Voice number for operationszinc@gmail.com; so I wasn't able to log in.

I did log in as zee@zinc.coop; and there are credentials there but I am not brainy enough to figure out if that's the right account or not.

Anyway, to unbreak the tests for Dependabot rolling again; I am ditching the `with_square` trait in the `marketplace` in the `buying_products_spec.rb`. We'll probably want to write a `marketplace/order_notifications/with_square_spec.rb` that tests that use case more explicitely, including assertions against the Square API that confirm we get the data in the PoS right.