### PR TITLE
✨`CardComponent`: Has a Header Slot

### DIFF
--- a/app/components/card_component.html.erb
+++ b/app/components/card_component.html.erb
@@ -1,6 +1,6 @@
-<div <%==attributes(classes: card_classes_wrapper) %>>
+<div <%==attributes(classes: "shadow rounded-lg bg-white group-hover:bg-slate-50 flex flex-col justify-between #{header_classes}") %>>
  <% if header? %>
-  <header>
+  <header class="p-2 sm:p-4">
     <%= header%>
   </header>
 
@@ -9,12 +9,12 @@
     NOTE: content? is not always working as described, and is returning a proc in some cases rather than a boolean
   %>
   <% if content.present? %>
-    <div class="<%== card_classes_content %>">
+    <div class="flex flex-col h-full justify-between p-2 sm:p-4 <%= content_classes%>">
       <%= content %>
     </div>
   <% end %>
   <% if footer? %>
-    <div class="<%== card_classes_footer %>">
+    <div class="bg-slate-50 p-2 sm:p-4 <%= "rounded-t-none" if content.blank? %> <%= footer_classes %>">
       <%= footer %>
     </div>
   <% end %>

--- a/app/components/card_component.html.erb
+++ b/app/components/card_component.html.erb
@@ -1,9 +1,15 @@
-<div class="<%== card_classes_wrapper %>">
+<div <%==attributes(classes: card_classes_wrapper) %>>
+ <% if header? %>
+  <header>
+    <%= header%>
+  </header>
+
+ <%- end %>
   <%#
     NOTE: content? is not always working as described, and is returning a proc in some cases rather than a boolean
   %>
   <% if content.present? %>
-    <div <%== attributes(classes: card_classes_content) %>>
+    <div class="<%== card_classes_content %>">
       <%= content %>
     </div>
   <% end %>

--- a/app/components/card_component.html.erb
+++ b/app/components/card_component.html.erb
@@ -1,21 +1,17 @@
-<div <%==attributes(classes: "shadow rounded-lg bg-white group-hover:bg-slate-50 flex flex-col justify-between #{header_classes}") %>>
+<div <%==attributes(classes: "shadow gap-y-3 rounded-lg bg-white group-hover:bg-slate-50 flex flex-col justify-between") %>>
  <% if header? %>
-  <header class="p-2 sm:p-4">
-    <%= header%>
-  </header>
-
+  <%= header%>
  <%- end %>
   <%#
     NOTE: content? is not always working as described, and is returning a proc in some cases rather than a boolean
   %>
   <% if content.present? %>
-    <div class="flex flex-col h-full justify-between p-2 sm:p-4 <%= content_classes%>">
+    <div class="flex flex-col h-full justify-between p-2 sm:p-4">
       <%= content %>
     </div>
   <% end %>
+
   <% if footer? %>
-    <div class="bg-slate-50 p-2 sm:p-4 <%= "rounded-t-none" if content.blank? %> <%= footer_classes %>">
-      <%= footer %>
-    </div>
+    <%= footer %>
   <% end %>
 </div>

--- a/app/components/card_component.rb
+++ b/app/components/card_component.rb
@@ -1,4 +1,5 @@
 class CardComponent < ApplicationComponent
+  renders_one :header
   renders_one :footer
 
   private

--- a/app/components/card_component.rb
+++ b/app/components/card_component.rb
@@ -1,15 +1,17 @@
 class CardComponent < ApplicationComponent
-  attr_accessor :wrapper_classes
+  HEADER_VARIANTS = {default: "p-2 sm:p-4", no_padding: ""}
+  renders_one :header, ->(variant: :default, &block) {
+    content_tag(:header, class: HEADER_VARIANTS.fetch(variant), &block)
+  }
 
-  renders_one :header
-  attr_accessor :header_classes
-
-  attr_accessor :content_classes
-
-  renders_one :footer
-  attr_accessor :footer_classes
-
-  def initialize(header_classes: "", content_classes: "", wrapper_classes: "", **kwargs)
-    super(**kwargs)
-  end
+  DEFAULT_FOOTER = "bg-slate-50 p-2 sm:p-4"
+  FOOTER_VARIANTS = {
+    default: DEFAULT_FOOTER,
+    action_bar: [DEFAULT_FOOTER, "flex flex-row justify-between"].join(" ")
+  }
+  renders_one :footer, ->(variant: :default, &block) {
+    classes = FOOTER_VARIANTS.fetch(variant)
+    classes += " rounded-t-none" unless content? || header?
+    content_tag(:footer, class: classes, &block)
+  }
 end

--- a/app/components/card_component.rb
+++ b/app/components/card_component.rb
@@ -1,33 +1,15 @@
 class CardComponent < ApplicationComponent
+  attr_accessor :wrapper_classes
+
   renders_one :header
+  attr_accessor :header_classes
+
+  attr_accessor :content_classes
+
   renders_one :footer
+  attr_accessor :footer_classes
 
-  private
-
-  def card_classes_content
-    [
-      "p-4",
-      "sm:p-6"
-    ].compact.join(" ")
-  end
-
-  def card_classes_wrapper
-    [
-      "shadow",
-      "rounded-lg",
-      "h-full",
-      "bg-white",
-      "group-hover:bg-slate-50"
-    ].compact.join(" ")
-  end
-
-  def card_classes_footer
-    [
-      "bg-orange-50",
-      "p-4",
-      "sm:p-6",
-      # content? is not always working as described, and is returning a proc in some cases rather than a boolean
-      ("rounded-t-none" if content.blank?)
-    ].compact.join(" ")
+  def initialize(header_classes: "", content_classes: "", wrapper_classes: "", **kwargs)
+    super(**kwargs)
   end
 end


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/2110

This is perhaps unnecessary; since `<header>` tags are easy to write; but maybe it's actually useful?