### PR TITLE
🌸 `Marketplace`: `Product::Photo` Better handling of aspect ratio / resolution

### DIFF
--- a/app/furniture/marketplace/product_component.html.erb
+++ b/app/furniture/marketplace/product_component.html.erb
@@ -3,7 +3,7 @@
     <% if product.photo.present? %>
       <figure>
         <%= image_tag hero_image, class: "rounded-t-lg w-full" %>
-        <figcaption class="px-2 sm:px-4">
+        <figcaption class="px-2 pt-4 sm:px-4">
           <h3><%= name %></h3>
           <%- if product.archived? %>
             <span class="italic">(archived)</span>

--- a/app/furniture/marketplace/product_component.html.erb
+++ b/app/furniture/marketplace/product_component.html.erb
@@ -1,17 +1,20 @@
 <%= render CardComponent.new(dom_id: dom_id(product)) do |card| %>
-  <%- card.with_header do %>
-    <h3 class="py-2"><%= name %></h3>
-    <%- if product.archived? %>
-      <span class="italic">(archived)</span>
-    <%- end %>
+  <%- card.with_header(variant: :no_padding) do %>
+    <% if product.photo.present? %>
+      <figure>
+        <%= image_tag hero_image, class: "rounded-t-lg w-full" %>
+        <figcaption class="px-2 sm:px-4">
+          <h3><%= name %></h3>
+          <%- if product.archived? %>
+            <span class="italic">(archived)</span>
+          <%- end %>
+        </figcaption>
+      </figure>
+    <%- else %>
+      <h3 class="px-4"><%= name %></h3>
+    <% end %>
   <%- end %>
 
-
-  <% if product.photo.present? %>
-    <div>
-      <%= image_tag product.photo.variant(resize_to_limit: [150, 150]) %>
-    </div>
-  <% end %>
   <div class="text-sm italic">
     <%= description %>
   </div>
@@ -22,7 +25,6 @@
     </div>
     <p><%= price %></p>
   </div>
-
 
   <%- card.with_footer(variant: :action_bar) do %>
     <%= render edit_button if edit_button? %>

--- a/app/furniture/marketplace/product_component.rb
+++ b/app/furniture/marketplace/product_component.rb
@@ -13,6 +13,14 @@ class Marketplace
       super(title: t("marketplace.products.edit.link_to", name: name), href: location(:edit))
     end
 
+    # 16:9 of 1290 is 1290:725.625
+    # We rounded up.
+    # @see https://www.ios-resolution.com/
+    FULL_WIDTH_16_BY_9 = [1290, 726]
+    def hero_image
+      product.photo.variant(resize_to_limit: FULL_WIDTH_16_BY_9)
+    end
+
     def tax_rates
       product.tax_rates.map do |tax_rate|
         "#{tax_rate.label} #{helpers.number_to_percentage(tax_rate.tax_rate, precision: 2)}"

--- a/spec/furniture/marketplace/selling_products_system_spec.rb
+++ b/spec/furniture/marketplace/selling_products_system_spec.rb
@@ -45,7 +45,6 @@ describe "Marketplace: Selling Products", type: :system do
       end
 
       click_button(I18n.t("restore.link_to"))
-
       expect(page).to have_content(product.name)
       expect(product.reload).not_to be_archived
     end


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1428

This, I think, looks a lot nicer. It also presumes a 16:9 aspect ratio; which feels more "normal"

## Before
<img width="380" alt="Screenshot 2024-01-12 at 8 38 20 PM" src="https://github.com/zinc-collective/convene/assets/50284/0d51d605-27c5-4205-b0a8-08b22c5ccf98">
<img width="1103" alt="Screenshot 2024-01-12 at 8 38 16 PM" src="https://github.com/zinc-collective/convene/assets/50284/c28ffeba-7bc1-4b70-b76b-38e021c1697d">


## After
<img width="1100" alt="Screenshot 2024-01-12 at 8 38 41 PM" src="https://github.com/zinc-collective/convene/assets/50284/b5ee31c1-e12c-4d1c-8521-9513465d726d">
<img width="383" alt="Screenshot 2024-01-12 at 8 38 34 PM" src="https://github.com/zinc-collective/convene/assets/50284/4048f02b-e32e-4d8c-807f-a00fa3492c6a">
