### PR TITLE
🌸 `Components`: `Card` does not need a `gap-y`

### DIFF
--- a/app/components/card_component.html.erb
+++ b/app/components/card_component.html.erb
@@ -1,4 +1,4 @@
-<div <%==attributes(classes: "shadow gap-y-3 rounded-lg bg-white group-hover:bg-slate-50 flex flex-col justify-between") %>>
+<div <%==attributes(classes: "shadow rounded-lg bg-white group-hover:bg-slate-50 flex flex-col justify-between") %>>
  <% if header? %>
   <%= header%>
  <%- end %>


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/2110

If we enforce a gap at the card level, it makes it hard to format things nicely in contexts where there should not be a gap between the header and footer.

The `justify-between` is "enough" to ensure that the footer sticks to the bottom of the card, and the `header` and `footer` both provide padding.

So no need to set that intention + enforce it multiple places; and this place seemed like the one that was least tailorable to the immediate usage context.

## Before
<img width="1102" alt="Screenshot 2024-01-24 at 5 50 33 PM" src="https://github.com/zinc-collective/convene/assets/50284/d6bd1342-8637-4419-af18-e702c23b8713">

## After
<img width="1107" alt="Screenshot 2024-01-24 at 5 50 16 PM" src="https://github.com/zinc-collective/convene/assets/50284/331b4505-ed96-4aa2-9297-efbb3a56e764">

The difference is subtle-if-not-invisible; but if you check out main and refresh then check out this branch and refresh then there is a difference!