### PR TITLE
🌸 `Marketplace`: `Product#hero_image` is always 16:9

### DIFF
--- a/app/furniture/marketplace/product_component.rb
+++ b/app/furniture/marketplace/product_component.rb
@@ -18,7 +18,7 @@ class Marketplace
     # @see https://www.ios-resolution.com/
     FULL_WIDTH_16_BY_9 = [1290, 726]
     def hero_image
-      product.photo.variant(resize_to_limit: FULL_WIDTH_16_BY_9)
+      product.photo.variant(resize_to_fill: FULL_WIDTH_16_BY_9)
     end
 
     def tax_rates


### PR DESCRIPTION
-  https://github.com/zinc-collective/convene/issues/1428

Apparently `resize_to_limit` does not actually enforce the aspect ratio

This ensures they are always the aspect ratio we want them to be.

## Before
<img width="1724" alt="Screenshot 2024-01-25 at 10 19 47 AM" src="https://github.com/zinc-collective/convene/assets/50284/0ee118c0-4e9f-44fd-8400-956bd46a6b75">


## After 
<img width="1249" alt="Screenshot 2024-01-25 at 10 19 38 AM" src="https://github.com/zinc-collective/convene/assets/50284/9a01912b-ee8e-4cb3-be6f-d9db6f06d25d">
