### PR TITLE
🧹 `Marketplace`: `Cart` no longer uses TurboStreams

### DIFF
--- a/app/furniture/marketplace/cart_products_controller.rb
+++ b/app/furniture/marketplace/cart_products_controller.rb
@@ -6,84 +6,47 @@ class Marketplace
     def create
       authorize(cart_product).save
 
-      respond_to do |format|
-        format.html do
-          if cart_product.errors.empty?
-            flash[:notice] = t(".success",
-              product: cart_product.product.name.pluralize(cart_product.quantity),
-              quantity: cart_product.quantity)
-          else
-            flash[:alert] = t(".failure",
-              product: cart_product.product.name.pluralize(cart_product.quantity),
-              quantity: cart_product.quantity)
-          end
-
-          redirect_to [marketplace.space, marketplace.room]
-        end
-
-        format.turbo_stream do
-          render turbo_stream: [
-            turbo_stream.replace(cart_product_component.dom_id, cart_product_component),
-            turbo_stream.replace("cart-footer-#{cart.id}",
-              partial: "marketplace/carts/footer", locals: {cart: cart}),
-            turbo_stream.replace("cart-total-#{cart.id}", partial: "marketplace/carts/total", locals: {cart: cart})
-          ]
-        end
+      if cart_product.errors.empty?
+        flash[:notice] = t(".success",
+          product: cart_product.product.name.pluralize(cart_product.quantity),
+          quantity: cart_product.quantity)
+      else
+        flash[:alert] = t(".failure",
+          product: cart_product.product.name.pluralize(cart_product.quantity),
+          quantity: cart_product.quantity)
       end
+
+      redirect_to marketplace.location
     end
 
     def update
       authorize(cart_product).update(cart_product_params)
-      respond_to do |format|
-        format.html do
-          if cart_product.errors.empty?
-            flash[:notice] =
-              t(".success", product: cart_product.product.name.pluralize(cart_product.quantity),
-                quantity: cart_product.quantity)
-          else
-            flash[:alert] =
-              t(".failure", product: cart_product.product.name.pluralize(cart_product.quantity),
-                quantity: cart_product.quantity)
-          end
-
-          redirect_to [marketplace.space, marketplace.room]
-        end
-        format.turbo_stream do
-          render turbo_stream: [
-            turbo_stream.replace(cart_product_component.dom_id, cart_product_component),
-            turbo_stream.replace("cart-footer-#{cart.id}",
-              partial: "marketplace/carts/footer", locals: {cart: cart}),
-            turbo_stream.replace("cart-total-#{cart.id}", partial: "marketplace/carts/total", locals: {cart: cart})
-          ]
-        end
+      if cart_product.errors.empty?
+        flash[:notice] =
+          t(".success", product: cart_product.product.name.pluralize(cart_product.quantity),
+            quantity: cart_product.quantity)
+      else
+        flash[:alert] =
+          t(".failure", product: cart_product.product.name.pluralize(cart_product.quantity),
+            quantity: cart_product.quantity)
       end
+
+      redirect_to marketplace.location
     end
 
     def destroy
       authorize(cart_product).destroy
-      respond_to do |format|
-        format.html do
-          if cart_product.destroyed?
-            flash[:notice] =
-              t(".success", product: cart_product.product.name.pluralize(cart_product.quantity),
-                quantity: cart_product.quantity)
-          else
-            flash[:alert] =
-              t(".failure", product: cart_product.product.name.pluralize(cart_product.quantity),
-                quantity: cart_product.quantity)
-          end
-          redirect_to [marketplace.space, marketplace.room]
-        end
 
-        format.turbo_stream do
-          render turbo_stream: [
-            turbo_stream.replace(cart_product_component.dom_id, cart_product_component),
-            turbo_stream.replace("cart-footer-#{cart.id}",
-              partial: "marketplace/carts/footer", locals: {cart: cart}),
-            turbo_stream.replace("cart-total-#{cart.id}", partial: "marketplace/carts/total", locals: {cart: cart})
-          ]
-        end
+      if cart_product.destroyed?
+        flash[:notice] =
+          t(".success", product: cart_product.product.name.pluralize(cart_product.quantity),
+            quantity: cart_product.quantity)
+      else
+        flash[:alert] =
+          t(".failure", product: cart_product.product.name.pluralize(cart_product.quantity),
+            quantity: cart_product.quantity)
       end
+      redirect_to marketplace.location
     end
 
     def cart_product_component

--- a/spec/furniture/marketplace/cart_products_controller_request_spec.rb
+++ b/spec/furniture/marketplace/cart_products_controller_request_spec.rb
@@ -20,30 +20,7 @@ RSpec.describe Marketplace::CartProductsController, type: :request do
     it "Add a Product to the Cart" do
       perform_request
 
-      expect(response).to redirect_to([space, room])
-    end
-
-    context "when a turbo stream" do
-      subject(:perform_request) do
-        post path, as: :turbo_stream, params: {cart_product: {product_id: product.id, quantity: 1}}
-        response
-      end
-
-      it "Replaces the cart product, cart footer and cart total" do
-        perform_request && cart.reload
-
-        assert_select("turbo-stream[action='replace'][target='cart_product_#{product.id}']") do
-          assert_select("*[data-cart-product-quantity]", text: "1")
-        end
-
-        assert_select("turbo-stream[action='replace'][target='cart-footer-#{cart.id}']")
-        assert_select("turbo-stream[action='replace'][target='cart-total-#{cart.id}'] *[data-cart-total]", text: "Total: #{controller.helpers.humanized_money_with_symbol(cart.price_total)}")
-
-        assert_select("turbo-stream[action='replace'][target='cart-total-#{cart.id}']") do
-          assert_select("*[data-cart-total]", text: "Total: #{controller.helpers.humanized_money_with_symbol(cart.price_total)}")
-          assert_select("*[data-cart-product-total]", text: "Products: #{controller.helpers.humanized_money_with_symbol(cart.product_total)}")
-        end
-      end
+      expect(response).to redirect_to(marketplace.location)
     end
   end
 
@@ -62,29 +39,7 @@ RSpec.describe Marketplace::CartProductsController, type: :request do
       perform_request
       cart_product.reload
       expect(cart_product.quantity).to eq(5)
-      expect(response).to redirect_to([space, room])
-    end
-
-    context "when a turbo stream" do
-      subject(:perform_request) do
-        put path, as: :turbo_stream, params: params
-      end
-
-      it "Replaces the cart product, cart footer and cart total" do
-        perform_request && cart.reload
-
-        assert_select("turbo-stream[action='replace'][target='cart_product_#{product.id}']") do
-          assert_select("*[data-cart-product-quantity]", text: "5")
-        end
-
-        assert_select("turbo-stream[action='replace'][target='cart-footer-#{cart.id}']")
-        assert_select("turbo-stream[action='replace'][target='cart-total-#{cart.id}'] *[data-cart-total]", text: "Total: #{controller.helpers.humanized_money_with_symbol(cart.price_total)}")
-
-        assert_select("turbo-stream[action='replace'][target='cart-total-#{cart.id}']") do
-          assert_select("*[data-cart-total]", text: "Total: #{controller.helpers.humanized_money_with_symbol(cart.price_total)}")
-          assert_select("*[data-cart-product-total]", text: "Products: #{controller.helpers.humanized_money_with_symbol(cart.product_total)}")
-        end
-      end
+      expect(response).to redirect_to(marketplace.location)
     end
   end
 
@@ -99,30 +54,7 @@ RSpec.describe Marketplace::CartProductsController, type: :request do
     let(:product) { create(:marketplace_product, marketplace: marketplace) }
     let(:cart_product) { create(:marketplace_cart_product, cart: cart, product: product) }
 
-    it { is_expected.to redirect_to([space, room]) }
+    it { is_expected.to redirect_to(marketplace.location) }
     specify { expect { perform_request }.to change { Marketplace::CartProduct.exists?(cart_product.id) }.to(false) }
-
-    context "when a turbo stream" do
-      subject(:perform_request) do
-        delete path, as: :turbo_stream
-        response
-      end
-
-      it "Replaces the cart product, cart footer and cart total" do
-        perform_request
-
-        assert_select("turbo-stream[action='replace'][target='cart_product_#{cart_product.product_id}']") do
-          assert_select("*[data-cart-product-quantity]", text: "0")
-        end
-
-        assert_select("turbo-stream[action='replace'][target='cart-footer-#{cart.id}']")
-        assert_select("turbo-stream[action='replace'][target='cart-total-#{cart.id}'] *[data-cart-total]", text: "Total: $0.00")
-
-        assert_select("turbo-stream[action='replace'][target='cart-total-#{cart.id}']") do
-          assert_select("*[data-cart-total]", text: "Total: $0.00")
-          assert_select("*[data-cart-product-total]", text: "Products: $0.00")
-        end
-      end
-    end
   end
 end


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1326
- https://github.com/zinc-collective/convene/issues/2155

Now that the Marketplace lives inside a TurboFrame, we don't need the turbo streams.

Extracted from https://github.com/zinc-collective/convene/pull/2072