### PR TITLE
🧹 `Marketplace`: Simplify changing `Product` quantities in `Cart`

### DIFF
--- a/app/furniture/marketplace/cart_product.rb
+++ b/app/furniture/marketplace/cart_product.rb
@@ -25,6 +25,10 @@ class Marketplace
       product.price * quantity
     end
 
+    def quantity_picker
+      QuantityPicker.new(cart_product: self)
+    end
+
     private
 
     def editable_cart

--- a/app/furniture/marketplace/cart_product/quantity_picker.rb
+++ b/app/furniture/marketplace/cart_product/quantity_picker.rb
@@ -1,0 +1,6 @@
+class Marketplace
+  class CartProduct::QuantityPicker < Model
+    attr_accessor :cart_product
+    delegate :location, :quantity, to: :cart_product
+  end
+end

--- a/app/furniture/marketplace/cart_product/quantity_pickers/_quantity_picker.html.erb
+++ b/app/furniture/marketplace/cart_product/quantity_pickers/_quantity_picker.html.erb
@@ -1,0 +1,13 @@
+<div class="flex flex-row justify-between items-center">
+  <%- if quantity_picker.quantity < 1%>
+    <span></span>
+  <%- elsif quantity_picker.quantity == 1 %>
+    <%= button_to("🗑️", quantity_picker.location, method: :delete) %>
+  <%- else %>
+    <%= button_to("➖", quantity_picker.location, method: :put, params: { cart_product: { quantity: quantity_picker.quantity - 1 } }) %>
+  <%- end %>
+
+  <span class="py-2 px-2 my-1 text-lg"><%= quantity_picker.quantity %></span>
+
+  <%= button_to("➕", quantity_picker.location, method: :put, params: { cart_product: { quantity: quantity_picker.quantity + 1 } }) %>
+</div>

--- a/app/furniture/marketplace/cart_product_component.html.erb
+++ b/app/furniture/marketplace/cart_product_component.html.erb
@@ -27,15 +27,10 @@
     <%= humanized_money_with_symbol(product.price) %>
   </td>
   <td class="py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
-    <div class="flex flex-row justify-between items-center">
-      <%= render "buttons/minus", title: t('marketplace.cart_product_component.remove'), method: remove_method,
-                                  disabled: cart_product.quantity.zero?,
-                                  href: remove_href %>
-
-      <span data-cart-product-quantity class="py-2 px-2 my-1 text-lg"><%= quantity %></span>
-
-      <%= render "buttons/plus", method: add_method, title: t('marketplace.cart_product_component.add'),
-                                 href: add_href %>
-    </div>
+    <%- if cart_product.quantity.zero? %>
+      <%= button_to("Add to Cart", cart.location(child: :cart_products), method: :post,  params: { cart_product: { product_id: product.id, quantity: 1 } }) %>
+    <%- else %>
+      <%= render cart_product.quantity_picker %>
+    <%- end %>
   </td>
 </tr>

--- a/app/furniture/marketplace/cart_product_component.rb
+++ b/app/furniture/marketplace/cart_product_component.rb
@@ -1,41 +1,13 @@
 class Marketplace
   class CartProductComponent < ApplicationComponent
     attr_accessor :cart_product
-    delegate :name, :description, :location, to: :cart_product
+    delegate :name, :description, :quantity, :location, to: :cart_product
     delegate :cart, :product, to: :cart_product
 
     def initialize(cart_product:, **kwargs)
       super(**kwargs)
 
       self.cart_product = cart_product
-    end
-
-    def quantity
-      cart_product.destroyed? ? 0 : cart_product.quantity
-    end
-
-    def add_quantity
-      quantity + 1
-    end
-
-    def add_method
-      (add_quantity == 1) ? :post : :put
-    end
-
-    def add_href
-      cart_product.location(query_params: {cart_product: {quantity: add_quantity, product_id: product.id}})
-    end
-
-    def remove_quantity
-      [quantity - 1, 0].max
-    end
-
-    def remove_method
-      remove_quantity.zero? ? :delete : :put
-    end
-
-    def remove_href
-      cart_product.location(query_params: {cart_product: {quantity: remove_quantity, product_id: product.id}})
     end
 
     def dom_id

--- a/app/furniture/marketplace/locales/en.yml
+++ b/app/furniture/marketplace/locales/en.yml
@@ -124,9 +124,6 @@ en:
       update:
         success: "Changed %{quantity} %{product} on Cart"
         failure: "Could not change %{quantity} %{product} on Cart"
-    cart_product_component:
-      remove: Remove from Cart
-      add: Add to Cart
     payment_settings:
       index:
         link_to: "Payment Settings"

--- a/spec/furniture/marketplace/buying_products_system_spec.rb
+++ b/spec/furniture/marketplace/buying_products_system_spec.rb
@@ -97,7 +97,7 @@ describe "Marketplace: Buying Products", type: :system do
 
   def add_product_to_cart(product)
     within("##{dom_id(product).gsub("product", "cart_product")}") do
-      click_link(t("marketplace.cart_product_component.add"))
+      click_button("Add to Cart")
     end
   end
 

--- a/spec/furniture/marketplace/cart_product_component_spec.rb
+++ b/spec/furniture/marketplace/cart_product_component_spec.rb
@@ -8,20 +8,27 @@ RSpec.describe Marketplace::CartProductComponent, type: :component do
   let(:cart) { create(:marketplace_cart) }
   let(:marketplace) { cart.marketplace }
   let(:product) { create(:marketplace_product, :with_description, :with_photo) }
-  let(:cart_product) { create(:marketplace_cart_product, cart: cart, product: product) }
+  let(:cart_product) { create(:marketplace_cart_product, cart:, product:, quantity: 5) }
 
   let(:component) { described_class.new(cart_product: cart_product, current_person: operator) }
 
   it { is_expected.to have_content(product.name) }
   it { is_expected.to have_content(product.description) }
   it { is_expected.to have_content(helpers.humanized_money_with_symbol(product.price)) }
-  it { is_expected.to have_link(I18n.t("marketplace.cart_product_component.add")) }
-  it { is_expected.to have_link(I18n.t("marketplace.cart_product_component.remove")) }
-  it { is_expected.to have_css("img[src*='#{product.photo.filename}']") }
+  it { is_expected.to have_button("➕") }
+  it { is_expected.to have_button("➖") }
 
-  context "when the product is not yet in the cart" do
-    let(:cart_product) { build(:marketplace_cart_product, cart: cart, product: product, quantity: 0) }
+  context "when the quantity is 0" do
+    let(:cart_product) { build(:marketplace_cart_product, cart:, product:, quantity: 0) }
 
-    it { is_expected.to have_no_link(I18n.t("marketplace.cart_product_component.remove")) }
+    it { is_expected.to have_no_button("➖") }
+    it { is_expected.to have_button("➕") }
+  end
+
+  context "when the quantity is 1" do
+    let(:cart_product) { build(:marketplace_cart_product, cart:, product:, quantity: 1) }
+
+    it { is_expected.to have_button("➕") }
+    it { is_expected.to have_button("🗑️") }
   end
 end

--- a/spec/furniture/marketplace/cart_product_component_spec.rb
+++ b/spec/furniture/marketplace/cart_product_component_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Marketplace::CartProductComponent, type: :component do
     let(:cart_product) { build(:marketplace_cart_product, cart:, product:, quantity: 0) }
 
     it { is_expected.to have_no_button("➖") }
-    it { is_expected.to have_button("➕") }
+    it { is_expected.to have_button("Add to Cart") }
   end
 
   context "when the quantity is 1" do


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/2155
- https://github.com/zinc-collective/convene/issues/1326

This gets rid of a bunch of nonsense from the `CartProductComponent`, and tees up some parts that I use in the `Menu::ProductComponent`

Extracted from: https://github.com/zinc-collective/convene/pull/2072/

