### PR TITLE
🧹🥗 `Journal`: Add `Entry#description` field

### DIFF
--- a/app/furniture/journal/entry.rb
+++ b/app/furniture/journal/entry.rb
@@ -33,6 +33,9 @@ class Journal
 
     scope :matching_keywords, ->(keywords) { where("keywords::text[] && ARRAY[?]::text[]", keywords) }
 
+    DESCRIPTION_MAX_LENGTH = 300
+    validates :description, length: {maximum: DESCRIPTION_MAX_LENGTH, allow_blank: true}
+
     def migrate_to(journal:, keywords: [])
       new_body = keywords.present? ? body + "\n##{keywords.join(" #")}" : body
       update(journal: journal, body: new_body)

--- a/db/migrate/20240129014151_journal_add_description_to_entry.rb
+++ b/db/migrate/20240129014151_journal_add_description_to_entry.rb
@@ -1,0 +1,5 @@
+class JournalAddDescriptionToEntry < ActiveRecord::Migration[7.1]
+  def change
+    add_column :journal_entries, :description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_20_034325) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_29_014151) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -116,6 +116,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_20_034325) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "keywords", array: true
+    t.text "description"
     t.index ["journal_id"], name: "index_journal_entries_on_journal_id"
   end
 

--- a/spec/furniture/journal/entry_spec.rb
+++ b/spec/furniture/journal/entry_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe Journal::Entry, type: :model do
     end
   end
 
+  describe "#description" do
+    it { is_expected.to validate_length_of(:description).is_at_most(300).allow_blank }
+  end
+
   describe "#save" do
     let(:entry) { create(:journal_entry, body: "#GoodTimes") }
     let(:journal) { entry.journal }


### PR DESCRIPTION
- https://github.com/zinc-collective/convene-journal/issues/6

What I'm driving towards here is similar to
https://github.com/zinc-collective/convene/pull/2055, where a `Journal::Entry` has an affordance for being opinionated about how it's represented when linked to in search engines or peer-to-peer sharing; as well as short text for when there are several on `Journal#show`.