### PR TITLE
🐞🔨`Marketplace`: `Buying Products` with one unarchived `DeliveryArea`

### DIFF
--- a/app/furniture/marketplace/carts/_footer.html.erb
+++ b/app/furniture/marketplace/carts/_footer.html.erb
@@ -10,6 +10,7 @@
       <%= render "marketplace/carts/total", cart: cart %>
     </td>
   </tr>
+
   <%- if cart.ready_for_checkout? %>
     <tr>
       <td class="text-right py-3.5" colspan="8">

--- a/app/furniture/marketplace/marketplace.rb
+++ b/app/furniture/marketplace/marketplace.rb
@@ -132,7 +132,7 @@ class Marketplace
     end
 
     def default_delivery_area
-      (delivery_areas.size == 1) ? delivery_areas.first : nil
+      (delivery_areas.unarchived.size == 1) ? delivery_areas.unarchived.first : nil
     end
   end
 end

--- a/spec/furniture/marketplace/buying_products_system_spec.rb
+++ b/spec/furniture/marketplace/buying_products_system_spec.rb
@@ -50,6 +50,19 @@ describe "Marketplace: Buying Products", type: :system do
     end
   end
 
+  describe "when the `Marketplace` has one active `DeliveryArea`" do
+    it "allows Checkout" do
+      archived_delivery_area = create(:marketplace_delivery_area,
+        marketplace: marketplace, label: "Oakland", price_cents: 10_00)
+      archived_delivery_area.archive
+      visit(polymorphic_path(marketplace.room.location))
+
+      add_product_to_cart(marketplace.products.first)
+
+      expect { click_link("Checkout") }.not_to raise_error
+    end
+  end
+
   it "Doesn't offer archived Products for sale" do
     archived_product = create(:marketplace_product, :archived, marketplace:)
 

--- a/spec/furniture/marketplace/marketplace_spec.rb
+++ b/spec/furniture/marketplace/marketplace_spec.rb
@@ -64,6 +64,15 @@ RSpec.describe Marketplace::Marketplace, type: :model do
         cart = marketplace.cart_for_shopper(shopper:)
         expect(cart.delivery_area).to be_nil
       end
+
+      context "when only one of them is unarchived" do
+        before { marketplace.delivery_areas.first.archive }
+
+        it "sets the default delivery area to the single unarchived one" do
+          cart = marketplace.cart_for_shopper(shopper:)
+          expect(cart.delivery_area).to eq(marketplace.delivery_areas.unarchived.first)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/2198

When we added [archiving delivery areas], I didn't take into account that `Marketplace#cart_for_shopper` was checking against all the delivery areas.

This fixes that and adds a system spec to make sure we can still checkout after!

[archiving delivery areas]: https://github.com/zinc-collective/convene/pull/2024