### PR TITLE
🐞🔨 `Pagination`: Fix missing translation error for `Next` and `Previous` links

### DIFF
--- a/app/assets/stylesheets/application.postcss.css
+++ b/app/assets/stylesheets/application.postcss.css
@@ -8,3 +8,4 @@
 @import "./utilities.scss";
 @import "./components.scss";
 @import "actiontext.css";
+@import "./extensions/pagy.scss";

--- a/app/assets/stylesheets/extensions/pagy.scss
+++ b/app/assets/stylesheets/extensions/pagy.scss
@@ -1,0 +1,8 @@
+.pagy-nav {
+  @apply flex justify-between;
+
+  .page.active a,
+  .page.disabled a {
+    @apply no-underline;
+  }
+}

--- a/app/furniture/journal/journals/_journal.html.erb
+++ b/app/furniture/journal/journals/_journal.html.erb
@@ -7,7 +7,7 @@
     <%= render Journal::EntryComponent.with_collection(@entries) %>
   </div>
 
-  <%== pagy_nav(@pagy, nav_extra: 'flex justify-between') %>
+  <%== pagy_nav(@pagy) %>
 
   <%= render Journal::NewEntryButtonComponent.new(journal: journal) %>
 </section>

--- a/app/furniture/marketplace/orders/index.html.erb
+++ b/app/furniture/marketplace/orders/index.html.erb
@@ -2,5 +2,5 @@
 <%- @pagy, @records = pagy(orders.paid) %>
 <div class="mx-auto w-full max-w-prose">
   <%= render @records %>
-  <%== pagy_nav(@pagy, nav_extra: 'flex justify-between mt-4') %>
+  <%== pagy_nav(@pagy) %>
 </div>

--- a/app/helpers/pagy_helper.rb
+++ b/app/helpers/pagy_helper.rb
@@ -1,35 +1,4 @@
 module PagyHelper
   include Pagy::Backend
   include Pagy::Frontend
-
-  # @todo submit a patch to Pagy which allows us to override the classes using `nav_extra`
-  #       since there wasn't a tidy seam to inject tailwind classes on the container beyond
-  #       copy-paste-and-replace
-  def pagy_nav(pagy, pagy_id: nil, link_extra: "", nav_extra: "", **)
-    p_id = %( id="#{pagy_id}") if pagy_id
-    link = pagy_link_proc(pagy, link_extra: link_extra)
-    p_prev = pagy.prev
-    p_next = pagy.next
-
-    html = +%(<nav#{p_id} class="pagy-nav pagination #{nav_extra}">)
-    html << if p_prev
-      %(<span class="page prev">#{link.call p_prev, pagy_t("pagy.nav.prev"), 'aria-label="previous"'}</span> )
-    else
-      %(<span class="page prev disabled">#{pagy_t("pagy.nav.prev")}</span> )
-    end
-    pagy.series(**).each do |item| # series example: [1, :gap, 7, 8, "9", 10, 11, :gap, 36]
-      html << case item
-      when Integer then %(<span class="page">#{link.call item}</span> )
-      when String then %(<span class="page active">#{pagy.label_for(item)}</span> )
-      when :gap then %(<span class="page gap">#{pagy_t("pagy.nav.gap")}</span> )
-      else raise InternalError, "expected item types in series to be Integer, String or :gap; got #{item.inspect}"
-      end
-    end
-    html << if p_next
-      %(<span class="page next">#{link.call p_next, pagy_t("pagy.nav.next"), 'aria-label="next"'}</span>)
-    else
-      %(<span class="page next disabled">#{pagy_t("pagy.nav.next")}</span>)
-    end
-    html << %(</nav>)
-  end
 end

--- a/app/views/neighborhoods/show.html.erb
+++ b/app/views/neighborhoods/show.html.erb
@@ -5,7 +5,7 @@
     <%= render @records %>
   </div>
 
-  <%== pagy_nav(@pagy, nav_extra: 'flex justify-between') %>
+  <%== pagy_nav(@pagy) %>
 
   <%- if policy(Space).new? %>
     <div class="text-center w-full">


### PR DESCRIPTION
- https://github.com/zinc-collective/journal/issues/4
- https://github.com/zinc-collective/convene/issues/1661
- https://github.com/zinc-collective/convene/issues/2216

With the Pagy 7 upgrade; the helper I wrote so we could add spacing between the Pagination links broke.

This switches out from doing an in-ruby style override to an in-css style override.


### After
<img width="1020" alt="Screenshot 2024-02-17 at 10 29 24 AM" src="https://github.com/zinc-collective/convene/assets/50284/a1cf28fa-4752-4b69-a47c-e1edab5bd140">

### Before
<img width="1106" alt="Screenshot 2024-02-17 at 10 26 16 AM" src="https://github.com/zinc-collective/convene/assets/50284/ab47bd66-ded5-4d84-a910-844d959a6c36">
