### PR TITLE
🌸 `Journal`: Remove italics from `Keyword`

### DIFF
--- a/app/furniture/journal/keywords/show.html.erb
+++ b/app/furniture/journal/keywords/show.html.erb
@@ -1,9 +1,9 @@
 <h1><%= keyword.canonical_keyword %></h1>
 <%- if keyword.aliases.present? %>
-  <p class="italic">Also known as <%= to_sentence(keyword.aliases) %></p>
+  <p class="text-sm">Also known as <%= to_sentence(keyword.aliases) %></p>
 <%- end %>
 
-<h2>Entries about <span class="italic"><%= keyword.canonical_keyword %></span></h2>
+<h2>Entries about <span class="text-gray-800"><%= keyword.canonical_keyword %></span></h2>
 <%= render Journal::NewEntryButtonComponent.new(keyword: keyword) %>
 <ul>
   <%- policy_scope(keyword.entries).each do |entry|%>


### PR DESCRIPTION
- https://github.com/zinc-collective/journal/issues/5

Another de-italicization!

### After
<img width="422" alt="Screenshot 2024-02-18 at 10 32 02 AM" src="https://github.com/zinc-collective/convene/assets/50284/b1688776-3c2b-4d6e-92a5-d53b36b97e35">


### Before
<img width="471" alt="Screenshot 2024-02-18 at 10 32 10 AM" src="https://github.com/zinc-collective/convene/assets/50284/2a071805-3844-4385-926b-0ebae18a45ab">
