### PR TITLE
🧹 `Marketplace`: Remove `Product#description` column

### DIFF
--- a/app/furniture/marketplace/product.rb
+++ b/app/furniture/marketplace/product.rb
@@ -2,8 +2,6 @@
 
 class Marketplace
   class Product < Record
-    self.ignored_columns += ["description"]
-
     include Archivable
 
     # TODO: Refactor to use Media model

--- a/db/migrate/20240222004148_remove_marketplace_products_description.rb
+++ b/db/migrate/20240222004148_remove_marketplace_products_description.rb
@@ -1,0 +1,7 @@
+class RemoveMarketplaceProductsDescription < ActiveRecord::Migration[7.1]
+  def change
+    safety_assured do
+      remove_column :marketplace_products, :description, :string
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_16_213129) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_22_004148) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -214,7 +214,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_16_213129) do
   create_table "marketplace_products", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "marketplace_id"
     t.string "name"
-    t.string "description"
     t.integer "price_cents", default: 0, null: false
     t.string "price_currency", default: "USD", null: false
     t.datetime "created_at", null: false

--- a/lib/tasks/release.rake
+++ b/lib/tasks/release.rake
@@ -4,8 +4,5 @@ namespace :release do
   desc "Ensures any post-release / pre-deploy behavior has occurred"
   task after_build: [:environment, "db:prepare"] do
     # Put code you want to execute after migrations but before release here
-    Marketplace::Product.connection.execute("SELECT id, description FROM marketplace_products").each do |result|
-      Marketplace::Product.find(result["id"]).update(description: result["description"])
-    end
   end
 end


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/2197

`ActionText` stores it's data in it's own table; so we don't need it.