### PR TITLE
🧹 Ensure that factory for Journal::Keyword always uses a unique canonical keyword

### DIFF
--- a/spec/factories/furniture/journal.rb
+++ b/spec/factories/furniture/journal.rb
@@ -28,7 +28,7 @@ FactoryBot.define do
   end
 
   factory :journal_keyword, class: "Journal::Keyword" do
-    canonical_keyword { Faker::Fantasy::Tolkien.location }
+    sequence(:canonical_keyword) { |n| "#{Faker::Fantasy::Tolkien.location}-#{n}" }
     journal
   end
 end


### PR DESCRIPTION
This should prevent occasional test failures caused by trying to create a duplicate keyword, such as the one in https://github.com/zinc-collective/convene/actions/runs/8070888101/job/22049297163