### PR TITLE
🧹 Uncomment `PG*` default lines in `.env.example`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,9 +5,9 @@
 
 # If you are using docker to manage your postgresql database,
 # you will want to uncomment these
-# PGHOST=localhost
-# PGUSER=postgres
-# PGPASSWORD=password
+PGHOST=localhost
+PGUSER=postgres
+PGPASSWORD=password
 
 
 PORT=3000


### PR DESCRIPTION
In general, people seem to need these to be uncommented more often than not. 
Discussion seemed to indicated this was a desirable change.