### PR TITLE
Fixes absolute paths in Marketplace mailers #2243 

### DIFF
--- a/app/furniture/marketplace/order/email_receipt_component.html.erb
+++ b/app/furniture/marketplace/order/email_receipt_component.html.erb
@@ -1,78 +1,81 @@
 <style>
-.align-top { vertical-align: top; }
-.table-fixed { table-layout: fixed; }
-.text-center { text-align: center; }
-.text-right { text-align: right; }
-.w-full { width: 100%; }
+  .align-top { vertical-align: top; }
+  .table-fixed { table-layout: fixed; }
+  .text-center { text-align: center; }
+  .text-right { text-align: right; }
+  .w-full { width: 100%; }
 </style>
-
 <div id="<%= dom_id %>">
-<h3 class="w-full text-center">
-  <%= link_to "Order #{order.id}", order.persisted? ? order.location : "#" %>
-</h3>
-<p class="w-full text-center text-sm">
-  <%= placed_at %>
-</p>
-
-
-<table class="w-full table-fixed">
-<tr><th colspan="3">Products</th></tr>
-<%- order.ordered_products.each do |ordered_product|%>
-  <tr>
-    <td class="text-right"><%= ordered_product.name %></td>
-    <td class="text-center">x <%= ordered_product.quantity %></td>
-    <td><%= humanized_money_with_symbol(ordered_product.price) %></td>
-  </tr>
-<%- end %>
-<tr>
-  <th class="text-right" colspan="1">Subtotal</th>
-  <td></td>
-  <td><%= humanized_money_with_symbol(order.product_total) %></td>
-</tr>
-<tr><th colspan="3">Taxes and Fees</th></tr>
-<tr>
-  <td class="text-right">Taxes</td>
-  <td></td>
-  <td><%= humanized_money_with_symbol(order.tax_total) %></td>
-</tr>
-<tr>
-  <td class="text-right">Delivery</td>
-  <td></td>
-  <td><%= humanized_money_with_symbol(order.delivery_fee) %></td>
-</tr>
-<tr>
-  <th class="text-right">Total</th>
-  <td></td>
-  <td><%= humanized_money_with_symbol(order.price_total) %></td>
-</tr>
-<tfoot>
-<tr><th colspan="3">Delivery Details</th></tr>
-<tr>
-  <td class="text-right">Delivery Notes</td>
-  <td><%= order.delivery_notes %></td>
-</tr>
-<%- if order.delivery_area.present? %>
-  <tr>
-    <td class="text-right">Delivery Schedule:</td>
-    <td><%= render(Marketplace::Cart::DeliveryWindowComponent.new(window: order.delivery_area.delivery_window)) %></td>
-  </tr>
-  <tr>
-    <td class="text-right">Delivering In:</td>
-    <td><%= order.delivery_area.label %></td>
-  </tr>
-<%- end %>
-<tr>
-  <td class="text-right">Buyer Email:</td>
-  <td colspan="2"><%= order.contact_email %></td>
-</tr>
-<tr>
-  <td class="text-right">Phone Number:</td>
-  <td colspan="2"><%= order.contact_phone_number %></td>
-</tr>
-<tr>
-  <td class="text-right align-top">Address:</td>
-  <td colspan="2"><%= order.delivery_address %></td>
-</tr>
-</tfoot>
-</table>
+  <h3 class="w-full text-center">
+    <%= link_to "Order #{order.id}", order.persisted? ? polymorphic_url(order.location) : "#" %>
+  </h3>
+  <p class="w-full text-center text-sm">
+    <%= placed_at %>
+  </p>
+  <table class="w-full table-fixed">
+    <tr>
+      <th colspan="3">Products</th>
+    </tr>
+    <%- order.ordered_products.each do |ordered_product|%>
+      <tr>
+        <td class="text-right"><%= ordered_product.name %></td>
+        <td class="text-center">x <%= ordered_product.quantity %></td>
+        <td><%= humanized_money_with_symbol(ordered_product.price) %></td>
+      </tr>
+    <%- end %>
+    <tr>
+      <th class="text-right" colspan="1">Subtotal</th>
+      <td></td>
+      <td><%= humanized_money_with_symbol(order.product_total) %></td>
+    </tr>
+    <tr>
+      <th colspan="3">Taxes and Fees</th>
+    </tr>
+    <tr>
+      <td class="text-right">Taxes</td>
+      <td></td>
+      <td><%= humanized_money_with_symbol(order.tax_total) %></td>
+    </tr>
+    <tr>
+      <td class="text-right">Delivery</td>
+      <td></td>
+      <td><%= humanized_money_with_symbol(order.delivery_fee) %></td>
+    </tr>
+    <tr>
+      <th class="text-right">Total</th>
+      <td></td>
+      <td><%= humanized_money_with_symbol(order.price_total) %></td>
+    </tr>
+    <tfoot>
+      <tr>
+        <th colspan="3">Delivery Details</th>
+      </tr>
+      <tr>
+        <td class="text-right">Delivery Notes</td>
+        <td><%= order.delivery_notes %></td>
+      </tr>
+      <%- if order.delivery_area.present? %>
+        <tr>
+          <td class="text-right">Delivery Schedule:</td>
+          <td><%= render(Marketplace::Cart::DeliveryWindowComponent.new(window: order.delivery_area.delivery_window)) %></td>
+        </tr>
+        <tr>
+          <td class="text-right">Delivering In:</td>
+          <td><%= order.delivery_area.label %></td>
+        </tr>
+      <%- end %>
+      <tr>
+        <td class="text-right">Buyer Email:</td>
+        <td colspan="2"><%= order.contact_email %></td>
+      </tr>
+      <tr>
+        <td class="text-right">Phone Number:</td>
+        <td colspan="2"><%= order.contact_phone_number %></td>
+      </tr>
+      <tr>
+        <td class="text-right align-top">Address:</td>
+        <td colspan="2"><%= order.delivery_address %></td>
+      </tr>
+    </tfoot>
+  </table>
 </div>

--- a/spec/factories/furniture/marketplace.rb
+++ b/spec/factories/furniture/marketplace.rb
@@ -78,7 +78,7 @@ FactoryBot.define do
   end
 
   factory :marketplace_product, class: "Marketplace::Product" do
-    name { Faker::TvShows::DrWho.specie }
+    name { Faker::TvShows::DrWho.unique.specie }
     price_cents { Random.rand(1_00..999_99) }
 
     marketplace
@@ -131,7 +131,7 @@ FactoryBot.define do
   end
 
   factory :marketplace_order, class: "Marketplace::Order" do
-    marketplace
+    marketplace { association(:marketplace, :ready_for_shopping) }
     shopper { association(:marketplace_shopper) }
 
     status { :paid }
@@ -141,7 +141,7 @@ FactoryBot.define do
         product_count { 1 }
       end
 
-      ordered_products { Array.new(product_count) { association(:marketplace_ordered_product) } }
+      ordered_products { Array.new(product_count) { association(:marketplace_ordered_product, marketplace: marketplace) } }
     end
 
     trait :with_taxed_products do
@@ -177,8 +177,12 @@ FactoryBot.define do
   end
 
   factory :marketplace_ordered_product, class: "Marketplace::OrderedProduct" do
-    product factory: :marketplace_product
-    order factory: :marketplace_order
+    transient do
+      marketplace { association(:marketplace) }
+    end
+
+    product { association(:marketplace_product, marketplace: marketplace) }
+    order { association(:marketplace_order, marketplace: marketplace) }
     quantity { 1 }
   end
 


### PR DESCRIPTION
## Summary

### Fixes Order Url
Because Mailers don't receive the request context, url generation in mailer templates is less straightforward than in templates backed by a controller. `*_url` helpers are recommended so that Rails can construct an absolute path. But In our case we need the `polymorphic_url` which works best with our `location` methods. 

See: https://guides.rubyonrails.org/action_mailer_basics.html#generating-urls-in-action-mailer-views. 

### (Slightly) better marketplace factories
In addition to fixing the url, this PR includes a bite-sized effort to harden the associations in the Marketplace factories. While we pair debugged the mailer previews in the browser, @anaulin and I noticed inconsistencies in the data which prevented us from easily verifying the url was correct -- trying to visit the link as a guest or logged-in as the shopper was resulting in 404s (effectively access denied). We're convinced the URL is fixed, but there's still remaining work to be done to make it easy to live test the mailers locally. For example, notice the mismatched order ids in the email subject and body:

![image](https://github.com/zinc-collective/convene/assets/5185/ad83ac38-d25a-4e71-a777-a4afc38f512a)