### PR TITLE
🌸 Make arrow in section navigation look more like a little button

### DIFF
--- a/app/furniture/section_navigation/section_navigations/_section_navigation.html.erb
+++ b/app/furniture/section_navigation/section_navigations/_section_navigation.html.erb
@@ -7,7 +7,7 @@
           <h3>
             <%= room.name %>
           </h3>
-          <%= render SvgComponent.new(classes: "h-5 w-5 min-w-5") do %>
+          <%= render SvgComponent.new(classes: "h-7 w-7 min-w-7 p-1 rounded-full bg-slate-100") do %>
             <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
           <% end %>
         </footer>


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/1988

This is closer to the styling we had earlier, but without the bright orange, and without a change during hover.

### Before
(journal card shows hover state)
![image](https://github.com/zinc-collective/convene/assets/6729309/5c12f8d5-3c4a-426a-a9c1-2ab03c23e320)


### After
(journal card shows hover state)
![image](https://github.com/zinc-collective/convene/assets/6729309/69851dbc-4b2d-4dd5-a3d1-3d0f0f5f7856)
