### PR TITLE
🛠️  Fix the build on `main`: Update Docker devcontainer to use our current Ruby version

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/ruby:3.2
+FROM mcr.microsoft.com/devcontainers/ruby:3.3
 
 LABEL org.opencontainers.image.source=https://github.com/zinc-collective/convene-devcontainer
 LABEL org.opencontainers.image.description="Container to facilitate easier development of convene, specifically to work in GitHub CodeSpaces."


### PR DESCRIPTION
I believe this change should fix the current failures of our build's `build-and-push-image` step, which has been failing with the error:
```
#8 [4/5] RUN su vscode -c "cd /tmp && bundle install --gemfile /tmp/Gemfile && sudo rm /tmp/Gemfile /tmp/.ruby-version"
#8 1.598 Your Ruby version is 3.2.3, but your Gemfile specified 3.3.0
#8 ERROR: process "/bin/sh -c su vscode -c \"cd /tmp && bundle install --gemfile /tmp/Gemfile && sudo rm /tmp/Gemfile /tmp/.ruby-version\"" did not complete successfully: exit code: 18
------
 > [4/5] RUN su vscode -c "cd /tmp && bundle install --gemfile /tmp/Gemfile && sudo rm /tmp/Gemfile /tmp/.ruby-version":
1.598 Your Ruby version is 3.2.3, but your Gemfile specified 3.3.0
```
(source: https://github.com/zinc-collective/convene/actions/runs/8210256537/job/22457364014)

It would be nice if we could make this Dockerfile just interpolate the contents of `.ruby-version`, the way the Gemfile does, but I don't know if that's possible, and definitely don't know how to do it off the top of my head.
