### PR TITLE
Improve look of section navigation cards when at least one section has an image

### DIFF
--- a/app/furniture/section_navigation/section_grid_component.html.erb
+++ b/app/furniture/section_navigation/section_grid_component.html.erb
@@ -1,0 +1,24 @@
+<div class="grid grid-cols-1 gap-5 sm:gap-6 sm:grid-cols-2 lg:grid-cols-4">
+  <% @rooms.each do |room| %>
+    <%= link_to polymorphic_path(room.location), id: dom_id(room, :link_to), class: "group no-underline" do %>
+      <%= render CardComponent.new(media: room.hero_image, classes: "flex flex-col justify-between h-full p-0") do |card| %>
+        <% if image_placeholder?(room) %>
+          <% card.with_header(variant: :no_padding) do %>
+           <%=  image_placeholder_div %>
+          <% end %>
+        <% end %>
+
+        <p class="<%= description_height %>"><%= room.description %></p>
+
+        <footer class="text-2xl text-justify font-semibold flex justify-between items-center">
+          <h3>
+            <%= room.name %>
+          </h3>
+          <%= render SvgComponent.new(classes: "h-7 w-7 min-w-7 p-1 rounded-full bg-slate-100") do %>
+            <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+          <% end %>
+        </footer>
+      <%- end %>
+    <%- end %>
+  <% end %>
+</div>

--- a/app/furniture/section_navigation/section_grid_component.rb
+++ b/app/furniture/section_navigation/section_grid_component.rb
@@ -1,0 +1,43 @@
+class SectionNavigation
+  class SectionGridComponent < ApplicationComponent
+    delegate :policy_scope, to: :helpers
+
+    def initialize(section_navigation)
+      @section_navigation = section_navigation
+    end
+
+    def render?
+      rooms.any?
+    end
+
+    private
+
+    def description_height
+      @description_height ||= section_descriptions? ? "min-h-[120px]" : ""
+    end
+
+    def image_placeholder?(room)
+      section_images? && room.hero_image.blank?
+    end
+
+    BG_COLORS = %w[
+      bg-cyan-100 bg-emerald-100 bg-indigo-100 bg-lime-100 bg-purple-100 bg-red-100
+      bg-rose-100 bg-sky-100 bg-teal-100
+    ].freeze
+    def image_placeholder_div
+      content_tag(:div, "", class: "h-36 #{BG_COLORS.sample} m-0 p-0 rounded-t-lg w-full")
+    end
+
+    def rooms
+      @rooms = policy_scope(@section_navigation.rooms)
+    end
+
+    def section_images?
+      @section_images ||= rooms.any? { |r| r.hero_image.present? }
+    end
+
+    def section_descriptions?
+      @section_descriptions ||= rooms.any? { |r| r.description.present? }
+    end
+  end
+end

--- a/app/furniture/section_navigation/section_navigations/_section_navigation.html.erb
+++ b/app/furniture/section_navigation/section_navigations/_section_navigation.html.erb
@@ -1,17 +1,1 @@
-<div class="grid grid-cols-1 gap-5 sm:gap-6 sm:grid-cols-2 lg:grid-cols-4">
-  <% policy_scope(section_navigation.rooms).each do |room| %>
-    <%= link_to polymorphic_path(room.location), id: dom_id(room, :link_to), class: "group no-underline" do %>
-      <%= render CardComponent.new(media: room.hero_image, classes: "flex flex-col justify-between h-full") do |card| %>
-        <p><%= room.description %></p>
-        <footer class="text-2xl text-justify font-semibold flex justify-between items-center">
-          <h3>
-            <%= room.name %>
-          </h3>
-          <%= render SvgComponent.new(classes: "h-7 w-7 min-w-7 p-1 rounded-full bg-slate-100") do %>
-            <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
-          <% end %>
-        </footer>
-      <%- end %>
-    <%- end %>
-  <% end %>
-</div>
+<%= render SectionNavigation::SectionGridComponent.new(section_navigation) %>


### PR DESCRIPTION
* https://github.com/zinc-collective/convene/issues/1988

This PR refines the look of the section navigation component:
* when at least one of the sections has an image an others don't, it inserts a colored image placeholder in all the cards that don't have an image
* when at least one of the sections has a description text, it makes sure that all the cards have the same description height, even if they don't have a description text

### Before
![image](https://github.com/zinc-collective/convene/assets/6729309/48b5269a-7dda-407f-b1da-2b85885a5cb6)
![image](https://github.com/zinc-collective/convene/assets/6729309/c693335a-d124-4cbc-a259-5c56cd032648)
![image](https://github.com/zinc-collective/convene/assets/6729309/51f73366-48e6-4eb9-b35e-6bafe2195e41)


### After
![image](https://github.com/zinc-collective/convene/assets/6729309/39a5f4d7-1039-44cf-b9f1-95798d6bdf09)
![image](https://github.com/zinc-collective/convene/assets/6729309/0409129f-3b49-4fef-872a-09e8d6bc902e)
![image](https://github.com/zinc-collective/convene/assets/6729309/6a942f90-fbc2-46bc-bada-66f214e94c6c)
