### PR TITLE
Adds a label and hint to the entrance field in the Space > Sections configuration form

### DIFF
--- a/app/components/select_component.html.erb
+++ b/app/components/select_component.html.erb
@@ -2,6 +2,9 @@
   <% unless @skip_label %>
     <%= @form.label @attribute %>
   <% end %>
+  <% if @label_hint %>
+    <small><%= @label_hint %></small>
+  <% end %>
   <%= @form.select @attribute, @choices, @options, @html_options %>
   <%= render partial: "error", locals: { model: @form.object, attribute: @attribute } %>
 </div>

--- a/app/components/select_component.rb
+++ b/app/components/select_component.rb
@@ -6,6 +6,7 @@ class SelectComponent < ApplicationComponent
     @options = config.fetch(:options, {})
     @html_options = config.fetch(:html_options, {})
     @skip_label = config.fetch(:skip_label, true)
+    @label_hint = config.fetch(:label_hint, "")
 
     super(**kwargs)
   end

--- a/app/views/spaces/_sections.html.erb
+++ b/app/views/spaces/_sections.html.erb
@@ -13,7 +13,7 @@
       <%- end %>
     <% end %>
   </div>
-  <footer>
+  <footer class="mb-4">
     <%= link_to [:new, space, :room] do %>
       <span class="icon --add" role="img" aria-label="Add"></span>Add New Section
     <% end %>
@@ -23,6 +23,8 @@
       choices: space.rooms.map { |room| [room.name, room.id] },
       attribute: :entrance_id,
       form: space_form,
+      skip_label: false,
+      label_hint: "Select a section for your Space home page"
     }) %>
     <%= space_form.submit %>
   <%- end %>


### PR DESCRIPTION
Yes, I _do_ remember we have an [outstanding issue](https://github.com/zinc-collective/convene/issues/2082) for a hint partial 😅. This was a small detour while working through how I want to present header and footer configuration for #2266 and my brain keeps forgetting what the _entrance_ field is.

After:
![image](https://github.com/zinc-collective/convene/assets/5185/3d66d1a4-98a2-402e-97be-582fc067fda8)
