### PR TITLE
Fix logic for determining if a Room has a hero image (aka header image)

### DIFF
--- a/app/furniture/section_navigation/section_grid_component.rb
+++ b/app/furniture/section_navigation/section_grid_component.rb
@@ -17,7 +17,7 @@ class SectionNavigation
     end
 
     def image_placeholder?(room)
-      section_images? && room.hero_image.blank?
+      section_images? && !room.hero_image?
     end
 
     BG_COLORS = %w[
@@ -33,7 +33,7 @@ class SectionNavigation
     end
 
     def section_images?
-      @section_images ||= rooms.any? { |r| r.hero_image.present? }
+      @section_images ||= rooms.any?(&:hero_image?)
     end
 
     def section_descriptions?

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -41,6 +41,10 @@ class Room < ApplicationRecord
     space.entrance == self
   end
 
+  def hero_image?
+    !!hero_image&.upload&.attached?
+  end
+
   def ==(other)
     super(other.becomes(Room))
   end


### PR DESCRIPTION
* https://github.com/zinc-collective/convene/issues/1988

Followup to https://github.com/zinc-collective/convene/pull/2302 to correctly identify if a Room has a hero image, taking into account that sometimes a Room might have a hero image association, but the associated Media object might not have an attachment.

A related question that this PR doesn't address is: why do we have Media objects with no attachment?