### PR TITLE
Remove obsolete docker-compose top-level `version` keyword

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   db:
     image: postgres:latest


### PR DESCRIPTION
The top-level version keyword in the docker-compose.yml spec has been deprecated, and using now triggers a warning. See: https://github.com/compose-spec/compose-spec/blob/master/04-version-and-name.md