### PR TITLE
Update GitHub workflows to use latest action versions

### DIFF
--- a/.github/workflows/test-convene-web.yml
+++ b/.github/workflows/test-convene-web.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Update apt
         env:
@@ -85,7 +85,7 @@ jobs:
           --health-retries 5
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Update apt
         env:
@@ -149,7 +149,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Ruby and install gems
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/test-convene-web.yml
+++ b/.github/workflows/test-convene-web.yml
@@ -49,7 +49,7 @@ jobs:
           bundler-cache: true
 
       - name: Setup Node with cache
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: 'yarn'
@@ -110,7 +110,7 @@ jobs:
           bundler-cache: true
 
       - name: Setup Node with cache
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: 'yarn'
@@ -157,7 +157,7 @@ jobs:
           bundler-cache: true
 
       - name: Setup Node with cache
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: 'yarn'


### PR DESCRIPTION
This is to get rid of these warnings:

![image](https://github.com/zinc-collective/convene/assets/6729309/d61659f4-929c-4ec9-9729-caa729d7b7bd)
