### PR TITLE
[FIX BUILD] Remove reference to `enableStripePass` hidden checkbox in system tests

### DIFF
--- a/spec/furniture/marketplace/buying_products_system_spec.rb
+++ b/spec/furniture/marketplace/buying_products_system_spec.rb
@@ -129,7 +129,6 @@ describe "Marketplace: Buying Products", type: :system do
     fill_in("billingName", with: billing_name)
     fill_in("email", with: email)
     fill_in("billingPostalCode", with: billing_postal_code)
-    uncheck("enableStripePass", visible: false)
     find("*[data-testid='hosted-payment-submit-button']").click
   end
 end


### PR DESCRIPTION
I'm not sure why or what for was this necessary in the past, but it seems it is no longer available in the Stripe checkout form.