### PR TITLE
Add up to 3 retries to the CI step that installs the Stripe CLI

### DIFF
--- a/.github/workflows/test-convene-web.yml
+++ b/.github/workflows/test-convene-web.yml
@@ -124,12 +124,16 @@ jobs:
       - name: Setup rails
         run: bin/setup-rails && bin/rails assets:precompile
 
-      - name: Install stripe cli
-        run: |
-          curl -s https://packages.stripe.dev/api/security/keypair/stripe-cli-gpg/public | gpg --dearmor | sudo tee /usr/share/keyrings/stripe.gpg
-          echo "deb [signed-by=/usr/share/keyrings/stripe.gpg] https://packages.stripe.dev/stripe-cli-debian-local stable main" | sudo tee -a /etc/apt/sources.list.d/stripe.list
-          sudo apt update
-          sudo apt install stripe
+      - name: Install stripe cli, with retries
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 3
+          timeout_minutes: 5
+          command: |
+            curl -s https://packages.stripe.dev/api/security/keypair/stripe-cli-gpg/public | gpg --dearmor | sudo tee /usr/share/keyrings/stripe.gpg
+            echo "deb [signed-by=/usr/share/keyrings/stripe.gpg] https://packages.stripe.dev/stripe-cli-debian-local stable main" | sudo tee -a /etc/apt/sources.list.d/stripe.list
+            sudo apt update
+            sudo apt install stripe
 
       - name: Run Tests
         env:


### PR DESCRIPTION
This step often fails due to intermittent network records, making our CI extra-flaky.

I'm hoping throwing in the occasional retry will make things less flaky without adding too much delay to the CI.