### PR TITLE
Revert "Bump shoulda-matchers from 6.2.0 to 6.4.0"

### DIFF
--- a/.github/workflows/test-convene-web.yml
+++ b/.github/workflows/test-convene-web.yml
@@ -140,7 +140,7 @@ jobs:
           HEADLESS: true
         run: bundle exec rspec
       - name: Upload RSpec Screenshots
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: rspec-failed-screenshot

--- a/Gemfile
+++ b/Gemfile
@@ -121,7 +121,7 @@ group :development, :test do
   gem "rails-controller-testing"
   gem "rspec-rails", "~> 6.1.3"
   gem "rswag-specs"
-  gem "shoulda-matchers", "~> 6.4"
+  gem "shoulda-matchers", "~> 6.2"
 
   gem "capybara"
   gem "selenium-webdriver"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,7 +154,7 @@ GEM
     choice (0.2.0)
     chunky_png (1.4.0)
     coderay (1.1.3)
-    concurrent-ruby (1.3.4)
+    concurrent-ruby (1.3.3)
     connection_pool (2.4.1)
     crack (1.0.0)
       bigdecimal
@@ -267,7 +267,7 @@ GEM
     method_source (1.1.0)
     mini_magick (4.13.2)
     mini_mime (1.1.5)
-    minitest (5.25.1)
+    minitest (5.24.1)
     monetize (1.12.0)
       money (~> 6.12)
     money (6.16.0)
@@ -464,7 +464,7 @@ GEM
     sentry-ruby (5.18.2)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
-    shoulda-matchers (6.4.0)
+    shoulda-matchers (6.2.0)
       activesupport (>= 5.2.0)
     sidekiq (7.3.0)
       concurrent-ruby (< 2)
@@ -600,7 +600,7 @@ DEPENDENCIES
   selenium-webdriver
   sentry-rails
   sentry-ruby
-  shoulda-matchers (~> 6.4)
+  shoulda-matchers (~> 6.2)
   sidekiq
   simplecov
   spring


### PR DESCRIPTION
Reverts zinc-collective/convene#2563 because it broke the build, seemingly?