### PR TITLE
Ensure "Remember Me for Stripe Link" Checkbox is unchecked

### DIFF
--- a/spec/furniture/marketplace/buying_products_system_spec.rb
+++ b/spec/furniture/marketplace/buying_products_system_spec.rb
@@ -129,6 +129,7 @@ describe "Marketplace: Buying Products", type: :system do
     fill_in("billingName", with: billing_name)
     fill_in("email", with: email)
     fill_in("billingPostalCode", with: billing_postal_code)
+    find(".SignUpForm .CheckboxField--checked").click if has_css?(".SignUpForm .CheckboxField--checked")
     find("*[data-testid='hosted-payment-submit-button']").click
   end
 end


### PR DESCRIPTION
At least one of the CI failures appears to be caused by changes to the Stripe Checkout flow which now defaults to asking them to save their Stripe Link contact info