### PR TITLE
Upgraded Redis requires SSL, and Heroku self-signs their certs

### DIFF
--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,3 +1,5 @@
-$redis = # rubocop:disable Style/GlobalVars
-  Redis.new(url: ENV["REDIS_URL"],
-    ssl_params: {verify_mode: OpenSSL::SSL::VERIFY_NONE})
+if Rails.env.production?
+  $redis = # rubocop:disable Style/GlobalVars
+    Redis.new(url: ENV["REDIS_URL"],
+      ssl_params: {verify_mode: OpenSSL::SSL::VERIFY_NONE})
+end

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,0 +1,3 @@
+$redis = # rubocop:disable Style/GlobalVars
+  Redis.new(url: ENV["REDIS_URL"],
+    ssl_params: {verify_mode: OpenSSL::SSL::VERIFY_NONE})

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,13 @@
+Sidekiq.configure_server do |config|
+  config.redis = {
+    url: ENV["REDIS_URL"],
+    ssl_params: {verify_mode: OpenSSL::SSL::VERIFY_NONE}
+  }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = {
+    url: ENV["REDIS_URL"],
+    ssl_params: {verify_mode: OpenSSL::SSL::VERIFY_NONE}
+  }
+end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,13 +1,15 @@
-Sidekiq.configure_server do |config|
-  config.redis = {
-    url: ENV["REDIS_URL"],
-    ssl_params: {verify_mode: OpenSSL::SSL::VERIFY_NONE}
-  }
-end
+if Rails.env.production?
+  Sidekiq.configure_server do |config|
+    config.redis = {
+      url: ENV["REDIS_URL"],
+      ssl_params: {verify_mode: OpenSSL::SSL::VERIFY_NONE}
+    }
+  end
 
-Sidekiq.configure_client do |config|
-  config.redis = {
-    url: ENV["REDIS_URL"],
-    ssl_params: {verify_mode: OpenSSL::SSL::VERIFY_NONE}
-  }
+  Sidekiq.configure_client do |config|
+    config.redis = {
+      url: ENV["REDIS_URL"],
+      ssl_params: {verify_mode: OpenSSL::SSL::VERIFY_NONE}
+    }
+  end
 end


### PR DESCRIPTION
See:
- https://help.heroku.com/HC0F8CUS/redis-connection-issues
- https://devcenter.heroku.com/articles/connecting-heroku-redis#connecting-in-ruby

This should fix our Redis connection, but I don't think it will recover anything that failed to get written to redis...