### PR TITLE
RedisClient is the appropriate one, not Redis

### DIFF
--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,5 +1,5 @@
-if Rails.env.production?
+if ENV["REDIS_URL"]
   $redis = # rubocop:disable Style/GlobalVars
-    Redis.new(url: ENV["REDIS_URL"],
+    RedisClient.new(url: ENV["REDIS_URL"],
       ssl_params: {verify_mode: OpenSSL::SSL::VERIFY_NONE})
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,4 +1,4 @@
-if Rails.env.production?
+if ENV["REDIS_URL"]
   Sidekiq.configure_server do |config|
     config.redis = {
       url: ENV["REDIS_URL"],


### PR DESCRIPTION
- #2625

Sooo, apparently the documentation provided by Heroku is not-quite-accurate; or perhaps I am not following it right, but we have `RedisClient` not `Redis`