### PR TITLE
`Marketplace`: Set `reply_to` on `Order::Mailer`s

### DIFF
--- a/app/furniture/marketplace/order/mailer.rb
+++ b/app/furniture/marketplace/order/mailer.rb
@@ -6,7 +6,7 @@ class Marketplace
 
       def notification(order)
         @order = order
-        mail(to: to,
+        mail(to: to, reply_to: reply_to,
           subject: t(".subject", marketplace_name: order.marketplace_name,
             order_id: order.id))
       end

--- a/app/furniture/marketplace/order/placed_mailer.rb
+++ b/app/furniture/marketplace/order/placed_mailer.rb
@@ -4,6 +4,10 @@ class Marketplace
       def to
         order.contact_email
       end
+
+      def reply_to
+        order.marketplace.notification_methods.map(&:contact_location)
+      end
     end
   end
 end

--- a/app/furniture/marketplace/order/received_mailer.rb
+++ b/app/furniture/marketplace/order/received_mailer.rb
@@ -4,6 +4,10 @@ class Marketplace
       def to
         order.marketplace.notification_methods.map(&:contact_location)
       end
+
+      def reply_to
+        order.contact_email
+      end
     end
   end
 end

--- a/spec/furniture/marketplace/order/placed_mailer_spec.rb
+++ b/spec/furniture/marketplace/order/placed_mailer_spec.rb
@@ -7,6 +7,11 @@ RSpec.describe Marketplace::Order::PlacedMailer, type: :mailer do
     subject(:notification) { described_class.notification(order) }
 
     it { is_expected.to be_to([order.contact_email]) }
+
+    it "replies to the marketplace's notification emails" do
+      expect(notification.reply_to).to eq(order.marketplace.notification_methods.map(&:contact_location))
+    end
+
     it { is_expected.to have_subject(t(".notification.subject", marketplace_name: order.marketplace_name, order_id: order.id)) }
 
     specify do

--- a/spec/furniture/marketplace/order/received_mailer_spec.rb
+++ b/spec/furniture/marketplace/order/received_mailer_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Marketplace::Order::ReceivedMailer, type: :mailer do
   let(:marketplace) { create(:marketplace) }
-  let(:order) { build(:marketplace_order, placed_at: 1.hour.ago, marketplace: marketplace) }
+  let(:order) { build(:marketplace_order, placed_at: 1.hour.ago, marketplace: marketplace, contact_email: "shopper@example.com") }
 
   describe "#notification" do
     subject(:notification) { described_class.notification(order) }
@@ -12,6 +12,10 @@ RSpec.describe Marketplace::Order::ReceivedMailer, type: :mailer do
     end
 
     it { is_expected.to be_to(marketplace.notification_methods.map(&:contact_location)) }
+
+    it "sets the shopper as the reply to" do
+      expect(notification.reply_to).to eq(["shopper@example.com"])
+    end
 
     it { is_expected.to have_subject(t(".notification.subject", marketplace_name: order.marketplace_name, order_id: order.id)) }
 


### PR DESCRIPTION
- https://github.com/zinc-collective/convene/issues/2639

When I placed my order last week, the replies started going to Convene Support, rather than the customer / seller.

This should reduce that happening.