### PR TITLE
Shopper may add Notes to a Product in their Cart on checkout

### DIFF
--- a/app/furniture/marketplace/cart_product/notes/_form.html.erb
+++ b/app/furniture/marketplace/cart_product/notes/_form.html.erb
@@ -1,0 +1,8 @@
+<%= form_with(model: cart_product,
+                url: polymorphic_path(cart_product.location(child: :note))) do |form| %>
+
+  <%= form.label :note %>
+  <%= form.text_area :note %>
+
+  <%= form.submit %>
+<%- end %>

--- a/app/furniture/marketplace/cart_product/notes/_note.html.erb
+++ b/app/furniture/marketplace/cart_product/notes/_note.html.erb
@@ -1,0 +1,6 @@
+<%- if cart_product.note.present? %>
+  <p><%= cart_product.note %></p>
+  <%= link_to("Edit Note", cart_product.location(:edit, child: :note)) %>
+<%- else %>
+  <%= link_to("Add Note", cart_product.location(:new, child: :note)) %>
+<%- end %>

--- a/app/furniture/marketplace/cart_product/notes/edit.html.erb
+++ b/app/furniture/marketplace/cart_product/notes/edit.html.erb
@@ -1,0 +1,4 @@
+
+<%= turbo_frame_tag(cart_product, :note) do %>
+  <%= render "form", cart_product: %>
+<%- end %>

--- a/app/furniture/marketplace/cart_product/notes/edit.html.erb
+++ b/app/furniture/marketplace/cart_product/notes/edit.html.erb
@@ -1,4 +1,3 @@
-
 <%= turbo_frame_tag(cart_product, :note) do %>
   <%= render "form", cart_product: %>
 <%- end %>

--- a/app/furniture/marketplace/cart_product/notes/new.html.erb
+++ b/app/furniture/marketplace/cart_product/notes/new.html.erb
@@ -1,0 +1,4 @@
+
+<%= turbo_frame_tag(cart_product, :note) do %>
+  <%= render "form", cart_product: %>
+<%- end %>

--- a/app/furniture/marketplace/cart_product/notes/new.html.erb
+++ b/app/furniture/marketplace/cart_product/notes/new.html.erb
@@ -1,4 +1,3 @@
-
 <%= turbo_frame_tag(cart_product, :note) do %>
   <%= render "form", cart_product: %>
 <%- end %>

--- a/app/furniture/marketplace/cart_product/notes/show.html.erb
+++ b/app/furniture/marketplace/cart_product/notes/show.html.erb
@@ -1,0 +1,3 @@
+<%= turbo_frame_tag(cart_product, :note) do %>
+  <%= render "note", cart_product: %>
+<%- end %>

--- a/app/furniture/marketplace/cart_product/notes_controller.rb
+++ b/app/furniture/marketplace/cart_product/notes_controller.rb
@@ -1,0 +1,33 @@
+class Marketplace
+  class CartProduct::NotesController < Controller
+    expose :cart, scope: -> { policy_scope(marketplace.carts) }, model: Cart
+    expose :cart_product, scope: -> { policy_scope(cart.cart_products) }, model: CartProduct
+
+    def new
+      authorize(cart_product, :update?)
+    end
+
+    def show
+      authorize(cart_product)
+    end
+
+    def edit
+      authorize(cart_product)
+    end
+
+    def update
+      authorize(cart_product)
+      cart_product.update(cart_product_params)
+
+      if cart_product.errors.present?
+        render :new, status: :unprocessable_entity
+      else
+        redirect_to cart_product.location(child: :note)
+      end
+    end
+
+    def cart_product_params
+      params.require(:cart_product).permit(:note)
+    end
+  end
+end

--- a/app/furniture/marketplace/checkouts/show.html.erb
+++ b/app/furniture/marketplace/checkouts/show.html.erb
@@ -6,7 +6,13 @@
     <dl class="grid grid-cols-2 gap-3 w-96">
       <%- cart.cart_products.each do |cart_product| %>
         <dt class="text-right"><%= cart_product.name %><br />
-        (<%=cart_product.quantity%>) x <%= humanized_money_with_symbol(cart_product.price) %></dt>
+        (<%=cart_product.quantity%>) x <%= humanized_money_with_symbol(cart_product.price) %><br />
+          <div>
+            <%= turbo_frame_tag(cart_product, :note) do %>
+              <%= render "marketplace/cart_product/notes/note", cart_product: %>
+            <%- end %>
+          </div>
+        </dt>
         <dd><%= humanized_money_with_symbol(cart_product.price_total) %></dd>
       <%- end %>
       <dt class="font-bold text-right">Sub Total</dt>

--- a/app/furniture/marketplace/order/email_receipt_component.html.erb
+++ b/app/furniture/marketplace/order/email_receipt_component.html.erb
@@ -22,6 +22,13 @@
         <td class="text-center">x <%= ordered_product.quantity %></td>
         <td><%= humanized_money_with_symbol(ordered_product.price) %></td>
       </tr>
+
+      <%- if ordered_product.note.present? %>
+        <tr>
+          <td></td>
+          <td colspan="2"><em><%= ordered_product.note %></em></td>
+        </tr>
+      <%- end %>
     <%- end %>
     <tr>
       <th class="text-right" colspan="1">Subtotal</th>

--- a/app/furniture/marketplace/routes.rb
+++ b/app/furniture/marketplace/routes.rb
@@ -3,7 +3,10 @@ class Marketplace
     def self.append_routes(router)
       router.resources :marketplaces, only: [:show, :edit, :update], module: "marketplace" do
         router.resources :carts, only: [] do
-          router.resources :cart_products
+          router.resources :cart_products do
+            router.resource :note, controller: "cart_product/notes"
+          end
+
           router.resource :checkout, only: [:show, :create]
           router.resource :delivery, controller: "cart/deliveries"
           router.resource :delivery_area, controller: "cart/delivery_areas"

--- a/db/migrate/20241017003307_marketplace_add_note_to_cart_product.rb
+++ b/db/migrate/20241017003307_marketplace_add_note_to_cart_product.rb
@@ -1,0 +1,5 @@
+class MarketplaceAddNoteToCartProduct < ActiveRecord::Migration[7.1]
+  def change
+    add_column :marketplace_cart_products, :note, :string, null: false, default: ""
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_10_004915) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_17_003307) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -145,6 +145,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_10_004915) do
     t.integer "quantity"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "note", default: "", null: false
     t.index ["cart_id"], name: "index_marketplace_cart_products_on_cart_id"
     t.index ["product_id"], name: "index_marketplace_cart_products_on_product_id"
   end

--- a/spec/factories/furniture/marketplace/marketplace.rb
+++ b/spec/factories/furniture/marketplace/marketplace.rb
@@ -183,6 +183,7 @@ FactoryBot.define do
 
     product { association(:marketplace_product, marketplace: marketplace) }
     order { association(:marketplace_order, marketplace: marketplace) }
+    note { "No #{Faker::Food.allergen} Please!" }
     quantity { 1 }
   end
 

--- a/spec/furniture/marketplace/buying_products_system_spec.rb
+++ b/spec/furniture/marketplace/buying_products_system_spec.rb
@@ -81,6 +81,10 @@ describe "Marketplace: Buying Products", type: :system do
     click_link("Checkout")
     expect(page).to have_current_path(polymorphic_path(marketplace.carts.first.location(child: :checkout)))
 
+    click_link("Add Note")
+    fill_in("Note", with: "No bananas!")
+    click_button("Save changes")
+
     set_delivery_details(delivery_address: "123 N West St Oakland, CA",
       contact_email: "AhsokaTano@example.com",
       contact_phone_number: "1234567890")


### PR DESCRIPTION
- Fixes #2661

### After

#### Email Receipt:
<img width="967" alt="Screenshot 2024-10-16 at 6 19 54 PM" src="https://github.com/user-attachments/assets/027edf49-9465-47a2-8e96-5e9a3539330a">


#### Checkout Page
<img width="645" alt="Screenshot 2024-10-16 at 6 20 19 PM" src="https://github.com/user-attachments/assets/88e72268-386d-4464-a17a-ef4ad337f2cd">


##### Editing Note

<img width="680" alt="Screenshot 2024-10-16 at 6 20 23 PM" src="https://github.com/user-attachments/assets/b7d79826-7e00-4fc6-a50d-4af9095d8db1">

