### PR TITLE
Tame our log output

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -104,6 +104,7 @@ gem "sidekiq"
 # Error reporting in production
 gem "sentry-rails"
 gem "sentry-ruby"
+gem "lograge"
 
 # Demo data
 gem "factory_bot_rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -243,6 +243,11 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     lockbox (2.0.0)
     logger (1.6.1)
+    lograge (0.14.0)
+      actionpack (>= 4)
+      activesupport (>= 4)
+      railties (>= 4)
+      request_store (~> 1.0)
     loofah (2.23.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -387,6 +392,8 @@ GEM
     regexp_parser (2.9.2)
     reline (0.5.10)
       io-console (~> 0.5)
+    request_store (1.7.0)
+      rack (>= 1.4)
     rexml (3.3.9)
     rotp (6.3.0)
     rouge (4.4.0)
@@ -564,6 +571,7 @@ DEPENDENCIES
   jsbundling-rails
   listen (~> 3.9)
   lockbox (= 2.0.0)
+  lograge
   lookbook (>= 2.0.0.beta.4)
   money-rails
   pagy (~> 9.1)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -54,6 +54,7 @@ Rails.application.configure do
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]
+  config.lograge.enabled = true
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store


### PR DESCRIPTION
This brings our production logs to a more browsable starting point