### PR TITLE
Capture console errors in Sentry for debugging

### DIFF
--- a/app/javascript/sentry.js
+++ b/app/javascript/sentry.js
@@ -8,7 +8,10 @@ export function initializeSentry() {
 
   Sentry.init({
     dsn: dsn,
-    integrations: [Sentry.browserTracingIntegration()],
+    integrations: [
+      Sentry.browserTracingIntegration(),
+      Sentry.captureConsoleIntegration(),
+    ],
     release: document.head.querySelector("meta[name=release_tag").content,
 
     // Set tracesSampleRate to 1.0 to capture 100%


### PR DESCRIPTION
The `TypeError: Load failed` error is a bit of  a mess to diagnose and debug. I could take some guesses (Turbo, for example, may be doing pre-fetching) but rather than (potentially) spinning my wheels guessing I'm going to get some more data before digging in.

See:
- https://github.com/zinc-collective/convene/issues/2705
- https://zinc-collective.sentry.io/issues/6036564075/
- https://sentry.io/answers/load-failed-javascript/