### PR TITLE
Marketplace: Apparently Stripe's checkbox-checking has changed

### DIFF
--- a/spec/furniture/marketplace/buying_products_system_spec.rb
+++ b/spec/furniture/marketplace/buying_products_system_spec.rb
@@ -134,6 +134,8 @@ describe "Marketplace: Buying Products", type: :system do
     fill_in("email", with: email)
     fill_in("billingPostalCode", with: billing_postal_code)
     find(".SignUpForm .CheckboxField--checked").click if has_css?(".SignUpForm .CheckboxField--checked")
+
+    find_by_id("enableStripePass", visible: false).uncheck
     find("*[data-testid='hosted-payment-submit-button']").click
   end
 end


### PR DESCRIPTION
No longer can we just click the horrifying javascript widget.

Now we must plumb the depths of their Checkout form to find the element and click it through